### PR TITLE
fix(store): enforce PIN auth store boundary

### DIFF
--- a/apps/pos-terminal/src/components/login-screen.test.tsx
+++ b/apps/pos-terminal/src/components/login-screen.test.tsx
@@ -147,7 +147,10 @@ describe('LoginScreen', () => {
     await waitFor(() => {
       expect(mockApiPost).toHaveBeenCalledWith(
         `/api/staff/${mockStaffList.data[0]!.id}/authenticate`,
-        { pin: '1234' },
+        {
+          storeId: '550e8400-e29b-41d4-a716-446655440020',
+          pin: '1234',
+        },
         expect.anything(),
       )
     })

--- a/apps/pos-terminal/src/components/login-screen.tsx
+++ b/apps/pos-terminal/src/components/login-screen.tsx
@@ -67,7 +67,7 @@ export function LoginScreen() {
     try {
       const result = await api.post(
         `/api/staff/${selectedStaff.id}/authenticate`,
-        { pin },
+        { storeId, pin },
         AuthenticateByPinResponseSchema,
       )
       if (result.success && result.staff) {

--- a/packages/shared-types/src/api-types.test.ts
+++ b/packages/shared-types/src/api-types.test.ts
@@ -188,8 +188,12 @@ describe('createPaginatedResponseSchema', () => {
 })
 
 describe('AuthenticateByPin schemas', () => {
-  it('現在の gateway リクエスト形式をパースできる', () => {
-    const result = AuthenticateByPinRequestSchema.parse({ pin: '1234' })
+  it('storeId を含む認証リクエストをパースできる', () => {
+    const result = AuthenticateByPinRequestSchema.parse({
+      storeId: '550e8400-e29b-41d4-a716-446655440002',
+      pin: '1234',
+    })
+    expect(result.storeId).toBe('550e8400-e29b-41d4-a716-446655440002')
     expect(result.pin).toBe('1234')
   })
 

--- a/packages/shared-types/src/store.ts
+++ b/packages/shared-types/src/store.ts
@@ -134,6 +134,7 @@ export const UpdateStaffRequestSchema = z.object({
 export type UpdateStaffRequest = z.infer<typeof UpdateStaffRequestSchema>
 
 export const AuthenticateByPinRequestSchema = z.object({
+  storeId: z.string().uuid(),
   pin: z.string().min(4).max(8),
 })
 

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
@@ -116,6 +116,7 @@ class StaffResource {
         val request =
             AuthenticateByPinRequest
                 .newBuilder()
+                .setStoreId(body.storeId)
                 .setStaffId(id)
                 .setPin(body.pin)
                 .build()
@@ -152,5 +153,6 @@ data class UpdateStaffBody(
 )
 
 data class AuthenticateBody(
+    val storeId: String,
     val pin: String,
 )

--- a/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
@@ -337,6 +337,7 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
         val result =
             staffService.authenticateByPin(
                 staffId = request.staffId.toUUID(),
+                storeId = request.storeId.toUUID(),
                 pin = request.pin,
                 pinVerifier = { pin, hash ->
                     BCrypt.verifyer().verify(pin.toCharArray(), hash).verified

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/StaffService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/StaffService.kt
@@ -99,11 +99,15 @@ class StaffService {
     @Transactional
     fun authenticateByPin(
         staffId: UUID,
+        storeId: UUID,
         pin: String,
         pinVerifier: (String, String) -> Boolean,
     ): PinAuthResult {
         tenantFilterService.enableFilter()
         val staff = staffRepository.findById(staffId) ?: return PinAuthResult(false, reason = "NOT_FOUND")
+        if (staff.storeId != storeId) {
+            return PinAuthResult(false, reason = "NOT_FOUND")
+        }
 
         if (!staff.isActive) {
             return PinAuthResult(false, staff = staff, reason = "ACCOUNT_INACTIVE")

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/StaffServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/StaffServiceTest.kt
@@ -268,7 +268,7 @@ class StaffServiceTest {
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "1234") { plain, hash -> plain == hash }
+            val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
 
             // Assert
             assertTrue(result.success)
@@ -286,7 +286,33 @@ class StaffServiceTest {
             whenever(staffRepository.findById(staffId)).thenReturn(null)
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "1234") { plain, hash -> plain == hash }
+            val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
+
+            // Assert
+            assertFalse(result.success)
+            assertNull(result.staff)
+            assertEquals("NOT_FOUND", result.reason)
+        }
+
+        @Test
+        fun `別店舗のスタッフIDの場合はNOT_FOUNDを返す`() {
+            // Arrange
+            val staffId = UUID.randomUUID()
+            val otherStoreId = UUID.randomUUID()
+            val entity =
+                StaffEntity().apply {
+                    this.id = staffId
+                    this.organizationId = orgId
+                    this.storeId = otherStoreId
+                    this.name = "田中太郎"
+                    this.role = "CASHIER"
+                    this.pinHash = "1234"
+                    this.isActive = true
+                }
+            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+
+            // Act
+            val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
 
             // Assert
             assertFalse(result.success)
@@ -311,7 +337,7 @@ class StaffServiceTest {
             whenever(staffRepository.findById(staffId)).thenReturn(entity)
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "1234") { plain, hash -> plain == hash }
+            val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
 
             // Assert
             assertFalse(result.success)
@@ -338,7 +364,7 @@ class StaffServiceTest {
             whenever(staffRepository.findById(staffId)).thenReturn(entity)
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "1234") { plain, hash -> plain == hash }
+            val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
 
             // Assert
             assertFalse(result.success)
@@ -365,7 +391,7 @@ class StaffServiceTest {
             whenever(staffRepository.findById(staffId)).thenReturn(entity)
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "1234") { plain, hash -> plain == hash }
+            val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
 
             // Assert
             assertFalse(result.success)
@@ -393,7 +419,7 @@ class StaffServiceTest {
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "9999") { _, _ -> false }
+            val result = staffService.authenticateByPin(staffId, storeId, "9999") { _, _ -> false }
 
             // Assert
             assertFalse(result.success)
@@ -422,7 +448,7 @@ class StaffServiceTest {
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "9999") { _, _ -> false }
+            val result = staffService.authenticateByPin(staffId, storeId, "9999") { _, _ -> false }
 
             // Assert
             assertFalse(result.success)
@@ -451,7 +477,7 @@ class StaffServiceTest {
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "1234") { plain, hash -> plain == hash }
+            val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
 
             // Assert
             assertTrue(result.success)
@@ -479,7 +505,7 @@ class StaffServiceTest {
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "1234") { plain, hash -> plain == hash }
+            val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
 
             // Assert
             assertTrue(result.success)
@@ -507,7 +533,7 @@ class StaffServiceTest {
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
-            val result = staffService.authenticateByPin(staffId, "9999") { _, _ -> false }
+            val result = staffService.authenticateByPin(staffId, storeId, "9999") { _, _ -> false }
 
             // Assert
             assertFalse(result.success)


### PR DESCRIPTION
## Summary
- require `storeId` in staff PIN authentication requests from the POS terminal through the API gateway
- validate the requested store boundary before PIN verification in store-service
- add regression coverage for shared-types, pos-terminal, and StaffService

## Testing
- pnpm --filter @shared-types/openpos test
- pnpm --filter pos-terminal test -- login-screen
- ./gradlew :services:store-service:test --tests com.openpos.store.service.StaffServiceTest :services:api-gateway:test --no-build-cache

Partially addresses #242.
