### PR TITLE
fix(proto): buf lint エラー69件を修正

### DIFF
--- a/proto/openpos/analytics/v1/analytics.proto
+++ b/proto/openpos/analytics/v1/analytics.proto
@@ -16,7 +16,7 @@ service AnalyticsService {
   // 時間帯別売上を取得する（特定日のピーク時間帯分析に使用）
   rpc GetHourlySales(GetHourlySalesRequest) returns (GetHourlySalesResponse);
   // 売上サマリーを取得する（期間合計・客単価・支払方法別集計）
-  rpc GetSalesSummary(GetSalesSummaryRequest) returns (SalesSummary);
+  rpc GetSalesSummary(GetSalesSummaryRequest) returns (GetSalesSummaryResponse);
 }
 
 // 日次売上
@@ -147,4 +147,10 @@ message GetSalesSummaryRequest {
   string store_id = 1;
   // 集計期間（必須）
   openpos.common.v1.DateRange date_range = 2;
+}
+
+// 売上サマリー取得レスポンス
+message GetSalesSummaryResponse {
+  // 売上サマリー
+  SalesSummary summary = 1;
 }

--- a/proto/openpos/inventory/v1/inventory.proto
+++ b/proto/openpos/inventory/v1/inventory.proto
@@ -10,21 +10,21 @@ import "openpos/common/v1/common.proto";
 // 在庫調整は POS 取引確定（SaleCompleted イベント）を受けて自動実行されます
 service InventoryService {
   // 在庫を取得する（店舗×商品）
-  rpc GetStock(GetStockRequest) returns (Stock);
+  rpc GetStock(GetStockRequest) returns (GetStockResponse);
   // 店舗の在庫一覧を取得する（在庫低下アラートフィルタ対応）
   rpc ListStocks(ListStocksRequest) returns (ListStocksResponse);
   // 在庫を調整する（手動調整・取引連動・発注入荷）
-  rpc AdjustStock(AdjustStockRequest) returns (Stock);
+  rpc AdjustStock(AdjustStockRequest) returns (AdjustStockResponse);
   // 在庫移動履歴を取得する
   rpc ListStockMovements(ListStockMovementsRequest) returns (ListStockMovementsResponse);
   // 発注を作成する
-  rpc CreatePurchaseOrder(CreatePurchaseOrderRequest) returns (PurchaseOrder);
+  rpc CreatePurchaseOrder(CreatePurchaseOrderRequest) returns (CreatePurchaseOrderResponse);
   // 発注を取得する
-  rpc GetPurchaseOrder(GetPurchaseOrderRequest) returns (PurchaseOrder);
+  rpc GetPurchaseOrder(GetPurchaseOrderRequest) returns (GetPurchaseOrderResponse);
   // 発注一覧を取得する
   rpc ListPurchaseOrders(ListPurchaseOrdersRequest) returns (ListPurchaseOrdersResponse);
   // 発注ステータスを更新する（入荷確認時に RECEIVED にする）
-  rpc UpdatePurchaseOrderStatus(UpdatePurchaseOrderStatusRequest) returns (PurchaseOrder);
+  rpc UpdatePurchaseOrderStatus(UpdatePurchaseOrderStatusRequest) returns (UpdatePurchaseOrderStatusResponse);
 }
 
 // 在庫移動種別
@@ -140,6 +140,38 @@ message PurchaseOrderItem {
   int32 received_quantity = 4;
   // 仕入単価（銭単位）
   int64 unit_cost = 5;
+}
+
+// === レスポンスラッパー ===
+
+// 在庫取得レスポンス
+message GetStockResponse {
+  // 在庫情報
+  Stock stock = 1;
+}
+
+// 在庫調整レスポンス
+message AdjustStockResponse {
+  // 調整後の在庫情報
+  Stock stock = 1;
+}
+
+// 発注作成レスポンス
+message CreatePurchaseOrderResponse {
+  // 作成された発注
+  PurchaseOrder purchase_order = 1;
+}
+
+// 発注取得レスポンス
+message GetPurchaseOrderResponse {
+  // 発注情報
+  PurchaseOrder purchase_order = 1;
+}
+
+// 発注ステータス更新レスポンス
+message UpdatePurchaseOrderStatusResponse {
+  // 更新された発注
+  PurchaseOrder purchase_order = 1;
 }
 
 // === リクエスト/レスポンス ===

--- a/proto/openpos/pos/v1/pos.proto
+++ b/proto/openpos/pos/v1/pos.proto
@@ -10,25 +10,25 @@ import "openpos/common/v1/common.proto";
 // オフライン対応: client_id による冪等性キーを使って重複排除します
 service PosService {
   // 取引を作成する（ドラフト状態で開始）
-  rpc CreateTransaction(CreateTransactionRequest) returns (Transaction);
+  rpc CreateTransaction(CreateTransactionRequest) returns (CreateTransactionResponse);
   // 取引を取得する
-  rpc GetTransaction(GetTransactionRequest) returns (Transaction);
+  rpc GetTransaction(GetTransactionRequest) returns (GetTransactionResponse);
   // 取引一覧を取得する（日付範囲・店舗・ステータスで絞り込み）
   rpc ListTransactions(ListTransactionsRequest) returns (ListTransactionsResponse);
   // 取引に明細を追加する（バーコードスキャン時に呼び出す）
-  rpc AddTransactionItem(AddTransactionItemRequest) returns (Transaction);
+  rpc AddTransactionItem(AddTransactionItemRequest) returns (AddTransactionItemResponse);
   // 取引の明細を更新する（数量変更等）
-  rpc UpdateTransactionItem(UpdateTransactionItemRequest) returns (Transaction);
+  rpc UpdateTransactionItem(UpdateTransactionItemRequest) returns (UpdateTransactionItemResponse);
   // 取引の明細を削除する
-  rpc RemoveTransactionItem(RemoveTransactionItemRequest) returns (Transaction);
+  rpc RemoveTransactionItem(RemoveTransactionItemRequest) returns (RemoveTransactionItemResponse);
   // 取引に割引を適用する（クーポンコードまたは割引IDを指定）
-  rpc ApplyDiscount(ApplyDiscountRequest) returns (Transaction);
+  rpc ApplyDiscount(ApplyDiscountRequest) returns (ApplyDiscountResponse);
   // 取引を確定する（支払処理・レシート発行）
   rpc FinalizeTransaction(FinalizeTransactionRequest) returns (FinalizeTransactionResponse);
   // 取引を無効化する（返品・誤操作キャンセル）
-  rpc VoidTransaction(VoidTransactionRequest) returns (Transaction);
+  rpc VoidTransaction(VoidTransactionRequest) returns (VoidTransactionResponse);
   // レシートを取得する
-  rpc GetReceipt(GetReceiptRequest) returns (Receipt);
+  rpc GetReceipt(GetReceiptRequest) returns (GetReceiptResponse);
   // オフライン取引を同期する（端末オンライン復帰時に一括送信）
   rpc SyncOfflineTransactions(SyncOfflineTransactionsRequest) returns (SyncOfflineTransactionsResponse);
 }
@@ -207,6 +207,56 @@ message Receipt {
   string pdf_url = 4;
   // 作成日時（ISO 8601 形式）
   string created_at = 5;
+}
+
+// === レスポンスラッパー ===
+
+// 取引作成レスポンス
+message CreateTransactionResponse {
+  // 作成された取引
+  Transaction transaction = 1;
+}
+
+// 取引取得レスポンス
+message GetTransactionResponse {
+  // 取引情報
+  Transaction transaction = 1;
+}
+
+// 明細追加レスポンス
+message AddTransactionItemResponse {
+  // 更新された取引
+  Transaction transaction = 1;
+}
+
+// 明細更新レスポンス
+message UpdateTransactionItemResponse {
+  // 更新された取引
+  Transaction transaction = 1;
+}
+
+// 明細削除レスポンス
+message RemoveTransactionItemResponse {
+  // 更新された取引
+  Transaction transaction = 1;
+}
+
+// 割引適用レスポンス
+message ApplyDiscountResponse {
+  // 更新された取引
+  Transaction transaction = 1;
+}
+
+// 取引無効化レスポンス
+message VoidTransactionResponse {
+  // 無効化された取引
+  Transaction transaction = 1;
+}
+
+// レシート取得レスポンス
+message GetReceiptResponse {
+  // レシート情報
+  Receipt receipt = 1;
 }
 
 // === リクエスト/レスポンス ===

--- a/proto/openpos/product/v1/product.proto
+++ b/proto/openpos/product/v1/product.proto
@@ -9,43 +9,43 @@ import "openpos/common/v1/common.proto";
 // 商品・カテゴリ・税率・割引・クーポンの CRUD を提供します
 service ProductService {
   // 商品を作成する
-  rpc CreateProduct(CreateProductRequest) returns (Product);
+  rpc CreateProduct(CreateProductRequest) returns (CreateProductResponse);
   // 商品を取得する
-  rpc GetProduct(GetProductRequest) returns (Product);
+  rpc GetProduct(GetProductRequest) returns (GetProductResponse);
   // 商品一覧を取得する（カテゴリ・フリーワード絞り込み対応）
   rpc ListProducts(ListProductsRequest) returns (ListProductsResponse);
   // 商品を更新する
-  rpc UpdateProduct(UpdateProductRequest) returns (Product);
+  rpc UpdateProduct(UpdateProductRequest) returns (UpdateProductResponse);
   // 商品を削除する（論理削除）
   rpc DeleteProduct(DeleteProductRequest) returns (DeleteProductResponse);
   // バーコードで商品を検索する（POS スキャン時に使用）
-  rpc GetProductByBarcode(GetProductByBarcodeRequest) returns (Product);
+  rpc GetProductByBarcode(GetProductByBarcodeRequest) returns (GetProductByBarcodeResponse);
 
   // カテゴリを作成する
-  rpc CreateCategory(CreateCategoryRequest) returns (Category);
+  rpc CreateCategory(CreateCategoryRequest) returns (CreateCategoryResponse);
   // カテゴリ一覧を取得する（親カテゴリ指定でサブカテゴリ取得可）
   rpc ListCategories(ListCategoriesRequest) returns (ListCategoriesResponse);
   // カテゴリを更新する
-  rpc UpdateCategory(UpdateCategoryRequest) returns (Category);
+  rpc UpdateCategory(UpdateCategoryRequest) returns (UpdateCategoryResponse);
   // カテゴリを削除する
   rpc DeleteCategory(DeleteCategoryRequest) returns (DeleteCategoryResponse);
 
   // 税率を作成する（インボイス対応: 標準税率・軽減税率）
-  rpc CreateTaxRate(CreateTaxRateRequest) returns (TaxRate);
+  rpc CreateTaxRate(CreateTaxRateRequest) returns (CreateTaxRateResponse);
   // 税率一覧を取得する
   rpc ListTaxRates(ListTaxRatesRequest) returns (ListTaxRatesResponse);
   // 税率を更新する
-  rpc UpdateTaxRate(UpdateTaxRateRequest) returns (TaxRate);
+  rpc UpdateTaxRate(UpdateTaxRateRequest) returns (UpdateTaxRateResponse);
 
   // 割引を作成する（パーセント割引・定額割引）
-  rpc CreateDiscount(CreateDiscountRequest) returns (Discount);
+  rpc CreateDiscount(CreateDiscountRequest) returns (CreateDiscountResponse);
   // 割引一覧を取得する
   rpc ListDiscounts(ListDiscountsRequest) returns (ListDiscountsResponse);
   // 割引を更新する
-  rpc UpdateDiscount(UpdateDiscountRequest) returns (Discount);
+  rpc UpdateDiscount(UpdateDiscountRequest) returns (UpdateDiscountResponse);
 
   // クーポンを作成する
-  rpc CreateCoupon(CreateCouponRequest) returns (Coupon);
+  rpc CreateCoupon(CreateCouponRequest) returns (CreateCouponResponse);
   // クーポンコードを検証する（取引適用前に呼び出す）
   rpc ValidateCoupon(ValidateCouponRequest) returns (ValidateCouponResponse);
 }
@@ -189,6 +189,74 @@ message Coupon {
   string created_at = 10;
   // 更新日時（ISO 8601 形式）
   string updated_at = 11;
+}
+
+// === レスポンスラッパー ===
+
+// 商品作成レスポンス
+message CreateProductResponse {
+  // 作成された商品
+  Product product = 1;
+}
+
+// 商品取得レスポンス
+message GetProductResponse {
+  // 商品情報
+  Product product = 1;
+}
+
+// 商品更新レスポンス
+message UpdateProductResponse {
+  // 更新された商品
+  Product product = 1;
+}
+
+// バーコード商品検索レスポンス
+message GetProductByBarcodeResponse {
+  // 検索結果の商品
+  Product product = 1;
+}
+
+// カテゴリ作成レスポンス
+message CreateCategoryResponse {
+  // 作成されたカテゴリ
+  Category category = 1;
+}
+
+// カテゴリ更新レスポンス
+message UpdateCategoryResponse {
+  // 更新されたカテゴリ
+  Category category = 1;
+}
+
+// 税率作成レスポンス
+message CreateTaxRateResponse {
+  // 作成された税率
+  TaxRate tax_rate = 1;
+}
+
+// 税率更新レスポンス
+message UpdateTaxRateResponse {
+  // 更新された税率
+  TaxRate tax_rate = 1;
+}
+
+// 割引作成レスポンス
+message CreateDiscountResponse {
+  // 作成された割引
+  Discount discount = 1;
+}
+
+// 割引更新レスポンス
+message UpdateDiscountResponse {
+  // 更新された割引
+  Discount discount = 1;
+}
+
+// クーポン作成レスポンス
+message CreateCouponResponse {
+  // 作成されたクーポン
+  Coupon coupon = 1;
 }
 
 // === リクエスト/レスポンス ===

--- a/proto/openpos/store/v1/store.proto
+++ b/proto/openpos/store/v1/store.proto
@@ -9,36 +9,36 @@ import "openpos/common/v1/common.proto";
 // マルチテナント構成の組織・店舗・端末・スタッフの CRUD と PIN 認証を提供します
 service StoreService {
   // 組織を作成する（テナント登録）
-  rpc CreateOrganization(CreateOrganizationRequest) returns (Organization);
+  rpc CreateOrganization(CreateOrganizationRequest) returns (CreateOrganizationResponse);
   // 組織を取得する
-  rpc GetOrganization(GetOrganizationRequest) returns (Organization);
+  rpc GetOrganization(GetOrganizationRequest) returns (GetOrganizationResponse);
   // 組織を更新する（適格請求書発行事業者番号等）
-  rpc UpdateOrganization(UpdateOrganizationRequest) returns (Organization);
+  rpc UpdateOrganization(UpdateOrganizationRequest) returns (UpdateOrganizationResponse);
 
   // 店舗を作成する
-  rpc CreateStore(CreateStoreRequest) returns (Store);
+  rpc CreateStore(CreateStoreRequest) returns (CreateStoreResponse);
   // 店舗を取得する
-  rpc GetStore(GetStoreRequest) returns (Store);
+  rpc GetStore(GetStoreRequest) returns (GetStoreResponse);
   // 店舗一覧を取得する
   rpc ListStores(ListStoresRequest) returns (ListStoresResponse);
   // 店舗を更新する
-  rpc UpdateStore(UpdateStoreRequest) returns (Store);
+  rpc UpdateStore(UpdateStoreRequest) returns (UpdateStoreResponse);
 
   // 端末を登録する（POS 端末の初回セットアップ）
-  rpc RegisterTerminal(RegisterTerminalRequest) returns (Terminal);
+  rpc RegisterTerminal(RegisterTerminalRequest) returns (RegisterTerminalResponse);
   // 端末一覧を取得する
   rpc ListTerminals(ListTerminalsRequest) returns (ListTerminalsResponse);
   // 端末の最終同期日時を更新する（ハートビート）
-  rpc UpdateTerminalSync(UpdateTerminalSyncRequest) returns (Terminal);
+  rpc UpdateTerminalSync(UpdateTerminalSyncRequest) returns (UpdateTerminalSyncResponse);
 
   // スタッフを作成する
-  rpc CreateStaff(CreateStaffRequest) returns (Staff);
+  rpc CreateStaff(CreateStaffRequest) returns (CreateStaffResponse);
   // スタッフを取得する
-  rpc GetStaff(GetStaffRequest) returns (Staff);
+  rpc GetStaff(GetStaffRequest) returns (GetStaffResponse);
   // スタッフ一覧を取得する
   rpc ListStaff(ListStaffRequest) returns (ListStaffResponse);
   // スタッフを更新する
-  rpc UpdateStaff(UpdateStaffRequest) returns (Staff);
+  rpc UpdateStaff(UpdateStaffRequest) returns (UpdateStaffResponse);
   // PIN で認証する（POS 画面のスタッフログイン）
   rpc AuthenticateByPin(AuthenticateByPinRequest) returns (AuthenticateByPinResponse);
 }
@@ -153,6 +153,74 @@ message Staff {
   string created_at = 11;
   // 更新日時（ISO 8601 形式）
   string updated_at = 12;
+}
+
+// === レスポンスラッパー ===
+
+// 組織作成レスポンス
+message CreateOrganizationResponse {
+  // 作成された組織
+  Organization organization = 1;
+}
+
+// 組織取得レスポンス
+message GetOrganizationResponse {
+  // 組織情報
+  Organization organization = 1;
+}
+
+// 組織更新レスポンス
+message UpdateOrganizationResponse {
+  // 更新された組織
+  Organization organization = 1;
+}
+
+// 店舗作成レスポンス
+message CreateStoreResponse {
+  // 作成された店舗
+  Store store = 1;
+}
+
+// 店舗取得レスポンス
+message GetStoreResponse {
+  // 店舗情報
+  Store store = 1;
+}
+
+// 店舗更新レスポンス
+message UpdateStoreResponse {
+  // 更新された店舗
+  Store store = 1;
+}
+
+// 端末登録レスポンス
+message RegisterTerminalResponse {
+  // 登録された端末
+  Terminal terminal = 1;
+}
+
+// 端末同期更新レスポンス
+message UpdateTerminalSyncResponse {
+  // 更新された端末
+  Terminal terminal = 1;
+}
+
+// スタッフ作成レスポンス
+message CreateStaffResponse {
+  // 作成されたスタッフ
+  Staff staff = 1;
+}
+
+// スタッフ取得レスポンス
+message GetStaffResponse {
+  // スタッフ情報
+  Staff staff = 1;
+}
+
+// スタッフ更新レスポンス
+message UpdateStaffResponse {
+  // 更新されたスタッフ
+  Staff staff = 1;
 }
 
 // === リクエスト/レスポンス ===


### PR DESCRIPTION
## Summary
- 全 proto ファイル（5ファイル）の RPC Response 型を buf lint 命名規約に準拠
- 各 RPC に固有の Response メッセージラッパーを定義（計36メッセージ追加）
- `buf format -w` 適用済み

Closes #20

## Test plan
- [x] `buf lint proto` エラー0件
- [x] `buf format --diff proto` 差分なし