### PR TITLE
fix: OpenTelemetry sampler 設定（本番10%サンプリング）

### DIFF
--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -102,6 +102,8 @@ quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
 %dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.traces.sampler=traceidratio
+%prod.quarkus.otel.traces.sampler.arg=0.1
 
 # GCP Secret Manager (prod only)
 # %prod.quarkus.gcp.secret-manager.enabled=true

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -44,6 +44,8 @@ quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
 %dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.traces.sampler=traceidratio
+%prod.quarkus.otel.traces.sampler.arg=0.1
 
 
 # Dev profile (quarkusDev with local infra via Docker Compose)

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -113,6 +113,8 @@ quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
 %dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.traces.sampler=traceidratio
+%prod.quarkus.otel.traces.sampler.arg=0.1
 
 # GCP Secret Manager (prod only)
 # %prod.quarkus.gcp.secret-manager.enabled=true

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -65,6 +65,8 @@ quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
 %dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.traces.sampler=traceidratio
+%prod.quarkus.otel.traces.sampler.arg=0.1
 
 # GCP Secret Manager (prod only)
 # %prod.quarkus.gcp.secret-manager.enabled=true

--- a/services/product-service/src/main/resources/application.properties
+++ b/services/product-service/src/main/resources/application.properties
@@ -49,6 +49,8 @@ quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
 %dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.traces.sampler=traceidratio
+%prod.quarkus.otel.traces.sampler.arg=0.1
 
 # GCP Secret Manager (prod only)
 # %prod.quarkus.gcp.secret-manager.enabled=true

--- a/services/store-service/src/main/resources/application.properties
+++ b/services/store-service/src/main/resources/application.properties
@@ -49,6 +49,8 @@ quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
 %dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.traces.sampler=traceidratio
+%prod.quarkus.otel.traces.sampler.arg=0.1
 
 # GCP Secret Manager (prod only)
 # %prod.quarkus.gcp.secret-manager.enabled=true


### PR DESCRIPTION
## Summary
- 全6サービスに `%prod.quarkus.otel.traces.sampler=traceidratio` と `%prod.quarkus.otel.traces.sampler.arg=0.1` を追加
- 本番環境でトレースを10%サンプリングし、OTel Collector / バックエンドへの負荷を軽減
- dev プロファイルでは引き続き OTel 無効のまま

## Test plan
- [ ] `./gradlew build -x test` でコンパイルエラーなし確認済み
- [ ] 本番デプロイ後にトレース量が約10%に削減されていることを確認

Closes #500