### PR TITLE
fix(ci): harden e2e web server startup

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { defineConfig } from '@playwright/test'
 
 const rootDir = path.resolve(process.cwd(), '..')
+const webServerTimeout = process.env.CI ? 300_000 : 120_000
 
 export default defineConfig({
   testDir: './tests',
@@ -10,18 +11,18 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : 'html',
   webServer: [
     {
-      command: 'pnpm --filter pos-terminal dev -- --host 127.0.0.1 --port 5173',
+      command: 'pnpm --filter pos-terminal exec vite --host 127.0.0.1 --port 5173 --strictPort',
       url: 'http://127.0.0.1:5173',
       cwd: rootDir,
       reuseExistingServer: !process.env.CI,
-      timeout: 120_000,
+      timeout: webServerTimeout,
     },
     {
-      command: 'pnpm --filter admin-dashboard dev -- --host 127.0.0.1 --port 5174',
+      command: 'pnpm --filter admin-dashboard exec vite --host 127.0.0.1 --port 5174 --strictPort',
       url: 'http://127.0.0.1:5174',
       cwd: rootDir,
       reuseExistingServer: !process.env.CI,
-      timeout: 120_000,
+      timeout: webServerTimeout,
     },
   ],
   use: {


### PR DESCRIPTION
## Summary
- run Playwright web servers via direct Vite commands with explicit host/strict port
- increase CI-only Playwright webServer startup timeout to absorb slower GitHub runner startups
- keep local reuse behavior unchanged

## Testing
- CI=1 DEBUG=pw:webserver pnpm --filter e2e test
- make docker-demo
