### PR TITLE
fix: align product API contracts

### DIFF
--- a/proto/openpos/product/v1/product.proto
+++ b/proto/openpos/product/v1/product.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 // openpos.product.v1 パッケージは商品マスタ管理の型とサービスを提供します
 package openpos.product.v1;
 
+import "google/protobuf/wrappers.proto";
 import "openpos/common/v1/common.proto";
 
 option java_multiple_files = true;
@@ -341,6 +342,12 @@ message UpdateProductRequest {
   int32 display_order = 10;
   // 有効フラグ
   bool is_active = 11;
+  // 販売価格（presence 付き更新用）
+  google.protobuf.Int64Value price_value = 12;
+  // 表示順序（presence 付き更新用）
+  google.protobuf.Int32Value display_order_value = 13;
+  // 有効フラグ（presence 付き更新用）
+  google.protobuf.BoolValue is_active_value = 14;
 }
 
 // 商品削除リクエスト
@@ -436,6 +443,10 @@ message UpdateTaxRateRequest {
   bool is_reduced = 4;
   // デフォルト税率フラグ
   bool is_default = 5;
+  // 軽減税率フラグ（presence 付き更新用）
+  google.protobuf.BoolValue is_reduced_value = 6;
+  // デフォルト税率フラグ（presence 付き更新用）
+  google.protobuf.BoolValue is_default_value = 7;
 }
 
 // 割引作成リクエスト
@@ -480,6 +491,8 @@ message UpdateDiscountRequest {
   string end_date = 6;
   // 有効フラグ
   bool is_active = 7;
+  // 有効フラグ（presence 付き更新用）
+  google.protobuf.BoolValue is_active_value = 8;
 }
 
 // クーポン作成リクエスト

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductResource.kt
@@ -1,5 +1,8 @@
 package com.openpos.gateway.resource
 
+import com.google.protobuf.BoolValue
+import com.google.protobuf.Int32Value
+import com.google.protobuf.Int64Value
 import com.openpos.gateway.cache.RedisCacheService
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.paginatedResponse
@@ -116,12 +119,12 @@ class ProductResource {
                     body.description?.let { setDescription(it) }
                     body.barcode?.let { setBarcode(it) }
                     body.sku?.let { setSku(it) }
-                    body.price?.let { setPrice(it) }
+                    body.price?.let { setPriceValue(Int64Value.of(it)) }
                     body.categoryId?.let { setCategoryId(it) }
                     body.taxRateId?.let { setTaxRateId(it) }
                     body.imageUrl?.let { setImageUrl(it) }
-                    body.displayOrder?.let { setDisplayOrder(it) }
-                    body.isActive?.let { setIsActive(it) }
+                    body.displayOrder?.let { setDisplayOrderValue(Int32Value.of(it)) }
+                    body.isActive?.let { setIsActiveValue(BoolValue.of(it)) }
                 }.build()
         val response = grpc.withTenant(stub).updateProduct(request)
         cache.invalidatePattern("openpos:gateway:product:list:*")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TaxRateResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TaxRateResource.kt
@@ -1,5 +1,6 @@
 package com.openpos.gateway.resource
 
+import com.google.protobuf.BoolValue
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
@@ -61,8 +62,8 @@ class TaxRateResource {
                 .apply {
                     body.name?.let { setName(it) }
                     body.rate?.let { setRate(it) }
-                    body.isReduced?.let { setIsReduced(it) }
-                    body.isDefault?.let { setIsDefault(it) }
+                    body.isReduced?.let { setIsReducedValue(BoolValue.of(it)) }
+                    body.isDefault?.let { setIsDefaultValue(BoolValue.of(it)) }
                 }.build()
         return grpc
             .withTenant(stub)

--- a/services/product-service/src/main/kotlin/com/openpos/product/entity/CouponEntity.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/entity/CouponEntity.kt
@@ -31,4 +31,7 @@ class CouponEntity : BaseEntity() {
 
     @Column(name = "valid_until")
     var validUntil: Instant? = null
+
+    @Column(name = "is_active", nullable = false)
+    var isActive: Boolean = true
 }

--- a/services/product-service/src/main/kotlin/com/openpos/product/entity/ProductEntity.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/entity/ProductEntity.kt
@@ -22,6 +22,9 @@ class ProductEntity : BaseEntity() {
     @Column(name = "name", nullable = false, length = 255)
     lateinit var name: String
 
+    @Column(name = "description")
+    var description: String? = null
+
     @Column(name = "barcode", length = 100)
     var barcode: String? = null
 

--- a/services/product-service/src/main/kotlin/com/openpos/product/entity/TaxRateEntity.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/entity/TaxRateEntity.kt
@@ -22,6 +22,9 @@ class TaxRateEntity : BaseEntity() {
     @Column(name = "tax_type", nullable = false, length = 20)
     var taxType: String = "STANDARD"
 
+    @Column(name = "is_default", nullable = false)
+    var isDefault: Boolean = false
+
     @Column(name = "is_active", nullable = false)
     var isActive: Boolean = true
 }

--- a/services/product-service/src/main/kotlin/com/openpos/product/grpc/ProductGrpcService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/grpc/ProductGrpcService.kt
@@ -93,6 +93,7 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
         val entity =
             productService.create(
                 name = request.name,
+                description = request.description.ifBlank { null },
                 barcode = request.barcode.ifBlank { null },
                 sku = request.sku.ifBlank { null },
                 price = request.price,
@@ -163,14 +164,15 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
             productService.update(
                 id = request.id.toUUID(),
                 name = request.name.ifBlank { null },
+                description = request.description.ifBlank { null },
                 barcode = request.barcode.ifBlank { null },
                 sku = request.sku.ifBlank { null },
-                price = if (request.price > 0) request.price else null,
+                price = request.priceOrNull(),
                 categoryId = request.categoryId.uuidOrNull(),
                 taxRateId = request.taxRateId.uuidOrNull(),
                 imageUrl = request.imageUrl.ifBlank { null },
-                displayOrder = if (request.displayOrder > 0) request.displayOrder else null,
-                isActive = if (request.isActive) true else null,
+                displayOrder = request.displayOrderOrNull(),
+                isActive = request.isActiveOrNull(),
             ) ?: throw Status.NOT_FOUND.withDescription("Product not found: ${request.id}").asRuntimeException()
         responseObserver.onNext(
             UpdateProductResponse.newBuilder().setProduct(entity.toProto()).build(),
@@ -283,6 +285,7 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
                 name = request.name,
                 rate = BigDecimal(request.rate),
                 taxType = if (request.isReduced) "REDUCED" else "STANDARD",
+                isDefault = request.isDefault,
             )
         responseObserver.onNext(
             CreateTaxRateResponse.newBuilder().setTaxRate(entity.toProto()).build(),
@@ -312,8 +315,9 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
                 id = request.id.toUUID(),
                 name = request.name.ifBlank { null },
                 rate = if (request.rate.isNotBlank()) BigDecimal(request.rate) else null,
-                taxType = if (request.isReduced) "REDUCED" else null,
+                taxType = request.taxTypeOrNull(),
                 isActive = null,
+                isDefault = request.isDefaultOrNull(),
             ) ?: throw Status.NOT_FOUND.withDescription("TaxRate not found: ${request.id}").asRuntimeException()
         responseObserver.onNext(
             UpdateTaxRateResponse.newBuilder().setTaxRate(entity.toProto()).build(),
@@ -377,7 +381,7 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
                 value = if (request.value.isNotBlank()) request.value.toLong() else null,
                 validFrom = request.startDate.instantOrNull(),
                 validUntil = request.endDate.instantOrNull(),
-                isActive = if (request.isActive) true else null,
+                isActive = request.isActiveOrNull(),
             ) ?: throw Status.NOT_FOUND.withDescription("Discount not found: ${request.id}").asRuntimeException()
         responseObserver.onNext(
             UpdateDiscountResponse.newBuilder().setDiscount(entity.toProto()).build(),
@@ -414,8 +418,8 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
         val result = couponService.validate(request.code)
         val builder = ValidateCouponResponse.newBuilder().setIsValid(result.isValid)
         result.coupon?.let { builder.setCoupon(it.toProto()) }
+        result.discount?.let { builder.setDiscount(it.toProto()) }
         result.reason?.let { builder.setReason(it) }
-        // TODO: 割引情報も返す場合は discount を設定
         responseObserver.onNext(builder.build())
         responseObserver.onCompleted()
     }
@@ -428,6 +432,7 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
             .setId(id.toString())
             .setOrganizationId(organizationId.toString())
             .setName(name)
+            .setDescription(description.orEmpty())
             .setBarcode(barcode.orEmpty())
             .setSku(sku.orEmpty())
             .setPrice(price)
@@ -462,6 +467,7 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
             .setName(name)
             .setRate(rate.toPlainString())
             .setIsReduced(taxType == "REDUCED")
+            .setIsDefault(isDefault)
             .setCreatedAt(createdAt.toString())
             .setUpdatedAt(updatedAt.toString())
             .build()
@@ -497,6 +503,7 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
             .setCurrentUses(usedCount)
             .setStartDate(validFrom?.toString().orEmpty())
             .setEndDate(validUntil?.toString().orEmpty())
+            .setIsActive(isActive)
             .setCreatedAt(createdAt.toString())
             .setUpdatedAt(updatedAt.toString())
             .build()
@@ -513,4 +520,46 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
     private fun String.uuidOrNull(): UUID? = if (isBlank()) null else toUUID()
 
     private fun String.instantOrNull(): Instant? = if (isBlank()) null else Instant.parse(this)
+
+    private fun UpdateProductRequest.priceOrNull(): Long? =
+        when {
+            hasPriceValue() -> priceValue.value
+            price > 0 -> price
+            else -> null
+        }
+
+    private fun UpdateProductRequest.displayOrderOrNull(): Int? =
+        when {
+            hasDisplayOrderValue() -> displayOrderValue.value
+            displayOrder > 0 -> displayOrder
+            else -> null
+        }
+
+    private fun UpdateProductRequest.isActiveOrNull(): Boolean? =
+        when {
+            hasIsActiveValue() -> isActiveValue.value
+            isActive -> true
+            else -> null
+        }
+
+    private fun UpdateTaxRateRequest.taxTypeOrNull(): String? =
+        when {
+            hasIsReducedValue() -> if (isReducedValue.value) "REDUCED" else "STANDARD"
+            isReduced -> "REDUCED"
+            else -> null
+        }
+
+    private fun UpdateTaxRateRequest.isDefaultOrNull(): Boolean? =
+        when {
+            hasIsDefaultValue() -> isDefaultValue.value
+            isDefault -> true
+            else -> null
+        }
+
+    private fun UpdateDiscountRequest.isActiveOrNull(): Boolean? =
+        when {
+            hasIsActiveValue() -> isActiveValue.value
+            isActive -> true
+            else -> null
+        }
 }

--- a/services/product-service/src/main/kotlin/com/openpos/product/repository/TaxRateRepository.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/repository/TaxRateRepository.kt
@@ -14,4 +14,18 @@ class TaxRateRepository : PanacheRepositoryBase<TaxRateEntity, UUID> {
      * 有効な税率のみ取得する。
      */
     fun findActive(): List<TaxRateEntity> = list("isActive = true ORDER BY name ASC")
+
+    /**
+     * 組織内のデフォルト税率を取得する。
+     */
+    fun findDefaultsByOrganizationId(organizationId: UUID): List<TaxRateEntity> =
+        list("organizationId = ?1 AND isDefault = true", organizationId)
+
+    /**
+     * 指定 ID を除く組織内のデフォルト税率を取得する。
+     */
+    fun findDefaultsByOrganizationIdExcludingId(
+        organizationId: UUID,
+        excludedId: UUID,
+    ): List<TaxRateEntity> = list("organizationId = ?1 AND isDefault = true AND id <> ?2", organizationId, excludedId)
 }

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/CouponService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/CouponService.kt
@@ -3,6 +3,7 @@ package com.openpos.product.service
 import com.openpos.product.config.OrganizationIdHolder
 import com.openpos.product.config.TenantFilterService
 import com.openpos.product.entity.CouponEntity
+import com.openpos.product.entity.DiscountEntity
 import com.openpos.product.repository.CouponRepository
 import com.openpos.product.repository.DiscountRepository
 import jakarta.enterprise.context.ApplicationScoped
@@ -17,6 +18,7 @@ import java.util.UUID
 data class CouponValidationResult(
     val isValid: Boolean,
     val coupon: CouponEntity? = null,
+    val discount: DiscountEntity? = null,
     val reason: String? = null,
 )
 
@@ -63,6 +65,7 @@ class CouponService {
                 this.usedCount = 0
                 this.validFrom = validFrom
                 this.validUntil = validUntil
+                this.isActive = true
             }
         couponRepository.persist(entity)
         return entity
@@ -94,6 +97,10 @@ class CouponService {
             couponRepository.findByCode(code)
                 ?: return CouponValidationResult(isValid = false, reason = "NOT_FOUND")
 
+        if (!coupon.isActive) {
+            return CouponValidationResult(isValid = false, coupon = coupon, reason = "COUPON_INACTIVE")
+        }
+
         val now = Instant.now()
 
         // 有効期間チェック
@@ -121,6 +128,6 @@ class CouponService {
             return CouponValidationResult(isValid = false, coupon = coupon, reason = "DISCOUNT_INACTIVE")
         }
 
-        return CouponValidationResult(isValid = true, coupon = coupon)
+        return CouponValidationResult(isValid = true, coupon = coupon, discount = discount)
     }
 }

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/ProductService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/ProductService.kt
@@ -31,6 +31,7 @@ class ProductService {
     @Transactional
     fun create(
         name: String,
+        description: String?,
         barcode: String?,
         sku: String?,
         price: Long,
@@ -48,6 +49,7 @@ class ProductService {
             ProductEntity().apply {
                 this.organizationId = orgId
                 this.name = name
+                this.description = description
                 this.barcode = barcode
                 this.sku = sku
                 this.price = price
@@ -103,6 +105,7 @@ class ProductService {
     fun update(
         id: UUID,
         name: String?,
+        description: String?,
         barcode: String?,
         sku: String?,
         price: Long?,
@@ -116,6 +119,7 @@ class ProductService {
         val entity = productRepository.findById(id) ?: return null
 
         name?.let { entity.name = it }
+        description?.let { entity.description = it }
         barcode?.let { entity.barcode = it }
         sku?.let { entity.sku = it }
         price?.let { entity.price = it }

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateService.kt
@@ -33,11 +33,16 @@ class TaxRateService {
         name: String,
         rate: BigDecimal,
         taxType: String,
+        isDefault: Boolean,
     ): TaxRateEntity {
         val orgId =
             requireNotNull(organizationIdHolder.organizationId) {
                 "organizationId is not set"
             }
+
+        if (isDefault) {
+            clearExistingDefaults(orgId)
+        }
 
         val entity =
             TaxRateEntity().apply {
@@ -45,6 +50,7 @@ class TaxRateService {
                 this.name = name
                 this.rate = rate
                 this.taxType = taxType
+                this.isDefault = isDefault
                 this.isActive = true
             }
         taxRateRepository.persist(entity)
@@ -77,6 +83,7 @@ class TaxRateService {
         rate: BigDecimal?,
         taxType: String?,
         isActive: Boolean?,
+        isDefault: Boolean?,
     ): TaxRateEntity? {
         tenantFilterService.enableFilter()
         val entity = taxRateRepository.findById(id) ?: return null
@@ -85,8 +92,28 @@ class TaxRateService {
         rate?.let { entity.rate = it }
         taxType?.let { entity.taxType = it }
         isActive?.let { entity.isActive = it }
+        isDefault?.let {
+            if (it) {
+                clearExistingDefaults(entity.organizationId, entity.id)
+            }
+            entity.isDefault = it
+        }
 
         taxRateRepository.persist(entity)
         return entity
+    }
+
+    private fun clearExistingDefaults(
+        organizationId: UUID,
+        excludedId: UUID? = null,
+    ) {
+        val defaults =
+            if (excludedId == null) {
+                taxRateRepository.findDefaultsByOrganizationId(organizationId)
+            } else {
+                taxRateRepository.findDefaultsByOrganizationIdExcludingId(organizationId, excludedId)
+            }
+
+        defaults.forEach { it.isDefault = false }
     }
 }

--- a/services/product-service/src/main/resources/db/migration/V2__align_product_api_contracts.sql
+++ b/services/product-service/src/main/resources/db/migration/V2__align_product_api_contracts.sql
@@ -1,0 +1,14 @@
+ALTER TABLE product_schema.products
+    ADD COLUMN description TEXT;
+
+ALTER TABLE product_schema.tax_rates
+    ADD COLUMN is_default BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX idx_tax_rates_org_default
+    ON product_schema.tax_rates(organization_id, is_default);
+
+ALTER TABLE product_schema.coupons
+    ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT true;
+
+CREATE INDEX idx_coupons_org_active
+    ON product_schema.coupons(organization_id, is_active);

--- a/services/product-service/src/test/kotlin/com/openpos/product/grpc/ProductGrpcServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/grpc/ProductGrpcServiceTest.kt
@@ -1,0 +1,372 @@
+package com.openpos.product.grpc
+
+import com.google.protobuf.BoolValue
+import com.google.protobuf.Int32Value
+import com.google.protobuf.Int64Value
+import com.openpos.product.entity.CouponEntity
+import com.openpos.product.entity.DiscountEntity
+import com.openpos.product.entity.ProductEntity
+import com.openpos.product.entity.TaxRateEntity
+import com.openpos.product.service.CategoryService
+import com.openpos.product.service.CouponService
+import com.openpos.product.service.CouponValidationResult
+import com.openpos.product.service.DiscountService
+import com.openpos.product.service.ProductService
+import com.openpos.product.service.TaxRateService
+import io.grpc.stub.StreamObserver
+import openpos.product.v1.CreateProductRequest
+import openpos.product.v1.DiscountType
+import openpos.product.v1.UpdateDiscountRequest
+import openpos.product.v1.UpdateProductRequest
+import openpos.product.v1.UpdateTaxRateRequest
+import openpos.product.v1.ValidateCouponRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+class ProductGrpcServiceTest {
+    private lateinit var grpcService: ProductGrpcService
+    private val productService = mock<ProductService>()
+    private val categoryService = mock<CategoryService>()
+    private val taxRateService = mock<TaxRateService>()
+    private val discountService = mock<DiscountService>()
+    private val couponService = mock<CouponService>()
+    private val tenantHelper = mock<GrpcTenantHelper>()
+
+    @BeforeEach
+    fun setUp() {
+        grpcService =
+            ProductGrpcService().apply {
+                this.productService = this@ProductGrpcServiceTest.productService
+                this.categoryService = this@ProductGrpcServiceTest.categoryService
+                this.taxRateService = this@ProductGrpcServiceTest.taxRateService
+                this.discountService = this@ProductGrpcServiceTest.discountService
+                this.couponService = this@ProductGrpcServiceTest.couponService
+                this.tenantHelper = this@ProductGrpcServiceTest.tenantHelper
+            }
+    }
+
+    @Test
+    fun `createProduct forwards description to service`() {
+        val productId = UUID.randomUUID()
+        whenever(
+            productService.create(
+                eq("コーヒー"),
+                eq("豆から抽出したホットコーヒー"),
+                anyOrNull(),
+                anyOrNull(),
+                eq(480L),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                eq(0),
+            ),
+        ).thenReturn(productEntity(productId))
+
+        val observer = CapturingObserver<openpos.product.v1.CreateProductResponse>()
+
+        grpcService.createProduct(
+            CreateProductRequest
+                .newBuilder()
+                .setName("コーヒー")
+                .setDescription("豆から抽出したホットコーヒー")
+                .setPrice(480L)
+                .build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContextWithoutFilter()
+        verify(productService).create(
+            eq("コーヒー"),
+            eq("豆から抽出したホットコーヒー"),
+            anyOrNull(),
+            anyOrNull(),
+            eq(480L),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            eq(0),
+        )
+        assertNotNull(observer.value)
+        assertEquals("商品説明", observer.value!!.product.description)
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `updateProduct forwards explicit zero and false values`() {
+        val productId = UUID.randomUUID()
+        whenever(
+            productService.update(
+                eq(productId),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                eq(0L),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                eq(0),
+                eq(false),
+            ),
+        ).thenReturn(productEntity(productId))
+
+        val observer = CapturingObserver<openpos.product.v1.UpdateProductResponse>()
+
+        grpcService.updateProduct(
+            UpdateProductRequest
+                .newBuilder()
+                .setId(productId.toString())
+                .setPriceValue(Int64Value.of(0))
+                .setDisplayOrderValue(Int32Value.of(0))
+                .setIsActiveValue(BoolValue.of(false))
+                .build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        verify(productService).update(
+            eq(productId),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            eq(0L),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            eq(0),
+            eq(false),
+        )
+        assertNotNull(observer.value)
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `updateProduct keeps presence fields null when omitted`() {
+        val productId = UUID.randomUUID()
+        whenever(
+            productService.update(
+                eq(productId),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                isNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                isNull(),
+                isNull(),
+            ),
+        ).thenReturn(productEntity(productId))
+
+        val observer = CapturingObserver<openpos.product.v1.UpdateProductResponse>()
+
+        grpcService.updateProduct(
+            UpdateProductRequest.newBuilder().setId(productId.toString()).build(),
+            observer,
+        )
+
+        verify(productService).update(
+            eq(productId),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            isNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            isNull(),
+            isNull(),
+        )
+        assertNotNull(observer.value)
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `updateTaxRate forwards explicit false booleans`() {
+        val taxRateId = UUID.randomUUID()
+        whenever(
+            taxRateService.update(
+                eq(taxRateId),
+                anyOrNull(),
+                anyOrNull(),
+                eq("STANDARD"),
+                isNull(),
+                eq(false),
+            ),
+        ).thenReturn(taxRateEntity(taxRateId))
+
+        val observer = CapturingObserver<openpos.product.v1.UpdateTaxRateResponse>()
+
+        grpcService.updateTaxRate(
+            UpdateTaxRateRequest
+                .newBuilder()
+                .setId(taxRateId.toString())
+                .setIsReducedValue(BoolValue.of(false))
+                .setIsDefaultValue(BoolValue.of(false))
+                .build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        verify(taxRateService).update(
+            eq(taxRateId),
+            anyOrNull(),
+            anyOrNull(),
+            eq("STANDARD"),
+            isNull(),
+            eq(false),
+        )
+        assertNotNull(observer.value)
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `updateDiscount forwards explicit false isActive`() {
+        val discountId = UUID.randomUUID()
+        whenever(
+            discountService.update(
+                eq(discountId),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                eq(false),
+            ),
+        ).thenReturn(discountEntity(discountId))
+
+        val observer = CapturingObserver<openpos.product.v1.UpdateDiscountResponse>()
+
+        grpcService.updateDiscount(
+            UpdateDiscountRequest
+                .newBuilder()
+                .setId(discountId.toString())
+                .setDiscountType(DiscountType.DISCOUNT_TYPE_PERCENTAGE)
+                .setIsActiveValue(BoolValue.of(false))
+                .build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        verify(discountService).update(
+            eq(discountId),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            eq(false),
+        )
+        assertNotNull(observer.value)
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `validateCoupon returns discount payload when coupon is valid`() {
+        val couponId = UUID.randomUUID()
+        val discountId = UUID.randomUUID()
+        whenever(couponService.validate("WELCOME")).thenReturn(
+            CouponValidationResult(
+                isValid = true,
+                coupon = couponEntity(couponId, discountId),
+                discount = discountEntity(discountId),
+            ),
+        )
+
+        val observer = CapturingObserver<openpos.product.v1.ValidateCouponResponse>()
+
+        grpcService.validateCoupon(
+            ValidateCouponRequest.newBuilder().setCode("WELCOME").build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        assertNotNull(observer.value)
+        assertTrue(observer.value!!.isValid)
+        assertTrue(observer.value!!.hasDiscount())
+        assertTrue(observer.value!!.coupon.isActive)
+        assertFalse(observer.value!!.discount.value.isBlank())
+        assertTrue(observer.completed)
+    }
+
+    private fun productEntity(productId: UUID): ProductEntity =
+        ProductEntity().apply {
+            id = productId
+            organizationId = UUID.randomUUID()
+            name = "コーヒー"
+            description = "商品説明"
+            price = 480L
+            displayOrder = 0
+            isActive = true
+        }
+
+    private fun taxRateEntity(taxRateId: UUID): TaxRateEntity =
+        TaxRateEntity().apply {
+            id = taxRateId
+            organizationId = UUID.randomUUID()
+            name = "標準税率10%"
+            rate = BigDecimal("0.1000")
+            taxType = "STANDARD"
+            isDefault = false
+            isActive = true
+        }
+
+    private fun discountEntity(discountId: UUID): DiscountEntity =
+        DiscountEntity().apply {
+            id = discountId
+            organizationId = UUID.randomUUID()
+            name = "10% OFF"
+            discountType = "PERCENTAGE"
+            value = 10
+            isActive = true
+        }
+
+    private fun couponEntity(
+        couponId: UUID,
+        discountId: UUID,
+    ): CouponEntity =
+        CouponEntity().apply {
+            id = couponId
+            organizationId = UUID.randomUUID()
+            code = "WELCOME"
+            this.discountId = discountId
+            maxUses = 100
+            usedCount = 1
+            validFrom = Instant.now().minusSeconds(3600)
+            validUntil = Instant.now().plusSeconds(3600)
+            isActive = true
+        }
+
+    private class CapturingObserver<T> : StreamObserver<T> {
+        var value: T? = null
+        var completed = false
+
+        override fun onNext(value: T) {
+            this.value = value
+        }
+
+        override fun onError(t: Throwable) {
+            throw AssertionError("Unexpected error", t)
+        }
+
+        override fun onCompleted() {
+            completed = true
+        }
+    }
+}

--- a/services/product-service/src/test/kotlin/com/openpos/product/integration/ProductRepositoryIntegrationTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/integration/ProductRepositoryIntegrationTest.kt
@@ -56,6 +56,7 @@ class ProductRepositoryIntegrationTest {
             ProductEntity().apply {
                 organizationId = testOrgId
                 name = "テスト商品A"
+                description = "商品説明"
                 barcode = "4901234567890"
                 sku = "SKU-001"
                 price = 10000L
@@ -71,6 +72,7 @@ class ProductRepositoryIntegrationTest {
         assertNotNull(found)
         requireNotNull(found)
         assertEquals("テスト商品A", found.name)
+        assertEquals("商品説明", found.description)
         assertEquals("4901234567890", found.barcode)
         assertEquals(10000L, found.price)
         assertEquals(testOrgId, found.organizationId)

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/CouponServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/CouponServiceTest.kt
@@ -79,6 +79,7 @@ class CouponServiceTest {
             assertEquals(0, result.usedCount)
             assertEquals(validFrom, result.validFrom)
             assertEquals(validUntil, result.validUntil)
+            assertEquals(true, result.isActive)
             assertEquals(orgId, result.organizationId)
             verify(couponRepository).persist(any<CouponEntity>())
         }
@@ -103,6 +104,7 @@ class CouponServiceTest {
             assertNull(result.maxUses)
             assertNull(result.validFrom)
             assertNull(result.validUntil)
+            assertEquals(true, result.isActive)
             verify(couponRepository).persist(any<CouponEntity>())
         }
     }
@@ -232,6 +234,29 @@ class CouponServiceTest {
             assertFalse(result.isValid)
             assertNotNull(result.coupon)
             assertEquals("NOT_YET_VALID", result.reason)
+        }
+
+        @Test
+        fun `無効化されたクーポンはCOUPON_INACTIVEを返す`() {
+            // Arrange
+            val entity =
+                CouponEntity().apply {
+                    this.id = UUID.randomUUID()
+                    this.organizationId = orgId
+                    this.code = "INACTIVE"
+                    this.discountId = this@CouponServiceTest.discountId
+                    this.usedCount = 0
+                    this.isActive = false
+                }
+            whenever(couponRepository.findByCode("INACTIVE")).thenReturn(entity)
+
+            // Act
+            val result = couponService.validate("INACTIVE")
+
+            // Assert
+            assertFalse(result.isValid)
+            assertNotNull(result.coupon)
+            assertEquals("COUPON_INACTIVE", result.reason)
         }
 
         @Test
@@ -375,8 +400,10 @@ class CouponServiceTest {
             // Assert
             assertTrue(result.isValid)
             assertNotNull(result.coupon)
+            assertNotNull(result.discount)
             assertNull(result.reason)
             assertEquals("VALID", result.coupon!!.code)
+            assertEquals("有効割引", result.discount!!.name)
         }
 
         @Test

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/ProductServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/ProductServiceTest.kt
@@ -59,6 +59,7 @@ class ProductServiceTest {
             val result =
                 productService.create(
                     name = "テスト商品",
+                    description = "商品説明",
                     barcode = "4901234567890",
                     sku = "SKU-001",
                     price = 10000L,
@@ -70,6 +71,7 @@ class ProductServiceTest {
 
             // Assert
             assertEquals("テスト商品", result.name)
+            assertEquals("商品説明", result.description)
             assertEquals("4901234567890", result.barcode)
             assertEquals("SKU-001", result.sku)
             assertEquals(10000L, result.price)
@@ -91,6 +93,7 @@ class ProductServiceTest {
             val result =
                 productService.create(
                     name = "シンプル商品",
+                    description = null,
                     barcode = null,
                     sku = null,
                     price = 5000L,
@@ -102,6 +105,7 @@ class ProductServiceTest {
 
             // Assert
             assertEquals("シンプル商品", result.name)
+            assertNull(result.description)
             assertNull(result.barcode)
             assertNull(result.sku)
             assertEquals(5000L, result.price)
@@ -301,6 +305,7 @@ class ProductServiceTest {
                 productService.update(
                     id = productId,
                     name = "更新後の商品",
+                    description = "更新後の説明",
                     barcode = null,
                     sku = null,
                     price = 20000L,
@@ -314,6 +319,7 @@ class ProductServiceTest {
             // Assert
             assertNotNull(result)
             assertEquals("更新後の商品", result!!.name)
+            assertEquals("更新後の説明", result.description)
             assertEquals(20000L, result.price)
             // null のフィールドは更新されない
             assertEquals("1111111111111", result.barcode)
@@ -333,6 +339,7 @@ class ProductServiceTest {
                 productService.update(
                     id = productId,
                     name = "更新後の商品",
+                    description = null,
                     barcode = null,
                     sku = null,
                     price = null,

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/TaxRateServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/TaxRateServiceTest.kt
@@ -58,12 +58,14 @@ class TaxRateServiceTest {
                     name = "標準税率10%",
                     rate = BigDecimal("0.1000"),
                     taxType = "STANDARD",
+                    isDefault = true,
                 )
 
             // Assert
             assertEquals("標準税率10%", result.name)
             assertEquals(BigDecimal("0.1000"), result.rate)
             assertEquals("STANDARD", result.taxType)
+            assertEquals(true, result.isDefault)
             assertTrue(result.isActive)
             assertEquals(orgId, result.organizationId)
             verify(taxRateRepository).persist(any<TaxRateEntity>())
@@ -80,12 +82,14 @@ class TaxRateServiceTest {
                     name = "軽減税率8%",
                     rate = BigDecimal("0.0800"),
                     taxType = "REDUCED",
+                    isDefault = false,
                 )
 
             // Assert
             assertEquals("軽減税率8%", result.name)
             assertEquals(BigDecimal("0.0800"), result.rate)
             assertEquals("REDUCED", result.taxType)
+            assertEquals(false, result.isDefault)
             assertTrue(result.isActive)
             verify(taxRateRepository).persist(any<TaxRateEntity>())
         }
@@ -215,6 +219,7 @@ class TaxRateServiceTest {
                     rate = BigDecimal("0.0800"),
                     taxType = null,
                     isActive = null,
+                    isDefault = null,
                 )
 
             // Assert
@@ -251,6 +256,7 @@ class TaxRateServiceTest {
                     rate = null,
                     taxType = null,
                     isActive = false,
+                    isDefault = null,
                 )
 
             // Assert
@@ -273,11 +279,59 @@ class TaxRateServiceTest {
                     rate = null,
                     taxType = null,
                     isActive = null,
+                    isDefault = null,
                 )
 
             // Assert
             assertNull(result)
             verify(tenantFilterService).enableFilter()
+        }
+
+        @Test
+        fun `デフォルト税率更新時は既存デフォルトを解除する`() {
+            // Arrange
+            val taxRateId = UUID.randomUUID()
+            val existingDefaultId = UUID.randomUUID()
+            val entity =
+                TaxRateEntity().apply {
+                    this.id = taxRateId
+                    this.organizationId = orgId
+                    this.name = "軽減税率8%"
+                    this.rate = BigDecimal("0.0800")
+                    this.taxType = "REDUCED"
+                    this.isDefault = false
+                    this.isActive = true
+                }
+            val existingDefault =
+                TaxRateEntity().apply {
+                    this.id = existingDefaultId
+                    this.organizationId = orgId
+                    this.name = "標準税率10%"
+                    this.rate = BigDecimal("0.1000")
+                    this.taxType = "STANDARD"
+                    this.isDefault = true
+                    this.isActive = true
+                }
+            whenever(taxRateRepository.findById(taxRateId)).thenReturn(entity)
+            whenever(taxRateRepository.findDefaultsByOrganizationIdExcludingId(orgId, taxRateId)).thenReturn(listOf(existingDefault))
+            doNothing().whenever(taxRateRepository).persist(any<TaxRateEntity>())
+
+            // Act
+            val result =
+                taxRateService.update(
+                    id = taxRateId,
+                    name = null,
+                    rate = null,
+                    taxType = null,
+                    isActive = null,
+                    isDefault = true,
+                )
+
+            // Assert
+            assertNotNull(result)
+            assertEquals(true, result!!.isDefault)
+            assertEquals(false, existingDefault.isDefault)
+            verify(taxRateRepository).persist(any<TaxRateEntity>())
         }
     }
 }


### PR DESCRIPTION
## Summary
- persist and return product descriptions, tax default flags, and coupon active state in product-service
- add presence-aware update fields for product, tax rate, and discount gRPC contracts so `0` and `false` update correctly
- return linked discount data from coupon validation and add regression tests around transport + persistence

## Testing
- `git diff --check`
- `cd proto && buf lint`
- `cd proto && buf breaking --against '../.git#branch=main,subdir=proto'`
- `./gradlew :services:product-service:test --tests com.openpos.product.grpc.ProductGrpcServiceTest --tests com.openpos.product.service.ProductServiceTest --tests com.openpos.product.service.TaxRateServiceTest --tests com.openpos.product.service.CouponServiceTest --tests com.openpos.product.integration.ProductRepositoryIntegrationTest :services:api-gateway:test --no-build-cache`

Closes #242
