### PR TITLE
fix: マルチテナント境界の6件のギャップ修正

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/repository/DailySalesRepository.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/repository/DailySalesRepository.kt
@@ -38,21 +38,38 @@ class DailySalesRepository : PanacheRepositoryBase<DailySalesEntity, UUID> {
         ).list()
 
     /**
-     * 特定日の全店舗の日次売上を取得する。
+     * 特定日の指定テナントの日次売上を取得する。
      */
-    fun findBySaleDate(date: LocalDate): List<DailySalesEntity> = list("date = ?1", date)
+    fun findBySaleDate(
+        date: LocalDate,
+        organizationId: UUID,
+    ): List<DailySalesEntity> = list("date = ?1 AND organizationId = ?2", date, organizationId)
 
     /**
-     * 日付範囲で全店舗の日次売上を取得する（日付昇順）。
+     * 日付範囲で指定テナントの日次売上を取得する（日付昇順）。
      */
     fun listByDateRange(
         startDate: LocalDate,
         endDate: LocalDate,
+        organizationId: UUID,
     ): List<DailySalesEntity> =
         find(
-            "date >= ?1 AND date <= ?2",
+            "date >= ?1 AND date <= ?2 AND organizationId = ?3",
             Sort.ascending("date"),
             startDate,
             endDate,
+            organizationId,
         ).list()
+
+    /**
+     * 指定日に売上データが存在するテナントの organization_id 一覧を返す。
+     */
+    fun findDistinctOrganizationIdsBySaleDate(date: LocalDate): List<UUID> {
+        @Suppress("UNCHECKED_CAST")
+        return getEntityManager()
+            .createQuery(
+                "SELECT DISTINCT d.organizationId FROM DailySalesEntity d WHERE d.date = :date",
+            ).setParameter("date", date)
+            .resultList as List<UUID>
+    }
 }

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/DailyReportJob.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/DailyReportJob.kt
@@ -22,7 +22,7 @@ class DailyReportJob {
     }
 
     /**
-     * 毎日 23:59 に前日の売上サマリーを生成する。
+     * 毎日 23:59 に前日の売上サマリーをテナントごとに生成する。
      * cron 式: 秒 分 時 日 月 曜日
      */
     @Scheduled(cron = "0 59 23 * * ?", identity = "daily-report-job")
@@ -30,11 +30,23 @@ class DailyReportJob {
         val yesterday = LocalDate.now().minusDays(1)
         logger.info("Generating daily sales report for $yesterday")
 
-        val sales = dailySalesRepository.findBySaleDate(yesterday)
-        if (sales.isEmpty()) {
+        val organizationIds = dailySalesRepository.findDistinctOrganizationIdsBySaleDate(yesterday)
+        if (organizationIds.isEmpty()) {
             logger.info("No sales data found for $yesterday")
             return
         }
+
+        for (orgId in organizationIds) {
+            generateReportForOrganization(yesterday, orgId)
+        }
+    }
+
+    private fun generateReportForOrganization(
+        date: LocalDate,
+        organizationId: java.util.UUID,
+    ) {
+        val sales = dailySalesRepository.findBySaleDate(date, organizationId)
+        if (sales.isEmpty()) return
 
         val totalSales = sales.sumOf { it.grossAmount }
         val totalTransactions = sales.sumOf { it.transactionCount }
@@ -42,7 +54,7 @@ class DailyReportJob {
 
         val summary =
             buildString {
-                appendLine("=== 売上速報 ($yesterday) ===")
+                appendLine("=== 売上速報 ($date) [org=$organizationId] ===")
                 appendLine("総売上: $totalSales (銭単位)")
                 appendLine("取引数: $totalTransactions")
                 appendLine("店舗数: $storeCount")
@@ -54,6 +66,6 @@ class DailyReportJob {
 
         logger.info(summary)
         // プレースホルダー: メール送信
-        // emailService.send(to = "admin@example.com", subject = "売上速報 $yesterday", body = summary)
+        // emailService.send(to = "admin@example.com", subject = "売上速報 $date", body = summary)
     }
 }

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/ProductAlertService.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/ProductAlertService.kt
@@ -1,6 +1,7 @@
 package com.openpos.analytics.service
 
 import com.openpos.analytics.config.OrganizationIdHolder
+import com.openpos.analytics.config.TenantFilterService
 import com.openpos.analytics.entity.ProductAlertEntity
 import com.openpos.analytics.repository.ProductAlertRepository
 import io.quarkus.panache.common.Page
@@ -20,6 +21,9 @@ class ProductAlertService {
 
     @Inject
     lateinit var organizationIdHolder: OrganizationIdHolder
+
+    @Inject
+    lateinit var tenantFilterService: TenantFilterService
 
     fun listByOrganization(
         organizationId: UUID,
@@ -54,7 +58,16 @@ class ProductAlertService {
 
     @Transactional
     fun markAsRead(id: UUID): ProductAlertEntity? {
+        val orgId =
+            requireNotNull(organizationIdHolder.organizationId) {
+                "organizationId is not set in OrganizationIdHolder"
+            }
         val entity = productAlertRepository.findById(id) ?: return null
+        // ProductAlertEntity は BaseEntity を継承していないため Hibernate Filter が効かない。
+        // 手動でテナント所有権を検証し、他テナントのアラートを操作できないようにする。
+        if (entity.organizationId != orgId) {
+            return null
+        }
         entity.isRead = true
         productAlertRepository.persist(entity)
         return entity

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/PaymentRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/PaymentRepository.kt
@@ -19,10 +19,12 @@ class PaymentRepository : PanacheRepositoryBase<PaymentEntity, UUID> {
 
     /**
      * 指定端末の完了済み取引における現金支払合計を取得する（精算用）。
+     * organization_id で明示的にフィルタし、マルチテナント分離を保証する。
      */
     fun sumCashPaymentsByTerminal(
         storeId: UUID,
         terminalId: UUID,
+        organizationId: UUID,
     ): Long {
         val result =
             getEntityManager()
@@ -35,10 +37,13 @@ class PaymentRepository : PanacheRepositoryBase<PaymentEntity, UUID> {
                       AND t.terminalId = :terminalId
                       AND t.status = 'COMPLETED'
                       AND p.method = 'CASH'
+                      AND t.organizationId = :organizationId
+                      AND p.organizationId = :organizationId
                     """.trimIndent(),
                     Long::class.javaObjectType,
                 ).setParameter("storeId", storeId)
                 .setParameter("terminalId", terminalId)
+                .setParameter("organizationId", organizationId)
                 .singleResult
         return result ?: 0L
     }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
@@ -10,7 +10,10 @@ import java.util.UUID
 
 @ApplicationScoped
 class TransactionRepository : PanacheRepositoryBase<TransactionEntity, UUID> {
-    fun findByClientId(clientId: String): TransactionEntity? = find("clientId = ?1", clientId).firstResult()
+    fun findByClientId(
+        clientId: String,
+        organizationId: UUID,
+    ): TransactionEntity? = find("clientId = ?1 AND organizationId = ?2", clientId, organizationId).firstResult()
 
     fun listByStoreId(
         storeId: UUID,

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/SettlementService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/SettlementService.kt
@@ -36,7 +36,7 @@ class SettlementService {
         tenantFilterService.enableFilter()
 
         // Calculate expected cash from completed transactions' cash payments
-        val cashExpected = paymentRepository.sumCashPaymentsByTerminal(storeId, terminalId)
+        val cashExpected = paymentRepository.sumCashPaymentsByTerminal(storeId, terminalId, orgId)
 
         val settlement =
             SettlementEntity().apply {

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -71,7 +71,7 @@ class TransactionService {
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
 
         if (!clientId.isNullOrBlank()) {
-            val existing = transactionRepository.findByClientId(clientId)
+            val existing = transactionRepository.findByClientId(clientId, orgId)
             if (existing != null) return existing
         }
 

--- a/services/store-service/src/main/kotlin/com/openpos/store/grpc/GrpcTenantHelper.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/grpc/GrpcTenantHelper.kt
@@ -34,4 +34,9 @@ class GrpcTenantHelper {
                 )
         organizationIdHolder.organizationId = orgId
     }
+
+    /**
+     * OrganizationIdHolder に設定済みの organizationId を返す。
+     */
+    fun currentOrganizationId(): java.util.UUID? = organizationIdHolder.organizationId
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
@@ -97,8 +97,18 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
         request: GetOrganizationRequest,
         responseObserver: io.grpc.stub.StreamObserver<GetOrganizationResponse>,
     ) {
+        // OrganizationEntity はテナントルートのため Hibernate Filter 不要だが、
+        // 呼び出し元の x-organization-id を検証し、自テナントのみアクセス可能にする
+        tenantHelper.setupTenantContextWithoutFilter()
+        val requestedId = request.id.toUUID()
+        val callerId = requireNotNull(tenantHelper.currentOrganizationId()) { "organizationId is not set" }
+        if (requestedId != callerId) {
+            throw Status.PERMISSION_DENIED
+                .withDescription("Cannot access organization belonging to another tenant")
+                .asRuntimeException()
+        }
         val entity =
-            organizationService.findById(request.id.toUUID())
+            organizationService.findById(requestedId)
                 ?: throw Status.NOT_FOUND.withDescription("Organization not found: ${request.id}").asRuntimeException()
         responseObserver.onNext(
             GetOrganizationResponse.newBuilder().setOrganization(entity.toProto()).build(),
@@ -110,9 +120,19 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
         request: UpdateOrganizationRequest,
         responseObserver: io.grpc.stub.StreamObserver<UpdateOrganizationResponse>,
     ) {
+        // OrganizationEntity はテナントルートのため Hibernate Filter 不要だが、
+        // 呼び出し元の x-organization-id を検証し、自テナントのみ更新可能にする
+        tenantHelper.setupTenantContextWithoutFilter()
+        val requestedId = request.id.toUUID()
+        val callerId = requireNotNull(tenantHelper.currentOrganizationId()) { "organizationId is not set" }
+        if (requestedId != callerId) {
+            throw Status.PERMISSION_DENIED
+                .withDescription("Cannot update organization belonging to another tenant")
+                .asRuntimeException()
+        }
         val entity =
             organizationService.update(
-                id = request.id.toUUID(),
+                id = requestedId,
                 name = request.name.ifBlank { null },
                 businessType = request.businessType.ifBlank { null },
                 invoiceNumber = request.invoiceNumber.ifBlank { null },


### PR DESCRIPTION
## Summary
検証 (#362) で発見された6件のテナント分離ギャップを修正:

1. **StoreGrpcService**: getOrganization/updateOrganizationにテナントコンテキスト設定+クロステナントチェック追加
2. **TransactionRepository.findByClientId**: organization_idパラメータ追加
3. **PaymentRepository.sumCashPaymentsByTerminal**: JPQL にorganization_idフィルタ追加
4. **DailyReportJob**: テナントごとに分離してレポート生成するよう再構成
5. **DailySalesRepository**: findBySaleDate/listByDateRangeにorganization_id追加
6. **ProductAlertService.markAsRead**: organizationId所有権チェック追加

## Test plan
- [ ] 異なるorganization_idでデータ作成し、クロステナントデータが漏洩しないことを確認
- [ ] DailyReportJobが各テナント別にレポート生成することを確認
- [ ] Organization取得時に他テナントのOrganizationにアクセスできないことを確認

Closes #362