### PR TITLE
fix: graceful shutdown timeout（30秒）設定

### DIFF
--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Application
 quarkus.application.name=analytics-service
+quarkus.shutdown.timeout=30s
 
 # gRPC code generation
 quarkus.generate-code.grpc.kotlin.generate=false

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Application
 quarkus.application.name=api-gateway
+quarkus.shutdown.timeout=30s
 
 # gRPC code generation
 quarkus.generate-code.grpc.kotlin.generate=false

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Application
 quarkus.application.name=inventory-service
+quarkus.shutdown.timeout=30s
 
 # gRPC code generation
 quarkus.generate-code.grpc.kotlin.generate=false

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Application
 quarkus.application.name=pos-service
+quarkus.shutdown.timeout=30s
 
 # gRPC code generation
 quarkus.generate-code.grpc.kotlin.generate=false

--- a/services/product-service/src/main/resources/application.properties
+++ b/services/product-service/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Application
 quarkus.application.name=product-service
+quarkus.shutdown.timeout=30s
 
 # gRPC code generation
 quarkus.generate-code.grpc.kotlin.generate=false

--- a/services/store-service/src/main/resources/application.properties
+++ b/services/store-service/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Application
 quarkus.application.name=store-service
+quarkus.shutdown.timeout=30s
 
 # gRPC code generation
 quarkus.generate-code.grpc.kotlin.generate=false


### PR DESCRIPTION
## Summary
- 全6サービスに `quarkus.shutdown.timeout=30s` を追加
- SIGTERM 受信後、処理中リクエストの完了を最大30秒待機してから終了
- Kubernetes の `terminationGracePeriodSeconds` と整合

## Test plan
- [ ] `./gradlew build -x test` でコンパイルエラーなし確認済み
- [ ] Pod 停止時にリクエストが graceful に処理完了されることを確認

Closes #502