### PR TITLE
fix(e2e): Docker ビルド内の依存解決エラーを修正

### DIFF
--- a/infra/docker/Dockerfile.service
+++ b/infra/docker/Dockerfile.service
@@ -4,23 +4,35 @@
 # The Quarkus gRPC/protobuf codegen path is more reliable on a glibc-based JDK image than Alpine.
 FROM eclipse-temurin:21-jdk AS build
 WORKDIR /app
+
+# --- Layer 1: Gradle wrapper & build config (rarely changes) ---
 COPY gradle gradle
 COPY gradlew .
+COPY gradle.properties .
 COPY settings.gradle.kts .
 COPY build.gradle.kts .
-COPY gradle.properties .
-COPY proto proto
+
 ARG SERVICE_NAME
-COPY services/${SERVICE_NAME} services/${SERVICE_NAME}
-# Create stub build.gradle.kts for other services so Gradle multi-project config succeeds
-RUN for dir in api-gateway pos-service product-service inventory-service analytics-service store-service; do \
-      if [ "$dir" != "${SERVICE_NAME}" ] && [ ! -d "services/$dir" ]; then \
-        mkdir -p "services/$dir" && \
-        echo 'plugins { kotlin("jvm") }' > "services/$dir/build.gradle.kts"; \
-      fi; \
-    done
+
+# Copy only the target service's build config for dependency resolution
+COPY services/${SERVICE_NAME}/build.gradle.kts services/${SERVICE_NAME}/build.gradle.kts
+
+# Rewrite settings.gradle.kts to include only the target service.
+# This eliminates the need for stub build files and avoids dependency
+# resolution failures caused by incomplete stub configurations.
+RUN sed -i '/^include(/,/^)/c\include("services:'"${SERVICE_NAME}"'")' settings.gradle.kts
+
+# --- Layer 2: Download dependencies (cached unless build config changes) ---
 RUN --mount=type=cache,target=/root/.gradle \
     chmod +x gradlew && \
+    ./gradlew --no-daemon :services:${SERVICE_NAME}:dependencies -q || true
+
+# --- Layer 3: Proto definitions & source code ---
+COPY proto proto
+COPY services/${SERVICE_NAME}/src services/${SERVICE_NAME}/src
+
+# --- Layer 4: Build uber-jar ---
+RUN --mount=type=cache,target=/root/.gradle \
     ./gradlew --no-daemon :services:${SERVICE_NAME}:quarkusBuild -Dquarkus.package.jar.type=uber-jar
 
 FROM eclipse-temurin:21-jre


### PR DESCRIPTION
## Summary
- Dockerfile.service で `settings.gradle.kts` をビルド対象サービスのみに書き換え、stub `build.gradle.kts` 生成を廃止
- 依存ダウンロードを別レイヤーに分離し、Docker キャッシュ効率を向上

## Root Cause
stub の `build.gradle.kts` が `plugins { kotlin("jvm") }` のみで Quarkus BOM/plugin 設定を欠いており、Gradle が `quarkus-bom:3.32.1` や `kotlin-stdlib:2.3.10` を解決できなかった。

## Fix
`sed` で `settings.gradle.kts` の `include(...)` ブロックをビルド対象サービスのみに書き換え。これにより Gradle は対象サービスの依存のみを解決し、stub が不要になる。

## Test plan
- [x] `docker build --build-arg SERVICE_NAME=product-service` 成功確認
- [x] `docker build --build-arg SERVICE_NAME=api-gateway` 成功確認
- [ ] CI E2E ジョブ (`make docker-demo`) の通過確認

Closes #311