### PR TITLE
fix: gRPC クライアント deadline 設定

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -51,6 +51,13 @@ quarkus.otel.propagators=tracecontext,baggage
 %dev.mp.jwt.verify.publickey.location=http://localhost:14444/.well-known/jwks.json
 %dev.mp.jwt.verify.issuer=http://localhost:14444/
 
+# gRPC client deadline (#498)
+quarkus.grpc.clients.product-service.deadline=5000
+quarkus.grpc.clients.store-service.deadline=5000
+quarkus.grpc.clients.pos-service.deadline=5000
+quarkus.grpc.clients.inventory-service.deadline=5000
+quarkus.grpc.clients.analytics-service.deadline=5000
+
 # gRPC connection pooling + keep-alive (#158)
 quarkus.grpc.clients.product-service.keep-alive-time=30s
 quarkus.grpc.clients.product-service.keep-alive-timeout=5s

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -42,10 +42,12 @@ mp.messaging.outgoing.outgoing-events.reconnect-interval=5
 # gRPC Client (product-service)
 quarkus.grpc.clients.product-service.host=${PRODUCT_SERVICE_HOST:localhost}
 quarkus.grpc.clients.product-service.port=${PRODUCT_SERVICE_PORT:9001}
+quarkus.grpc.clients.product-service.deadline=5000
 
 # gRPC Client (store-service)
 quarkus.grpc.clients.store-service.host=${STORE_SERVICE_HOST:localhost}
 quarkus.grpc.clients.store-service.port=${STORE_SERVICE_PORT:9000}
+quarkus.grpc.clients.store-service.deadline=5000
 
 # Structured Logging (JSON in prod)
 quarkus.log.console.json=false


### PR DESCRIPTION
## Summary
- api-gateway: 全5 gRPCクライアント（product, store, pos, inventory, analytics）に `deadline=5000`（5秒）を設定
- pos-service: product-service, store-service クライアントに `deadline=5000` を設定
- 無限待機を防止し、障害時のカスケード障害リスクを低減

## Test plan
- [ ] `./gradlew build -x test` でコンパイルエラーなし確認済み
- [ ] gRPC呼び出しが5秒以内にタイムアウトすることを確認

Closes #498