### PR TITLE
chore(oss): automate pull request component labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,58 @@
+svc:api-gateway:
+- changed-files:
+  - any-glob-to-any-file: services/api-gateway/**
+
+svc:pos:
+- changed-files:
+  - any-glob-to-any-file: services/pos-service/**
+
+svc:product:
+- changed-files:
+  - any-glob-to-any-file: services/product-service/**
+
+svc:analytics:
+- changed-files:
+  - any-glob-to-any-file: services/analytics-service/**
+
+svc:inventory:
+- changed-files:
+  - any-glob-to-any-file: services/inventory-service/**
+
+svc:store:
+- changed-files:
+  - any-glob-to-any-file: services/store-service/**
+
+app:pos-terminal:
+- changed-files:
+  - any-glob-to-any-file: apps/pos-terminal/**
+
+app:admin:
+- changed-files:
+  - any-glob-to-any-file: apps/admin-dashboard/**
+
+pkg:shared-types:
+- changed-files:
+  - any-glob-to-any-file: packages/shared-types/**
+
+proto:
+- changed-files:
+  - any-glob-to-any-file: proto/**
+
+infra:
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/**
+    - infra/**
+    - scripts/**
+    - gradle/**
+    - .mise.toml
+    - .editorconfig
+    - .dockerignore
+    - .gitleaks.toml
+    - Makefile
+    - build.gradle.kts
+    - settings.gradle.kts
+    - gradle.properties
+    - package.json
+    - pnpm-lock.yaml
+    - pnpm-workspace.yaml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        with:
+          sync-labels: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added `GOVERNANCE.md` and `docs/runbook/triage.md` to make maintainer decision-making and issue triage explicit.
+- Added PR component auto-labeling and a label taxonomy runbook for maintainer triage consistency.
 - Added `make doctor`, `make verify`, and `make verify-full` as supported local quality gates.
 - Added maintainer-facing release guidance in [docs/runbook/release.md](docs/runbook/release.md).
 - Added a documentation index in [docs/README.md](docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This directory contains the project design, runbooks, product requirements, and 
 - [guides/branching-strategy.md](guides/branching-strategy.md): branch and PR conventions
 - [runbook/release.md](runbook/release.md): maintainer release checklist
 - [runbook/triage.md](runbook/triage.md): issue, PR, and label triage policy
+- [runbook/labels.md](runbook/labels.md): label taxonomy and PR auto-labeling rules
 
 ## Architecture
 

--- a/docs/runbook/labels.md
+++ b/docs/runbook/labels.md
@@ -1,0 +1,98 @@
+# Label Taxonomy
+
+This runbook documents the label groups used in `open-pos` and how maintainers should apply them.
+
+## Goals
+
+- keep issue and pull request triage predictable
+- make ownership and affected surfaces visible at a glance
+- preserve useful release notes and roadmap hygiene
+
+## Label Groups
+
+### Work Shape
+
+Use one `type:*` label to describe the primary shape of the change:
+
+- `type:feature`
+- `type:bug`
+- `type:docs`
+- `type:chore`
+- `type:test`
+- `type:epic`
+
+These labels are still maintainer-curated. Do not rely on file paths alone to decide them.
+
+### Affected Surface
+
+Use `svc:*`, `app:*`, `pkg:*`, `infra`, or `proto` to show what part of the repository is affected.
+
+| Label | Intended Surface | Auto-applied on PRs |
+|-------|------------------|---------------------|
+| `svc:api-gateway` | `services/api-gateway/**` | yes |
+| `svc:pos` | `services/pos-service/**` | yes |
+| `svc:product` | `services/product-service/**` | yes |
+| `svc:analytics` | `services/analytics-service/**` | yes |
+| `svc:inventory` | `services/inventory-service/**` | yes |
+| `svc:store` | `services/store-service/**` | yes |
+| `app:pos-terminal` | `apps/pos-terminal/**` | yes |
+| `app:admin` | `apps/admin-dashboard/**` | yes |
+| `pkg:shared-types` | `packages/shared-types/**` | yes |
+| `proto` | `proto/**` | yes |
+| `infra` | CI, Compose, scripts, toolchain, root build config | yes |
+
+Automation is defined in [../../.github/labeler.yml](../../.github/labeler.yml) and runs via [../../.github/workflows/labeler.yml](../../.github/workflows/labeler.yml).
+
+If a change is cross-cutting, keep all relevant surface labels instead of forcing a single one.
+
+### Product and Technical Concerns
+
+Use `area:*` labels when the change maps to a domain concern rather than a repository boundary.
+
+Current `area:*` labels include:
+
+- `area:auth`
+- `area:payment`
+- `area:receipt`
+- `area:tax`
+- `area:cart`
+- `area:a11y`
+- `area:sync`
+- `area:i18n`
+- `area:perf`
+- `area:security`
+- `area:monitoring`
+- `area:dx`
+- `area:offline`
+- `area:settlement`
+- `area:customer`
+- `area:report`
+- `area:loyalty`
+
+These are maintainer-applied and should reflect the user-facing or architectural concern, not only the file path.
+
+### Priority
+
+Use `P0:*` to `P3:*` when priority should be visible in the tracker:
+
+- `P0:critical`
+- `P1:high`
+- `P2:medium`
+- `P3:low`
+
+Priority labels are not added automatically.
+
+## Maintainer Guidance
+
+For pull requests:
+
+1. Let the PR Labeler apply the obvious surface labels first.
+2. Verify the auto-applied labels are still correct for the final diff.
+3. Add or adjust `type:*`, `area:*`, and priority labels manually when they matter.
+4. Remove misleading labels on cross-cutting or reshaped PRs before merge.
+
+For issues:
+
+- labels are always maintainer-applied
+- prefer the smallest useful set of labels
+- avoid using labels as a substitute for a clear issue title or description

--- a/docs/runbook/triage.md
+++ b/docs/runbook/triage.md
@@ -21,9 +21,11 @@ This runbook describes the minimum maintainer workflow for incoming issues and p
 Use at least one label from each relevant group:
 
 - `type:*` for the work shape, for example `type:bug`, `type:feature`, `type:docs`, `type:chore`
-- `svc:*`, `app:*`, `infra`, or `proto` for the affected surface
+- `svc:*`, `app:*`, `pkg:*`, `infra`, or `proto` for the affected surface
 - `area:*` when the problem maps to a product or technical concern
 - `P0:*` to `P3:*` when priority needs to be made explicit
+
+See [labels.md](labels.md) for the current label taxonomy and PR label automation rules.
 
 ## Priority Guidance
 
@@ -37,6 +39,7 @@ Use at least one label from each relevant group:
 Before merge, confirm that:
 
 - the title and labels describe the change
+- auto-applied surface labels still match the final diff
 - the linked issue or rationale is clear for non-trivial work
 - the author ran the relevant local checks
 - required GitHub checks are green


### PR DESCRIPTION
## Summary
- add an official GitHub PR labeler workflow pinned to `actions/labeler` v6.0.1
- auto-apply component labels for services, apps, `packages/shared-types`, `proto`, and infra/tooling paths
- document the label taxonomy and update the triage/docs runbooks to reflect the new automation

## Testing
- git diff --check
- docker run --rm -v "$PWD":/work -w /work rhysd/actionlint:latest

## Repo metadata
- created the `pkg:shared-types` label in GitHub for package-level triage