### PR TITLE
chore(deps): update testcontainers to 2.0.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,9 +28,9 @@ subprojects {
 
         afterEvaluate {
             dependencies {
-                "testImplementation"("org.testcontainers:testcontainers:1.21.4")
-                "testImplementation"("org.testcontainers:postgresql:1.21.4")
-                "testImplementation"("org.testcontainers:junit-jupiter:1.21.4")
+                "testImplementation"("org.testcontainers:testcontainers:2.0.3")
+                "testImplementation"("org.testcontainers:testcontainers-postgresql:2.0.3")
+                "testImplementation"("org.testcontainers:testcontainers-junit-jupiter:2.0.3")
             }
 
             apply(plugin = "jacoco")


### PR DESCRIPTION
## Summary
- update the shared Testcontainers version from 1.21.4 to 2.0.3
- switch the renamed module coordinates required by Testcontainers 2
- supersede #255 with a main-based, validated update

## Notes
- Testcontainers 2 renamed extension artifacts to testcontainers-*
- this change updates postgresql -> testcontainers-postgresql
- this change updates junit-jupiter -> testcontainers-junit-jupiter

## Validation
- ./gradlew test