### PR TITLE
fix: api-gateway Structured Logging 設定追加

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -45,6 +45,10 @@ quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
 %dev.quarkus.otel.enabled=false
 
+# Structured Logging (JSON in prod)
+quarkus.log.console.json=false
+%prod.quarkus.log.console.json=true
+quarkus.log.console.json.additional-field.service.value=${quarkus.application.name}
 
 # Dev profile (quarkusDev with local infra via Docker Compose)
 %dev.quarkus.redis.hosts=redis://localhost:16379


### PR DESCRIPTION
## Summary
- api-gateway に構造化ログ設定を追加（他の5サービスと統一）
- `quarkus.log.console.json=false`（dev では通常テキスト）
- `%prod.quarkus.log.console.json=true`（本番では JSON 出力）
- `quarkus.log.console.json.additional-field.service.value=${quarkus.application.name}`（サービス名フィールド付き）

## Test plan
- [ ] `./gradlew build -x test` でコンパイルエラーなし確認済み
- [ ] 本番デプロイ後に JSON 形式でログが出力されることを確認

Closes #501