### PR TITLE
fix: JDBC 接続プール明示設定

### DIFF
--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -14,6 +14,8 @@ quarkus.datasource.username=${DB_USER:openpos}
 quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 quarkus.datasource.jdbc.url=${DB_URL:jdbc:postgresql://localhost:16432/openpos}
 quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
+quarkus.datasource.jdbc.max-size=10
+quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=analytics_schema
 quarkus.hibernate-orm.database.generation=none
 

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -14,6 +14,8 @@ quarkus.datasource.username=${DB_USER:openpos}
 quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 quarkus.datasource.jdbc.url=${DB_URL:jdbc:postgresql://localhost:16432/openpos}
 quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
+quarkus.datasource.jdbc.max-size=10
+quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=inventory_schema
 quarkus.hibernate-orm.database.generation=none
 

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -14,6 +14,8 @@ quarkus.datasource.username=${DB_USER:openpos}
 quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 quarkus.datasource.jdbc.url=${DB_URL:jdbc:postgresql://localhost:16432/openpos}
 quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
+quarkus.datasource.jdbc.max-size=10
+quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=pos_schema
 quarkus.hibernate-orm.database.generation=none
 

--- a/services/product-service/src/main/resources/application.properties
+++ b/services/product-service/src/main/resources/application.properties
@@ -14,6 +14,8 @@ quarkus.datasource.username=${DB_USER:openpos}
 quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 quarkus.datasource.jdbc.url=${DB_URL:jdbc:postgresql://localhost:16432/openpos}
 quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
+quarkus.datasource.jdbc.max-size=10
+quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=product_schema
 quarkus.hibernate-orm.database.generation=none
 

--- a/services/store-service/src/main/resources/application.properties
+++ b/services/store-service/src/main/resources/application.properties
@@ -14,6 +14,8 @@ quarkus.datasource.username=${DB_USER:openpos}
 quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 quarkus.datasource.jdbc.url=${DB_URL:jdbc:postgresql://localhost:16432/openpos}
 quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
+quarkus.datasource.jdbc.max-size=10
+quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=store_schema
 quarkus.hibernate-orm.database.generation=none
 


### PR DESCRIPTION
## Summary
- 全5 DBサービス（pos, product, store, inventory, analytics）に `quarkus.datasource.jdbc.max-size=10` と `quarkus.datasource.jdbc.min-size=2` を追加
- Quarkus デフォルト（max-size=20）を明示的に制限し、PgBouncer 経由の接続数を適切に管理

## Test plan
- [ ] `./gradlew build -x test` でコンパイルエラーなし確認済み
- [ ] 本番環境で接続プールサイズが適切に制限されていることを確認

Closes #490