### PR TITLE
fix: CI buildキャッシュ有効化、Docker非root化、セキュリティaudit強制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           :services:pos-service:build
           :services:inventory-service:build
           :services:analytics-service:build
-          -x test --no-build-cache
+          -x test
       - name: Unit & Functional Test
         run: >-
           ./gradlew
@@ -66,7 +66,6 @@ jobs:
           :services:pos-service:test
           :services:inventory-service:test
           :services:analytics-service:test
-          --no-build-cache
       - name: JaCoCo Coverage Report
         run: >-
           ./gradlew
@@ -108,7 +107,6 @@ jobs:
           ./gradlew
           :services:product-service:test
           -Dquarkus.test.profile=integration
-          --no-build-cache
 
   frontend:
     name: Frontend Build, Lint & Test

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -87,10 +87,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: pnpm audit (frontend)
-        run: pnpm audit --audit-level=high || true
+        run: pnpm audit --audit-level=high
 
       - name: Gradle dependency verification (backend)
-        run: ./gradlew dependencies --scan || true
+        run: ./gradlew dependencies --scan
 
   container-scan:
     name: Container Security Scan (Trivy)

--- a/infra/docker/Dockerfile.app
+++ b/infra/docker/Dockerfile.app
@@ -11,7 +11,11 @@ COPY apps/${APP_NAME} apps/${APP_NAME}
 RUN pnpm --filter ${APP_NAME} build
 
 FROM nginx:alpine
+RUN addgroup -S appuser && adduser -S -G appuser -u 1001 appuser && \
+    chown -R appuser:appuser /var/cache/nginx /var/log/nginx /etc/nginx/conf.d && \
+    touch /var/run/nginx.pid && chown appuser:appuser /var/run/nginx.pid
 ARG APP_NAME
 COPY --from=build /app/apps/${APP_NAME}/dist /usr/share/nginx/html
 COPY infra/docker/nginx.conf /etc/nginx/conf.d/default.conf
+USER appuser
 EXPOSE 80

--- a/infra/docker/Dockerfile.native
+++ b/infra/docker/Dockerfile.native
@@ -36,8 +36,12 @@ RUN --mount=type=cache,target=/root/.gradle \
       -Dquarkus.package.jar.enabled=false
 
 FROM quay.io/quarkus/quarkus-micro-image:2.0
+RUN microdnf install shadow-utils -y && microdnf clean all && \
+    groupadd -r appuser && useradd -r -g appuser -u 1001 appuser
 WORKDIR /app
 ARG SERVICE_NAME
 COPY --from=build /app/services/${SERVICE_NAME}/build/*-runner /app/application
+RUN chown -R appuser:appuser /app
+USER appuser
 EXPOSE 8080 9000
 ENTRYPOINT ["/app/application"]

--- a/infra/docker/Dockerfile.service
+++ b/infra/docker/Dockerfile.service
@@ -24,8 +24,11 @@ RUN --mount=type=cache,target=/root/.gradle \
     ./gradlew --no-daemon :services:${SERVICE_NAME}:quarkusBuild -Dquarkus.package.jar.type=uber-jar
 
 FROM eclipse-temurin:21-jre
+RUN groupadd -r appuser && useradd -r -g appuser -u 1001 appuser
 WORKDIR /app
 ARG SERVICE_NAME
 COPY --from=build /app/services/${SERVICE_NAME}/build/*-runner.jar app.jar
+RUN chown -R appuser:appuser /app
+USER appuser
 EXPOSE 8080 9000
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- #331: `--no-build-cache` フラグ削除（3箇所）でGradleキャッシュ有効化
- #332: Dockerfile 3ファイルに非rootユーザー(appuser:1001)追加
- #333: security.ymlの`|| true`削除、HIGH+脆弱性でCI失敗に

## Test plan
- [ ] CIパイプライン実行でキャッシュヒット確認
- [ ] Dockerコンテナ内で`whoami`が`appuser`を返すことを確認
- [ ] 脆弱性ありの依存追加時にCIが失敗することを確認

Closes #331, Closes #332, Closes #333