### PR TITLE
docs(oss): refresh local development runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added GitHub CodeQL scanning and tightened the documented security reporting path to GitHub private advisories only.
 - Tightened contributor setup docs around actual required tools (`curl`, `jq`, `bc`) and the supported verification flow.
+- Rewrote the local development runbook to match the supported `make local-demo` / `make docker-demo` flows, generated runtime config files, and current troubleshooting steps.
 - Added clearer prerequisite checks to local helper scripts.
 - Fixed the Docker-based startup flow to wait on `hydra` health instead of the one-shot `hydra-migrate` container.
 - Shifted open-ended setup and usage questions toward GitHub Discussions, keeping Issues focused on bugs and feature work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This directory contains the project design, runbooks, product requirements, and 
 ## Setup and Daily Development
 
 - [guides/setup.md](guides/setup.md): local environment setup and supported startup flows
-- [runbook/local-dev.md](runbook/local-dev.md): day-to-day commands and troubleshooting
+- [runbook/local-dev.md](runbook/local-dev.md): supported local modes, runtime config outputs, and troubleshooting
 - [guides/contributing.md](guides/contributing.md): lightweight contribution workflow
 - [guides/branching-strategy.md](guides/branching-strategy.md): branch and PR conventions
 - [runbook/release.md](runbook/release.md): maintainer release checklist

--- a/docs/runbook/local-dev.md
+++ b/docs/runbook/local-dev.md
@@ -1,66 +1,195 @@
-# ローカル開発手順書
+# Local Development Runbook
 
-## 日常の開発フロー
+This runbook describes the supported day-to-day development flows for `open-pos`.
+
+## Recommended Modes
+
+### Host-run core backend
+
+Use this for normal development. Infrastructure runs in Docker, while the core backend runs on the host as built Quarkus jars.
 
 ```bash
-# 1. インフラ起動
-make up
-
-# 2. バックエンドサービス起動（開発モード）
-./gradlew :services:api-gateway:quarkusDev
-./gradlew :services:product-service:quarkusDev
-
-# 3. フロントエンド起動
-pnpm dev:pos     # POS端末
-pnpm dev:admin   # 管理画面
+make local-demo
+pnpm dev:admin   # http://localhost:5174
+pnpm dev:pos     # http://localhost:5173
 ```
 
-## よくあるトラブル
+`make local-demo` performs all of the following:
 
-### ポート競合
-dev-stack と同時起動する場合、以下のポートが open-pos 用:
-- PostgreSQL: **15432**（dev-stack: 5432）
-- Redis: **16379**（dev-stack: 6379）
-- RabbitMQ: **15672/15673**
+- starts infrastructure via Docker Compose
+- builds and starts `product-service`, `store-service`, `pos-service`, and `api-gateway` on the host
+- seeds demo data
+- writes frontend runtime config files
+- runs the API smoke check
 
-### DB マイグレーションエラー
+### Containerized core backend
+
+Use this when you want the core backend to match the containerized CI/release-style path more closely.
+
 ```bash
-# スキーマ再作成
-docker compose -f infra/compose.yml down -v
-make up
+make docker-demo
+pnpm dev:admin
+pnpm dev:pos
 ```
 
-### Proto コード生成が失敗する
+When switching from the host-run path, stop the local backend first:
+
 ```bash
-buf --version
-buf lint  # エラー内容確認
+make local-down
+make docker-up-core
 ```
 
-### Docker コンテナが起動しない
+## Common Commands
+
+### Infrastructure only
+
+```bash
+make up       # PostgreSQL, Redis, RabbitMQ, Hydra
+make up-dev   # infra + pgAdmin + Redis Commander
+make down
+```
+
+### Host-run backend
+
+```bash
+make local-up       # rebuild and start the core backend
+make local-up-fast  # start without rebuilding
+make local-down
+```
+
+Logs and PIDs for the host-run backend are written to:
+
+- `.local/logs/`
+- `.local/pids/`
+
+### Containerized backend
+
+```bash
+make docker-build-core
+make docker-up-core
+make docker-down-core
+```
+
+### Seed and smoke
+
+```bash
+make local-seed
+make local-smoke
+make docker-smoke
+```
+
+### Frontend dev servers
+
+```bash
+pnpm dev:admin
+pnpm dev:pos
+```
+
+### Verification
+
+```bash
+make doctor
+make verify
+pnpm e2e:install
+make verify-full
+```
+
+## Runtime Config Files
+
+`scripts/seed.sh` writes both environment files and runtime config files:
+
+- `apps/admin-dashboard/.env.development.local`
+- `apps/pos-terminal/.env.development.local`
+- `apps/admin-dashboard/public/demo-config.json`
+- `apps/pos-terminal/public/demo-config.json`
+
+The frontend apps read `public/demo-config.json` at runtime, so a browser reload is enough after reseeding. You usually do not need to restart the Vite dev servers.
+
+## Health Checks and Useful Endpoints
+
+| Service | URL | Notes |
+|---------|-----|-------|
+| API Gateway | http://localhost:8080/api/health | Main smoke target |
+| Product Service | http://localhost:8081/health | Host-run mode |
+| Store Service | http://localhost:8082/health | Host-run mode |
+| POS Service | http://localhost:8083/health | Host-run mode |
+| PostgreSQL | localhost:15432/openpos | `openpos` / `openpos_dev` |
+| Redis | localhost:16379 | no auth |
+| RabbitMQ UI | http://localhost:15673 | `openpos` / `openpos_dev` |
+| Hydra Public | http://localhost:14444 | OAuth/OIDC public endpoint |
+| Hydra Admin | http://localhost:14445 | Hydra admin API |
+| pgAdmin | http://localhost:15080 | available via `make up-dev` |
+| Redis Commander | http://localhost:18081 | available via `make up-dev` |
+
+Useful checks:
+
+```bash
+docker compose -f infra/compose.yml ps
+curl -s http://localhost:8080/api/health
+docker compose -f infra/compose.yml logs -f postgres
+docker compose -f infra/compose.yml logs -f rabbitmq
+```
+
+## Troubleshooting
+
+### Port conflicts
+
+`open-pos` intentionally uses non-default local ports for shared infra:
+
+- PostgreSQL: `15432`
+- Redis: `16379`
+- RabbitMQ AMQP/UI: `15672` / `15673`
+- Hydra Public/Admin: `14444` / `14445`
+
+If another local stack is already using those ports, stop it before running `make local-demo` or `make docker-demo`.
+
+### Host-run backend fails to start
+
+Check the per-service logs under `.local/logs/`. If you recently changed dependencies or build outputs, rebuild:
+
+```bash
+make local-down
+make local-up
+```
+
+### Container stack is unhealthy
+
+Inspect the relevant service logs, then do a full reset if necessary:
+
 ```bash
 docker compose -f infra/compose.yml logs postgres
 docker compose -f infra/compose.yml logs rabbitmq
-
-# 全リセット
 docker compose -f infra/compose.yml down -v
-docker compose -f infra/compose.yml up -d
+make up
 ```
 
-## 接続情報
+### Demo IDs or config are missing
 
-| サービス | URL | ユーザー | パスワード |
-|---------|-----|---------|-----------|
-| PostgreSQL | localhost:15432/openpos | openpos | openpos_dev |
-| Redis | localhost:16379 | - | - |
-| RabbitMQ UI | http://localhost:15673 | openpos | openpos_dev |
-| Hydra Public | http://localhost:14444 | - | - |
-| Hydra Admin | http://localhost:14445 | - | - |
-| pgAdmin | http://localhost:15080 | admin@openpos.dev | admin |
-| Redis Commander | http://localhost:18081 | - | - |
-
-## インフラ停止
+If `demo-config.json` or `.env.development.local` files are missing, reseed:
 
 ```bash
-make down          # コンテナ停止（データ保持）
-docker compose -f infra/compose.yml down -v  # コンテナ + データ削除
+make local-seed
+make local-smoke
+```
+
+If the frontend still shows old data, reload the browser tab.
+
+### Smoke check fails after switching modes
+
+Make sure only one core backend mode is active at a time:
+
+```bash
+make local-down
+make docker-down-core
+```
+
+Then start the mode you actually want to use.
+
+### Playwright E2E fails locally
+
+Install the browser bundle once, then use the supported full verification path:
+
+```bash
+pnpm e2e:install
+make verify-full
 ```


### PR DESCRIPTION
## Summary
- rewrite the local development runbook around the supported `make local-demo` and `make docker-demo` paths
- document the generated runtime config files, host/container switching commands, and current troubleshooting steps
- update the docs index and changelog to reflect the refreshed runbook

## Testing
- make doctor
- git diff --check