### PR TITLE
feat(dx): add developer Makefile commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added `GOVERNANCE.md` and `docs/runbook/triage.md` to make maintainer decision-making and issue triage explicit.
 - Added PR component auto-labeling and a label taxonomy runbook for maintainer triage consistency.
 - Added `make doctor`, `make verify`, and `make verify-full` as supported local quality gates.
+- Added developer Makefile helpers for PostgreSQL backup/restore, demo reset, `pos-service` log tailing, and grpcurl-based gRPC health checks.
 - Added maintainer-facing release guidance in [docs/runbook/release.md](docs/runbook/release.md).
 - Added a documentation index in [docs/README.md](docs/README.md).
 - Added [SUPPORT.md](SUPPORT.md) and [MAINTAINERS.md](MAINTAINERS.md) for public OSS operations.
@@ -23,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Tightened contributor setup docs around actual required tools (`curl`, `jq`, `bc`) and the supported verification flow.
 - Rewrote the local development runbook to match the supported `make local-demo` / `make docker-demo` flows, generated runtime config files, and current troubleshooting steps.
 - Added clearer prerequisite checks to local helper scripts.
+- Expanded the documented local development command set to include `make docker-build`, `make reset`, `make db-backup`, `make db-restore`, `make logs-pos`, and `make grpc-test`.
 - Fixed the Docker-based startup flow to wait on `hydra` health instead of the one-shot `hydra-migrate` container.
 - Shifted open-ended setup and usage questions toward GitHub Discussions, keeping Issues focused on bugs and feature work.
 - Enabled GitHub Discussions, branch protection on `main`, auto-merge support, and GitHub-native secret scanning / push protection.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: help doctor verify verify-full up up-all up-dev down logs \
+.PHONY: help doctor verify verify-full up up-all up-dev down logs logs-pos \
        dev-gateway dev-product dev-store dev-pos dev-inventory dev-analytics dev-backend \
-       local-build local-up local-up-fast local-down local-seed local-smoke local-demo \
-       docker-build-core docker-up-core docker-down-core docker-smoke docker-demo \
+       local-build local-up local-up-fast local-down local-seed local-smoke local-demo reset \
+       docker-build docker-build-core docker-up-core docker-down-core docker-smoke docker-demo \
        build build-apps build-services \
-       test test-apps test-backend test-frontend test-e2e test-all \
-       lint proto proto-lint proto-breaking seed clean
+       test test-apps test-backend test-frontend test-e2e test-all grpc-test \
+       lint proto proto-lint proto-breaking seed db-backup db-restore clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -33,8 +33,11 @@ down: ## Stop all containers
 up-dev: ## Start infrastructure with dev tools (pgAdmin, Redis Commander)
 	docker compose -f infra/compose.yml -f infra/compose.override.yml up -d
 
-logs: ## Show infrastructure logs
+logs: ## Show Docker Compose logs for infrastructure and any containerized backend services
 	docker compose -f infra/compose.yml logs -f
+
+logs-pos: ## Show pos-service logs (host-run or containerized mode)
+	bash scripts/logs-pos.sh
 
 # === Local Development (quarkusDev) ===
 dev-gateway: ## Start api-gateway in dev mode
@@ -89,6 +92,17 @@ local-smoke: ## Verify the seeded local demo data via the API gateway
 local-demo: up local-up local-seed local-smoke ## Start infra, local backend, seed demo data, and verify the API path
 	@echo "Demo data is ready. Reload the browser to pick up the latest demo-config.json."
 
+reset: ## Reset PostgreSQL data, restart the supported backend mode, and reseed the demo data
+	bash scripts/reset.sh
+
+docker-build: ## Build all backend service container images sequentially
+	docker compose -f infra/compose.yml build product-service
+	docker compose -f infra/compose.yml build store-service
+	docker compose -f infra/compose.yml build pos-service
+	docker compose -f infra/compose.yml build inventory-service
+	docker compose -f infra/compose.yml build analytics-service
+	docker compose -f infra/compose.yml build api-gateway
+
 docker-build-core: ## Build the core backend container images sequentially
 	docker compose -f infra/compose.yml build product-service
 	docker compose -f infra/compose.yml build store-service
@@ -136,6 +150,9 @@ test-e2e: ## Run Playwright E2E tests (requires browsers via `pnpm e2e:install`)
 
 test-all: test-backend test-frontend ## Run backend + frontend unit/functional tests
 
+grpc-test: ## Run grpcurl-based health checks against the running backend gRPC services
+	bash scripts/grpc-test.sh
+
 # === Lint ===
 lint: ## Lint proto and frontend
 	cd proto && buf lint
@@ -155,8 +172,17 @@ proto-breaking: ## Check proto breaking changes
 seed: ## Seed demo data (requires running backend)
 	bash scripts/seed.sh
 
+db-backup: ## Write a PostgreSQL SQL backup to FILE=.local/backups/openpos-YYYYmmdd-HHMMSS.sql by default
+	bash scripts/db-backup.sh "$(FILE)"
+
+db-restore: ## Restore a PostgreSQL SQL backup from FILE=path and restart the detected backend mode
+	bash scripts/db-restore.sh "$(FILE)"
+
 # === Clean ===
 clean: ## Clean all build artifacts
 	./gradlew clean
 	pnpm -r clean
 	rm -rf proto/gen
+	rm -rf .local
+	rm -f apps/admin-dashboard/.env.development.local apps/pos-terminal/.env.development.local
+	rm -f apps/admin-dashboard/public/demo-config.json apps/pos-terminal/public/demo-config.json

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ A multi-tenant, offline-capable POS (Point of Sale) system built with microservi
 - curl
 - jq
 - bc
+- grpcurl (optional, for `make grpc-test`)
 
 ### Quick Start
 
@@ -113,6 +114,8 @@ pnpm dev:pos
 ```bash
 # Start with dev tools (pgAdmin, Redis Commander)
 make up-dev
+make logs         # Docker Compose logs
+make logs-pos     # pos-service logs in the active backend mode
 
 # Run backend service in dev mode
 make dev-product   # product-service on quarkusDev
@@ -125,12 +128,18 @@ pnpm dev:admin     # Admin dashboard → http://localhost:5174
 # Run tests
 make test          # Backend tests
 make test-apps     # Frontend unit/functional tests
+make grpc-test     # gRPC health checks for running backend services
 make verify        # typecheck + lint + backend/frontend unit-functional tests
 pnpm e2e:install   # Install Playwright browser once
 make verify-full   # verify + docker-demo + Playwright E2E
 
 # Lint supported local targets
 make lint          # Proto + Frontend
+
+# Database helpers
+make db-backup
+make db-restore FILE=.local/backups/openpos-20260314-120000.sql
+make reset
 ```
 
 `pnpm test` runs unit/functional tests for `packages/` and `apps/`. E2E is opt-in via `pnpm test:e2e` so routine local verification does not depend on Playwright browsers.
@@ -162,9 +171,12 @@ make local-smoke
 make docker-up-core
 make docker-down-core
 make docker-build-core
+make docker-build
 ```
 
 `make docker-up-core` stops the locally managed host backend first, so switching between the two supported modes is predictable.
+
+`make reset` recreates the PostgreSQL data volume, then brings the last detected supported backend mode back up and reseeds the demo data. `make db-backup` writes a plain SQL dump under `.local/backups/` by default, and `make db-restore FILE=...` restores that dump and restarts the detected backend mode.
 
 See [docs/guides/setup.md](docs/guides/setup.md) for detailed setup instructions.
 

--- a/docs/runbook/local-dev.md
+++ b/docs/runbook/local-dev.md
@@ -47,6 +47,7 @@ make docker-up-core
 make up       # PostgreSQL, Redis, RabbitMQ, Hydra
 make up-dev   # infra + pgAdmin + Redis Commander
 make down
+make logs     # Docker Compose logs
 ```
 
 ### Host-run backend
@@ -55,6 +56,7 @@ make down
 make local-up       # rebuild and start the core backend
 make local-up-fast  # start without rebuilding
 make local-down
+make logs-pos       # tail .local/logs/pos-service.log while host-run mode is active
 ```
 
 Logs and PIDs for the host-run backend are written to:
@@ -65,6 +67,7 @@ Logs and PIDs for the host-run backend are written to:
 ### Containerized backend
 
 ```bash
+make docker-build        # all backend images
 make docker-build-core
 make docker-up-core
 make docker-down-core
@@ -76,7 +79,13 @@ make docker-down-core
 make local-seed
 make local-smoke
 make docker-smoke
+make grpc-test
+make db-backup
+make db-restore FILE=.local/backups/openpos-YYYYmmdd-HHMMSS.sql
+make reset
 ```
+
+`make reset` recreates the PostgreSQL data volume, restores the last detected supported backend mode, and reseeds the demo data. If no supported backend mode was running, it starts the host-run core backend before reseeding.
 
 ### Frontend dev servers
 
@@ -93,6 +102,8 @@ make verify
 pnpm e2e:install
 make verify-full
 ```
+
+`make doctor` warns if `grpcurl` is missing, because `make grpc-test` depends on it.
 
 ## Runtime Config Files
 

--- a/scripts/db-backup.sh
+++ b/scripts/db-backup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/dev-stack.sh"
+
+backup_arg="${1:-}"
+timestamp="$(date +%Y%m%d-%H%M%S)"
+default_backup_path="$ROOT_DIR/.local/backups/openpos-$timestamp.sql"
+backup_path="${backup_arg:-$default_backup_path}"
+backup_path="$(resolve_path "$backup_path")"
+
+require_command docker
+ensure_postgres_is_available
+
+mkdir -p "$(dirname "$backup_path")"
+
+compose exec -T postgres \
+  pg_dump \
+  -U openpos \
+  -d openpos \
+  --clean \
+  --create \
+  --if-exists \
+  --no-owner \
+  --no-privileges >"$backup_path"
+
+printf 'Wrote PostgreSQL backup to %s\n' "$backup_path"

--- a/scripts/db-restore.sh
+++ b/scripts/db-restore.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/dev-stack.sh"
+
+backup_arg="${1:-}"
+[[ -n "$backup_arg" ]] || {
+  echo "Usage: make db-restore FILE=.local/backups/<backup>.sql" >&2
+  exit 1
+}
+
+backup_path="$(resolve_path "$backup_arg")"
+[[ -f "$backup_path" ]] || {
+  echo "Backup file not found: $backup_path" >&2
+  exit 1
+}
+
+require_command docker
+
+mode="$(detect_core_backend_mode)"
+ensure_supported_mode "$mode"
+mapfile -t optional_services < <(running_optional_container_services)
+
+stop_detected_core_backend "$mode"
+stop_optional_container_services "${optional_services[@]}"
+compose stop hydra >/dev/null 2>&1 || true
+ensure_postgres
+ensure_postgres_is_available
+
+printf 'Restoring PostgreSQL backup from %s\n' "$backup_path"
+
+compose exec -T postgres \
+  psql \
+  -U openpos \
+  -d postgres \
+  -v ON_ERROR_STOP=1 \
+  -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'openpos' AND pid <> pg_backend_pid();" >/dev/null
+
+compose exec -T postgres \
+  psql \
+  -U openpos \
+  -d postgres \
+  -v ON_ERROR_STOP=1 \
+  -q <"$backup_path" >/dev/null
+
+ensure_infra
+if [[ "$mode" != "none" ]]; then
+  start_core_backend_for_mode "$mode"
+fi
+restart_optional_container_services "${optional_services[@]}"
+
+printf 'Restored PostgreSQL backup from %s\n' "$backup_path"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -60,6 +60,19 @@ require_command() {
   return 1
 }
 
+optional_command() {
+  local name="$1"
+  local hint="$2"
+
+  if command -v "$name" >/dev/null 2>&1; then
+    pass "$name is installed"
+    return 0
+  fi
+
+  warn "$name is not installed. $hint"
+  return 0
+}
+
 check_version() {
   local label="$1"
   local actual="$2"
@@ -148,6 +161,7 @@ check_utilities() {
   require_command curl "Install curl for seed/smoke scripts." || true
   require_command jq "Install jq for seed/smoke scripts." || true
   require_command bc "Install bc for seed output formatting." || true
+  optional_command grpcurl "Install grpcurl to use 'make grpc-test'." || true
 }
 
 check_workspace_state() {

--- a/scripts/grpc-test.sh
+++ b/scripts/grpc-test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILURES=0
+SKIPS=0
+TMP_DIR=""
+DEFAULT_ORG_ID="${ORG_ID:-00000000-0000-0000-0000-000000000000}"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+pass() {
+  printf 'OK   %s\n' "$*"
+}
+
+skip() {
+  printf 'SKIP %s\n' "$*"
+  SKIPS=$((SKIPS + 1))
+}
+
+fail() {
+  printf 'FAIL %s\n' "$*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+check_health() {
+  local name="$1"
+  local host="$2"
+  local port="$3"
+  local required="$4"
+  local output
+
+  if output="$(grpcurl \
+    -plaintext \
+    -connect-timeout 2 \
+    -max-time 5 \
+    -import-path "$TMP_DIR" \
+    -proto grpc/health/v1/health.proto \
+    -rpc-header "x-organization-id: $DEFAULT_ORG_ID" \
+    -d '{}' \
+    "$host:$port" \
+    grpc.health.v1.Health/Check 2>&1)"; then
+    if grep -Fq '"SERVING"' <<<"$output"; then
+      pass "$name gRPC health is SERVING on $host:$port"
+      return 0
+    fi
+    fail "$name returned an unexpected gRPC health payload: $output"
+    return 1
+  fi
+
+  if [[ "$required" == "required" ]]; then
+    fail "$name gRPC health check failed on $host:$port: $output"
+    return 1
+  fi
+
+  skip "$name is not reachable on $host:$port"
+  return 0
+}
+
+require_command grpcurl
+
+mkdir -p "$ROOT_DIR/.local/tmp"
+TMP_DIR="$(mktemp -d "$ROOT_DIR/.local/tmp/grpc-health.XXXXXX")"
+mkdir -p "$TMP_DIR/grpc/health/v1"
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat >"$TMP_DIR/grpc/health/v1/health.proto" <<'EOF'
+syntax = "proto3";
+
+package grpc.health.v1;
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;
+  }
+
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+}
+EOF
+
+check_health "product-service" "localhost" "9001" "required"
+check_health "store-service" "localhost" "9002" "required"
+check_health "pos-service" "localhost" "9003" "required"
+check_health "inventory-service" "localhost" "9004" "optional"
+check_health "analytics-service" "localhost" "9005" "optional"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  printf 'gRPC health check failed: %d failure(s), %d skip(s).\n' "$FAILURES" "$SKIPS" >&2
+  exit 1
+fi
+
+printf 'gRPC health check passed with %d skip(s).\n' "$SKIPS"

--- a/scripts/lib/dev-stack.sh
+++ b/scripts/lib/dev-stack.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/infra/compose.yml"
+PID_DIR="$ROOT_DIR/.local/pids"
+LOG_DIR="$ROOT_DIR/.local/logs"
+POSTGRES_VOLUME_NAME="${POSTGRES_VOLUME_NAME:-openpos_openpos-pgdata}"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+compose() {
+  docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+service_pid_is_running() {
+  local name="$1"
+  local pid_file="$PID_DIR/$name.pid"
+
+  [[ -f "$pid_file" ]] || return 1
+
+  local pid
+  pid="$(cat "$pid_file")"
+  kill -0 "$pid" >/dev/null 2>&1
+}
+
+service_container_is_running() {
+  local name="$1"
+
+  compose ps --status running --services 2>/dev/null | grep -Fxq "$name"
+}
+
+running_optional_container_services() {
+  local services=()
+
+  if service_container_is_running inventory-service; then
+    services+=("inventory-service")
+  fi
+
+  if service_container_is_running analytics-service; then
+    services+=("analytics-service")
+  fi
+
+  if [[ "${#services[@]}" -gt 0 ]]; then
+    printf '%s\n' "${services[@]}"
+  fi
+}
+
+detect_core_backend_mode() {
+  local host_running=0
+  local docker_running=0
+
+  if service_pid_is_running product-service || service_pid_is_running store-service || \
+    service_pid_is_running pos-service || service_pid_is_running api-gateway; then
+    host_running=1
+  fi
+
+  if service_container_is_running product-service || service_container_is_running store-service || \
+    service_container_is_running pos-service || service_container_is_running api-gateway; then
+    docker_running=1
+  fi
+
+  if [[ "$host_running" -eq 1 && "$docker_running" -eq 1 ]]; then
+    echo "mixed"
+    return 0
+  fi
+
+  if [[ "$host_running" -eq 1 ]]; then
+    echo "host"
+    return 0
+  fi
+
+  if [[ "$docker_running" -eq 1 ]]; then
+    echo "docker"
+    return 0
+  fi
+
+  echo "none"
+}
+
+ensure_supported_mode() {
+  local mode="$1"
+
+  if [[ "$mode" == "mixed" ]]; then
+    cat >&2 <<EOF
+Detected both host-run and containerized core backend services.
+Stop one mode first with 'make local-down' or 'make docker-down-core', then retry.
+EOF
+    exit 1
+  fi
+}
+
+stop_detected_core_backend() {
+  local mode="$1"
+
+  case "$mode" in
+    host)
+      bash "$ROOT_DIR/scripts/local-stack-down.sh"
+      ;;
+    docker)
+      compose stop api-gateway product-service store-service pos-service >/dev/null
+      ;;
+    none)
+      ;;
+    *)
+      echo "Unsupported backend mode: $mode" >&2
+      exit 1
+      ;;
+  esac
+}
+
+start_core_backend_for_mode() {
+  local mode="$1"
+
+  case "$mode" in
+    host)
+      bash "$ROOT_DIR/scripts/local-stack-up.sh" --skip-build
+      ;;
+    docker)
+      compose up -d --wait product-service store-service pos-service api-gateway
+      ;;
+    none)
+      bash "$ROOT_DIR/scripts/local-stack-up.sh"
+      ;;
+    *)
+      echo "Unsupported backend mode: $mode" >&2
+      exit 1
+      ;;
+  esac
+}
+
+restart_optional_container_services() {
+  local service
+
+  for service in "$@"; do
+    [[ -n "$service" ]] || continue
+    compose up -d --wait "$service"
+  done
+}
+
+stop_optional_container_services() {
+  local service
+
+  for service in "$@"; do
+    [[ -n "$service" ]] || continue
+    compose stop "$service" >/dev/null
+  done
+}
+
+ensure_infra() {
+  compose up -d --wait postgres redis rabbitmq hydra
+}
+
+ensure_postgres() {
+  compose up -d --wait postgres
+}
+
+ensure_postgres_is_available() {
+  require_command docker
+
+  if ! service_container_is_running postgres; then
+    cat >&2 <<EOF
+PostgreSQL is not running.
+Start the stack first with 'make up', 'make local-demo', or 'make docker-demo'.
+EOF
+    exit 1
+  fi
+}
+
+resolve_path() {
+  local path="$1"
+
+  if [[ "$path" = /* ]]; then
+    printf '%s\n' "$path"
+    return 0
+  fi
+
+  printf '%s\n' "$ROOT_DIR/$path"
+}

--- a/scripts/logs-pos.sh
+++ b/scripts/logs-pos.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/dev-stack.sh"
+
+mode="$(detect_core_backend_mode)"
+ensure_supported_mode "$mode"
+
+case "$mode" in
+  host)
+    log_file="$LOG_DIR/pos-service.log"
+    if [[ ! -f "$log_file" ]]; then
+      echo "Missing host-run log file: $log_file" >&2
+      exit 1
+    fi
+    exec tail -n 200 -f "$log_file"
+    ;;
+  docker)
+    exec compose logs -f pos-service
+    ;;
+  none)
+    echo "pos-service is not running in host or container mode." >&2
+    exit 1
+    ;;
+esac

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/dev-stack.sh"
+
+require_command docker
+
+mode="$(detect_core_backend_mode)"
+ensure_supported_mode "$mode"
+mapfile -t optional_services < <(running_optional_container_services)
+
+stop_detected_core_backend "$mode"
+compose down
+docker volume rm -f "$POSTGRES_VOLUME_NAME" >/dev/null 2>&1 || true
+ensure_infra
+start_core_backend_for_mode "$mode"
+restart_optional_container_services "${optional_services[@]}"
+
+bash "$ROOT_DIR/scripts/seed.sh"
+bash "$ROOT_DIR/scripts/local-demo-smoke.sh"
+
+cat <<EOF
+Reset complete.
+Demo data has been reseeded and the API smoke check passed.
+EOF


### PR DESCRIPTION
## Summary
- add script-backed Makefile commands for reset, db backup/restore, pos-service logs, grpcurl health checks, and all-image Docker builds
- document the expanded local DX command set in the README and local-dev runbook
- extend `make doctor` with optional `grpcurl` guidance and expand `make clean` to remove local runtime artifacts

## Testing
- `bash -n scripts/logs-pos.sh scripts/grpc-test.sh scripts/db-backup.sh scripts/db-restore.sh scripts/reset.sh scripts/lib/dev-stack.sh scripts/doctor.sh`
- `make help`
- `make grpc-test`
- `timeout 2 make logs-pos`
- `make db-backup FILE=.local/backups/dev-commands.sql`
- `make db-restore FILE=.local/backups/dev-commands.sql`
- `make local-smoke`
- `make reset`
- `make doctor`

Closes #169