### PR TITLE
fix(ci): stabilize docker demo bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help: ## Show this help
 
 # === Infrastructure ===
 up: ## Start infrastructure only (PostgreSQL, Redis, RabbitMQ, Hydra)
-	docker compose -f infra/compose.yml up -d postgres redis rabbitmq hydra-migrate hydra
+	docker compose -f infra/compose.yml up -d --wait postgres redis rabbitmq hydra-migrate hydra
 
 up-all: ## Start infrastructure + all backend services
 	docker compose -f infra/compose.yml up -d
@@ -85,7 +85,7 @@ docker-build-core: ## Build the core backend container images sequentially
 	docker compose -f infra/compose.yml build api-gateway
 
 docker-up-core: up local-down ## Start the core backend services in containers
-	docker compose -f infra/compose.yml up -d product-service store-service pos-service api-gateway
+	docker compose -f infra/compose.yml up -d --wait product-service store-service pos-service api-gateway
 
 docker-down-core: ## Stop only the containerized core backend services
 	docker compose -f infra/compose.yml stop api-gateway product-service store-service pos-service

--- a/infra/init-scripts/rabbitmq/definitions.json
+++ b/infra/init-scripts/rabbitmq/definitions.json
@@ -1,4 +1,12 @@
 {
+  "users": [
+    {
+      "name": "openpos",
+      "password_hash": "l5GyEzSXS1nYBMcs2lz4gbFzBOHWo4u5cR9VmojOJOLFNyJB",
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "tags": "administrator"
+    }
+  ],
   "vhosts": [{ "name": "/" }],
   "permissions": [
     {


### PR DESCRIPTION
## Summary
- add the seeded `openpos` RabbitMQ user to boot-time definitions so RabbitMQ 4 can import permissions during startup
- wait for infra and core backend service health in `make docker-demo` before seeding and smoke checks
- restore the E2E workflow path that failed in `Start full demo stack`

## Validation
- docker compose -f infra/compose.yml up rabbitmq
- make docker-demo
- pnpm --filter e2e exec playwright install --with-deps chromium
- pnpm --filter e2e test
- docker compose -f infra/compose.yml down -v