### PR TITLE
fix: preserve false in store/staff update requests

### DIFF
--- a/proto/openpos/store/v1/store.proto
+++ b/proto/openpos/store/v1/store.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 package openpos.store.v1;
 
 import "openpos/common/v1/common.proto";
+import "google/protobuf/wrappers.proto";
 
 option java_multiple_files = true;
 
@@ -305,6 +306,8 @@ message UpdateStoreRequest {
   string settings = 6;
   // 有効フラグ
   bool is_active = 7;
+  // 有効フラグ（presence 付き更新用）
+  google.protobuf.BoolValue is_active_value = 8;
 }
 
 // 端末登録リクエスト
@@ -387,6 +390,8 @@ message UpdateStaffRequest {
   string pin = 5;
   // 有効フラグ
   bool is_active = 6;
+  // 有効フラグ（presence 付き更新用）
+  google.protobuf.BoolValue is_active_value = 7;
 }
 
 // PIN 認証リクエスト

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
@@ -3,6 +3,7 @@ package com.openpos.gateway.resource
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.paginatedResponse
 import com.openpos.gateway.config.toMap
+import com.google.protobuf.BoolValue
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
 import jakarta.inject.Inject
@@ -98,7 +99,7 @@ class StaffResource {
                     body.email?.let { setEmail(it) }
                     body.role?.let { setRole(it.toProtoRole()) }
                     body.pin?.let { setPin(it) }
-                    body.isActive?.let { setIsActive(it) }
+                    body.isActive?.let { setIsActiveValue(BoolValue.of(it)) }
                 }.build()
         return grpc
             .withTenant(stub)

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StoreResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StoreResource.kt
@@ -1,5 +1,6 @@
 package com.openpos.gateway.resource
 
+import com.google.protobuf.BoolValue
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.paginatedResponse
 import com.openpos.gateway.config.toMap
@@ -99,7 +100,7 @@ class StoreResource {
                     body.phone?.let { setPhone(it) }
                     body.timezone?.let { setTimezone(it) }
                     body.settings?.let { setSettings(it) }
-                    body.isActive?.let { setIsActive(it) }
+                    body.isActive?.let { setIsActiveValue(BoolValue.of(it)) }
                 }.build()
         return grpc
             .withTenant(stub)

--- a/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
@@ -193,7 +193,12 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
                 phone = request.phone.ifBlank { null },
                 timezone = request.timezone.ifBlank { null },
                 settings = request.settings.ifBlank { null },
-                isActive = if (request.isActive) true else null,
+                isActive =
+                    when {
+                        request.hasIsActiveValue() -> request.isActiveValue.value
+                        request.isActive -> true
+                        else -> null
+                    },
             ) ?: throw Status.NOT_FOUND.withDescription("Store not found: ${request.id}").asRuntimeException()
         responseObserver.onNext(
             UpdateStoreResponse.newBuilder().setStore(entity.toProto()).build(),
@@ -321,7 +326,12 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
                 email = request.email.ifBlank { null },
                 role = if (request.role != StaffRole.STAFF_ROLE_UNSPECIFIED) request.role.toDbRole() else null,
                 pinHash = pinHash,
-                isActive = if (request.isActive) true else null,
+                isActive =
+                    when {
+                        request.hasIsActiveValue() -> request.isActiveValue.value
+                        request.isActive -> true
+                        else -> null
+                    },
             ) ?: throw Status.NOT_FOUND.withDescription("Staff not found: ${request.id}").asRuntimeException()
         responseObserver.onNext(
             UpdateStaffResponse.newBuilder().setStaff(entity.toProto()).build(),

--- a/services/store-service/src/test/kotlin/com/openpos/store/grpc/StoreGrpcServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/grpc/StoreGrpcServiceTest.kt
@@ -1,0 +1,213 @@
+package com.openpos.store.grpc
+
+import com.google.protobuf.BoolValue
+import com.openpos.store.entity.StaffEntity
+import com.openpos.store.entity.StoreEntity
+import com.openpos.store.service.StaffService
+import com.openpos.store.service.StoreService
+import io.grpc.stub.StreamObserver
+import openpos.store.v1.UpdateStaffRequest
+import openpos.store.v1.UpdateStoreRequest
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class StoreGrpcServiceTest {
+    private lateinit var grpcService: StoreGrpcService
+    private val storeService = mock<StoreService>()
+    private val staffService = mock<StaffService>()
+    private val tenantHelper = mock<GrpcTenantHelper>()
+
+    @BeforeEach
+    fun setUp() {
+        grpcService =
+            StoreGrpcService().apply {
+                this.storeService = this@StoreGrpcServiceTest.storeService
+                this.staffService = this@StoreGrpcServiceTest.staffService
+                this.tenantHelper = this@StoreGrpcServiceTest.tenantHelper
+            }
+    }
+
+    @Test
+    fun `updateStore forwards explicit false isActive`() {
+        val storeId = UUID.randomUUID()
+        whenever(
+            storeService.update(
+                eq(storeId),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                eq(false),
+            ),
+        ).thenReturn(storeEntity(storeId))
+
+        val observer = CapturingObserver<openpos.store.v1.UpdateStoreResponse>()
+
+        grpcService.updateStore(
+            UpdateStoreRequest.newBuilder().setId(storeId.toString()).setIsActiveValue(BoolValue.of(false)).build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        verify(storeService).update(
+            eq(storeId),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            eq(false),
+        )
+        assertNotNull(observer.value)
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `updateStore keeps isActive null when omitted`() {
+        val storeId = UUID.randomUUID()
+        whenever(
+            storeService.update(
+                eq(storeId),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                isNull(),
+            ),
+        ).thenReturn(storeEntity(storeId))
+
+        val observer = CapturingObserver<openpos.store.v1.UpdateStoreResponse>()
+
+        grpcService.updateStore(
+            UpdateStoreRequest.newBuilder().setId(storeId.toString()).build(),
+            observer,
+        )
+
+        verify(storeService).update(
+            eq(storeId),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            isNull(),
+        )
+        assertNotNull(observer.value)
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `updateStaff forwards explicit false isActive`() {
+        val staffId = UUID.randomUUID()
+        whenever(
+            staffService.update(
+                eq(staffId),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                eq(false),
+            ),
+        ).thenReturn(staffEntity(staffId))
+
+        val observer = CapturingObserver<openpos.store.v1.UpdateStaffResponse>()
+
+        grpcService.updateStaff(
+            UpdateStaffRequest.newBuilder().setId(staffId.toString()).setIsActiveValue(BoolValue.of(false)).build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        verify(staffService).update(
+            eq(staffId),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            eq(false),
+        )
+        assertNotNull(observer.value)
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `updateStaff keeps isActive null when omitted`() {
+        val staffId = UUID.randomUUID()
+        whenever(
+            staffService.update(
+                eq(staffId),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                isNull(),
+            ),
+        ).thenReturn(staffEntity(staffId))
+
+        val observer = CapturingObserver<openpos.store.v1.UpdateStaffResponse>()
+
+        grpcService.updateStaff(
+            UpdateStaffRequest.newBuilder().setId(staffId.toString()).build(),
+            observer,
+        )
+
+        verify(staffService).update(
+            eq(staffId),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            isNull(),
+        )
+        assertNotNull(observer.value)
+        assertTrue(observer.completed)
+    }
+
+    private fun storeEntity(storeId: UUID): StoreEntity =
+        StoreEntity().apply {
+            id = storeId
+            organizationId = UUID.randomUUID()
+            name = "Store"
+            timezone = "Asia/Tokyo"
+            settings = "{}"
+            isActive = true
+        }
+
+    private fun staffEntity(staffId: UUID): StaffEntity =
+        StaffEntity().apply {
+            id = staffId
+            organizationId = UUID.randomUUID()
+            storeId = UUID.randomUUID()
+            name = "Staff"
+            role = "CASHIER"
+            isActive = true
+        }
+
+    private class CapturingObserver<T> : StreamObserver<T> {
+        var value: T? = null
+        var completed = false
+
+        override fun onNext(value: T) {
+            this.value = value
+        }
+
+        override fun onError(t: Throwable) {
+            throw AssertionError("Unexpected error", t)
+        }
+
+        override fun onCompleted() {
+            completed = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add presence-aware `BoolValue` fields for store/staff update requests without breaking the existing proto contract
- make the API gateway send the new presence-aware fields for `isActive`
- map the new fields in store-service and add regression tests for explicit `false` vs omitted values

## Testing
- `cd proto && buf lint && buf breaking --against '../.git#branch=main,subdir=proto'`
- `./gradlew :services:store-service:test --tests com.openpos.store.grpc.StoreGrpcServiceTest --tests com.openpos.store.service.StoreServiceTest --tests com.openpos.store.service.StaffServiceTest :services:api-gateway:test --tests com.openpos.gateway.HealthCheckTest --no-build-cache`

Closes #242 (store/staff `is_active=false` slice only).