### PR TITLE
fix(e2e): Playwright設定にfullyParallel・forbidOnly・workers・video追加

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,6 +6,9 @@ const webServerTimeout = process.env.CI ? 300_000 : 120_000
 
 export default defineConfig({
   testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  workers: process.env.CI ? 1 : undefined,
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'html',
@@ -28,6 +31,7 @@ export default defineConfig({
   use: {
     baseURL: 'http://127.0.0.1:5173',
     screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
     trace: 'on-first-retry',
   },
   projects: [


### PR DESCRIPTION
## Summary
- **#505**: `fullyParallel: true`、`forbidOnly: !!process.env.CI`、`workers: process.env.CI ? 1 : undefined` を `playwright.config.ts` に追加
- **#506**: `use` セクションに `video: 'retain-on-failure'` を追加し、失敗テストの動画を自動保持

## 変更ファイル
- `e2e/playwright.config.ts`

## Test plan
- [ ] ローカルで `pnpm --filter e2e test` が並列実行されることを確認
- [ ] `.only` 付きテストがローカルでは実行可、CI では失敗することを確認
- [ ] テスト失敗時に動画ファイルが `test-results/` に保存されることを確認

Closes #505
Closes #506