### PR TITLE
feat: K8s本番構成(Ingress/NetworkPolicy/リソース)とCDパイプライン完成

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,31 @@ env:
   IMAGE_PREFIX: ghcr.io/${{ github.repository }}
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      semver: ${{ steps.version.outputs.semver }}
+      short_sha: ${{ steps.version.outputs.short_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Generate semantic version
+        id: version
+        run: |
+          # Derive version from git describe (falls back to 0.0.0 if no tags)
+          RAW_VERSION=$(git describe --tags --always 2>/dev/null || echo "v0.0.0-0-g$(git rev-parse --short HEAD)")
+          # Strip leading 'v' if present and normalize to semver
+          SEMVER=$(echo "$RAW_VERSION" | sed 's/^v//' | sed 's/-\([0-9]*\)-g\([a-f0-9]*\)$/+\1.\2/')
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "semver=${SEMVER}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${SEMVER}"
+
   build-and-push:
+    needs: version
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,18 +72,59 @@ jobs:
           tags: |
             ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:latest
             ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ needs.version.outputs.semver }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   deploy-staging:
-    needs: build-and-push
+    needs: [version, build-and-push]
     runs-on: ubuntu-latest
     environment: staging
     steps:
       - uses: actions/checkout@v4
 
-      - name: Deploy to staging
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
         run: |
-          echo "Staging deployment placeholder"
-          echo "Image tag: ${{ github.sha }}"
-          echo "TODO: Apply Kubernetes manifests to staging cluster"
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG_STAGING }}" | base64 -d > "$HOME/.kube/config"
+
+      - name: Update image tags in manifests
+        run: |
+          IMAGE_TAG="${{ needs.version.outputs.semver }}"
+          SERVICES=(api-gateway product-service store-service pos-service inventory-service analytics-service)
+          for SERVICE in "${SERVICES[@]}"; do
+            sed -i "s|image: ghcr.io/akaitigo/open-pos/${SERVICE}:.*|image: ${{ env.IMAGE_PREFIX }}/${SERVICE}:${IMAGE_TAG}|" \
+              "infra/k8s/${SERVICE}.yaml"
+          done
+
+      - name: Apply Kubernetes manifests
+        run: |
+          kubectl apply -f infra/k8s/namespace.yaml
+          kubectl apply -f infra/k8s/network-policy.yaml
+          kubectl apply -f infra/k8s/ingress.yaml
+          kubectl apply -f infra/k8s/
+
+      - name: Rollout restart deployments
+        run: |
+          SERVICES=(api-gateway product-service store-service pos-service inventory-service analytics-service)
+          for SERVICE in "${SERVICES[@]}"; do
+            kubectl rollout restart deployment/"${SERVICE}" -n openpos
+          done
+
+      - name: Wait for rollout completion
+        run: |
+          SERVICES=(api-gateway product-service store-service pos-service inventory-service analytics-service)
+          for SERVICE in "${SERVICES[@]}"; do
+            echo "Waiting for ${SERVICE} rollout..."
+            kubectl rollout status deployment/"${SERVICE}" -n openpos --timeout=300s
+          done
+
+      - name: Verify deployment
+        run: |
+          echo "Deployed version: ${{ needs.version.outputs.semver }}"
+          echo "Commit SHA: ${{ github.sha }}"
+          kubectl get deployments -n openpos
+          kubectl get pods -n openpos

--- a/infra/k8s/analytics-service.yaml
+++ b/infra/k8s/analytics-service.yaml
@@ -28,6 +28,13 @@ spec:
                 name: analytics-service-config
             - secretRef:
                 name: openpos-secrets
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
           readinessProbe:
             httpGet:
               path: /health
@@ -42,11 +49,11 @@ spec:
             periodSeconds: 15
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
               cpu: 500m
               memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -70,5 +77,5 @@ metadata:
   name: analytics-service-config
   namespace: openpos
 data:
-  QUARKUS_HTTP_PORT: "8080"
-  QUARKUS_GRPC_SERVER_PORT: "9000"
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'

--- a/infra/k8s/api-gateway.yaml
+++ b/infra/k8s/api-gateway.yaml
@@ -27,6 +27,13 @@ spec:
                 name: api-gateway-config
             - secretRef:
                 name: openpos-secrets
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
           readinessProbe:
             httpGet:
               path: /health
@@ -41,11 +48,11 @@ spec:
             periodSeconds: 15
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
               cpu: 500m
               memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -67,5 +74,4 @@ metadata:
   name: api-gateway-config
   namespace: openpos
 data:
-  QUARKUS_HTTP_PORT: "8080"
-
+  QUARKUS_HTTP_PORT: '8080'

--- a/infra/k8s/ingress.yaml
+++ b/infra/k8s/ingress.yaml
@@ -1,0 +1,53 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openpos-ingress
+  namespace: openpos
+  labels:
+    app.kubernetes.io/part-of: openpos
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+    nginx.ingress.kubernetes.io/proxy-body-size: '10m'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '60'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '60'
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - api.openpos.example.com
+        - pos.openpos.example.com
+        - admin.openpos.example.com
+      secretName: openpos-tls
+  rules:
+    - host: api.openpos.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api-gateway
+                port:
+                  number: 80
+    - host: pos.openpos.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: pos-terminal
+                port:
+                  number: 80
+    - host: admin.openpos.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: admin-dashboard
+                port:
+                  number: 80

--- a/infra/k8s/inventory-service.yaml
+++ b/infra/k8s/inventory-service.yaml
@@ -28,6 +28,13 @@ spec:
                 name: inventory-service-config
             - secretRef:
                 name: openpos-secrets
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
           readinessProbe:
             httpGet:
               path: /health
@@ -42,11 +49,11 @@ spec:
             periodSeconds: 15
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
               cpu: 500m
               memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -70,5 +77,5 @@ metadata:
   name: inventory-service-config
   namespace: openpos
 data:
-  QUARKUS_HTTP_PORT: "8080"
-  QUARKUS_GRPC_SERVER_PORT: "9000"
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'

--- a/infra/k8s/network-policy.yaml
+++ b/infra/k8s/network-policy.yaml
@@ -1,0 +1,117 @@
+## Default deny all ingress traffic in the openpos namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: openpos
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+## Allow ingress controller to reach api-gateway and frontend services
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-gateway
+  namespace: openpos
+spec:
+  podSelector:
+    matchLabels:
+      app: api-gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+## Allow api-gateway to reach backend services (HTTP + gRPC)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-gateway-to-services
+  namespace: openpos
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - product-service
+          - store-service
+          - pos-service
+          - inventory-service
+          - analytics-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: api-gateway
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 9000
+---
+## Allow inter-service gRPC communication between backend services
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-inter-service-grpc
+  namespace: openpos
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - product-service
+          - store-service
+          - pos-service
+          - inventory-service
+          - analytics-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - product-service
+                  - store-service
+                  - pos-service
+                  - inventory-service
+                  - analytics-service
+      ports:
+        - protocol: TCP
+          port: 9000
+---
+## Allow DNS resolution for all pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: openpos
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/infra/k8s/pos-service.yaml
+++ b/infra/k8s/pos-service.yaml
@@ -28,6 +28,13 @@ spec:
                 name: pos-service-config
             - secretRef:
                 name: openpos-secrets
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
           readinessProbe:
             httpGet:
               path: /health
@@ -42,11 +49,11 @@ spec:
             periodSeconds: 15
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
               cpu: 500m
               memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -70,5 +77,5 @@ metadata:
   name: pos-service-config
   namespace: openpos
 data:
-  QUARKUS_HTTP_PORT: "8080"
-  QUARKUS_GRPC_SERVER_PORT: "9000"
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'

--- a/infra/k8s/product-service.yaml
+++ b/infra/k8s/product-service.yaml
@@ -28,6 +28,13 @@ spec:
                 name: product-service-config
             - secretRef:
                 name: openpos-secrets
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
           readinessProbe:
             httpGet:
               path: /health
@@ -42,11 +49,11 @@ spec:
             periodSeconds: 15
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
               cpu: 500m
               memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -70,5 +77,5 @@ metadata:
   name: product-service-config
   namespace: openpos
 data:
-  QUARKUS_HTTP_PORT: "8080"
-  QUARKUS_GRPC_SERVER_PORT: "9000"
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'

--- a/infra/k8s/store-service.yaml
+++ b/infra/k8s/store-service.yaml
@@ -28,6 +28,13 @@ spec:
                 name: store-service-config
             - secretRef:
                 name: openpos-secrets
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
           readinessProbe:
             httpGet:
               path: /health
@@ -42,11 +49,11 @@ spec:
             periodSeconds: 15
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
-            limits:
               cpu: 500m
               memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -70,5 +77,5 @@ metadata:
   name: store-service-config
   namespace: openpos
 data:
-  QUARKUS_HTTP_PORT: "8080"
-  QUARKUS_GRPC_SERVER_PORT: "9000"
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'


### PR DESCRIPTION
## Summary
- #346: K8s Ingress(TLS/cert-manager)、NetworkPolicy 5件、リソースlimits引上げ(1Gi/1000m)、startupProbe追加
- #347: cd.ymlにsemantic versioning(git describe)、staging deploy job、GitHub Environment参照

## Test plan
- [ ] `kubectl apply`でIngress/NetworkPolicyリソースが正常作成されることを確認
- [ ] CDパイプラインのstagingデプロイジョブが正常動作することを確認
- [ ] NetworkPolicyでサービス間通信が制限されていることを確認

Closes #346, Closes #347