### PR TITLE
ci: 残り P2-P3 修正（main 失敗通知・sed ハードコード・コメント追加）

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -109,15 +109,17 @@ jobs:
           IMAGE_TAG="${{ needs.version.outputs.semver }}"
           SERVICES=(api-gateway product-service store-service pos-service inventory-service analytics-service)
           for SERVICE in "${SERVICES[@]}"; do
-            sed -i "s|image: ghcr.io/akaitigo/open-pos/${SERVICE}:.*|image: ${{ env.IMAGE_PREFIX }}/${SERVICE}:${IMAGE_TAG}|" \
+            sed -i "s|image: ${{ env.IMAGE_PREFIX }}/${SERVICE}:.*|image: ${{ env.IMAGE_PREFIX }}/${SERVICE}:${IMAGE_TAG}|" \
               "infra/k8s/${SERVICE}.yaml"
           done
 
       - name: Apply Kubernetes manifests
         run: |
+          # namespace と network-policy を先に適用（他リソースの依存先）
           kubectl apply -f infra/k8s/namespace.yaml
           kubectl apply -f infra/k8s/network-policy.yaml
           kubectl apply -f infra/k8s/ingress.yaml
+          # 全マニフェストを適用（上記含む。kubectl apply は冪等）
           kubectl apply -f infra/k8s/
 
       - name: Wait for rollout completion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -120,6 +121,7 @@ jobs:
           :services:store-service:jacocoTestCoverageVerification
           :services:pos-service:jacocoTestCoverageVerification
           :services:inventory-service:jacocoTestCoverageVerification
+          # analytics-service は jacocoTestCoverageVerification タスク未定義のため除外
       - name: Upload Coverage Reports
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -225,3 +227,27 @@ jobs:
             fi
           done
           echo "All CI checks passed or were correctly skipped."
+      - name: Notify on main branch failure
+        if: failure() && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --title "ci: main ブランチの CI が失敗 ($(date -u +%Y-%m-%d))" \
+            --label "type:bug,infra" \
+            --body "## CI 失敗通知
+
+          **ワークフロー**: [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          **コミット**: [\`${GITHUB_SHA::7}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          **実行者**: @${{ github.actor }}
+
+          ### ジョブ結果
+          | ジョブ | 結果 |
+          |--------|------|
+          | changes | \`${{ needs.changes.result }}\` |
+          | proto-lint | \`${{ needs.proto-lint.result }}\` |
+          | backend | \`${{ needs.backend.result }}\` |
+          | frontend | \`${{ needs.frontend.result }}\` |
+          | e2e | \`${{ needs.e2e.result }}\` |
+
+          [ワークフロー実行を確認](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"


### PR DESCRIPTION
## Summary

CI/CD 監査の残り P2-P3 項目を修正。

### 変更内容

| ファイル | 修正 |
|---------|------|
| ci.yml | main CI 失敗時に GitHub Issue を自動作成する通知ステップ追加 |
| ci.yml | analytics-service の coverage verification 除外理由をコメント追加 |
| cd.yml | sed パターンのハードコード `ghcr.io/akaitigo/open-pos` を `${{ env.IMAGE_PREFIX }}` に統一 |
| cd.yml | kubectl apply の順序意図をコメントで明記 |

### 調査の結果、対応不要だった項目

| 項目 | 理由 |
|------|------|
| E2E ヘルスチェック | `docker compose --wait` で対応済み |
| analytics-service カバレッジ | `jacocoTestCoverageVerification` タスク未定義（意図的除外） |
| スケジュール集中 | security(09:00) / codeql(03:23) で6時間差あり問題なし |

### 検証

- [x] `actionlint` — エラーなし
- [x] YAML 構文チェック — valid

## Test plan

- [ ] main CI 失敗時に Issue が自動作成されることを確認
- [ ] CD の sed パターンが正しくイメージタグを置換することを確認