### PR TITLE
DLQ ログの PII マスキング

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumer.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumer.kt
@@ -69,14 +69,18 @@ class DeadLetterQueueConsumer {
         republish: (String) -> Unit,
     ) {
         val retryCount = extractRetryCount(messageBody)
+        val eventId = extractField(messageBody, "eventId")
+        val eventType = extractField(messageBody, "eventType")
 
         if (retryCount < MAX_RETRY_COUNT) {
             val delayMs = BACKOFF_DELAYS_MS[retryCount]
             log.warnf(
-                "DLQ message retry %d/%d for queue=%s, delay=%dms",
+                "DLQ message retry %d/%d for queue=%s, eventId=%s, eventType=%s, delay=%dms",
                 retryCount + 1,
                 MAX_RETRY_COUNT,
                 originalQueue,
+                eventId,
+                eventType,
                 delayMs,
             )
 
@@ -86,13 +90,27 @@ class DeadLetterQueueConsumer {
             republish(updatedMessage)
         } else {
             log.errorf(
-                "PERMANENT FAILURE: DLQ message exceeded max retries (%d) for queue=%s. Message: %s",
+                "PERMANENT FAILURE: DLQ message exceeded max retries (%d) for queue=%s, eventId=%s, eventType=%s",
                 MAX_RETRY_COUNT,
                 originalQueue,
-                messageBody,
+                eventId,
+                eventType,
             )
+            log.debugf("PERMANENT FAILURE full payload for eventId=%s: %s", eventId, messageBody)
         }
     }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun extractField(
+        message: String,
+        field: String,
+    ): String =
+        try {
+            val map = objectMapper.readValue(message, Map::class.java) as Map<String, Any>
+            map[field]?.toString() ?: "unknown"
+        } catch (e: Exception) {
+            "unknown"
+        }
 
     @Suppress("UNCHECKED_CAST")
     private fun extractRetryCount(message: String): Int =

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumer.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumer.kt
@@ -69,14 +69,18 @@ class DeadLetterQueueConsumer {
         republish: (String) -> Unit,
     ) {
         val retryCount = extractRetryCount(messageBody)
+        val eventId = extractField(messageBody, "eventId")
+        val eventType = extractField(messageBody, "eventType")
 
         if (retryCount < MAX_RETRY_COUNT) {
             val delayMs = BACKOFF_DELAYS_MS[retryCount]
             log.warnf(
-                "DLQ message retry %d/%d for queue=%s, delay=%dms",
+                "DLQ message retry %d/%d for queue=%s, eventId=%s, eventType=%s, delay=%dms",
                 retryCount + 1,
                 MAX_RETRY_COUNT,
                 originalQueue,
+                eventId,
+                eventType,
                 delayMs,
             )
 
@@ -86,13 +90,27 @@ class DeadLetterQueueConsumer {
             republish(updatedMessage)
         } else {
             log.errorf(
-                "PERMANENT FAILURE: DLQ message exceeded max retries (%d) for queue=%s. Message: %s",
+                "PERMANENT FAILURE: DLQ message exceeded max retries (%d) for queue=%s, eventId=%s, eventType=%s",
                 MAX_RETRY_COUNT,
                 originalQueue,
-                messageBody,
+                eventId,
+                eventType,
             )
+            log.debugf("PERMANENT FAILURE full payload for eventId=%s: %s", eventId, messageBody)
         }
     }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun extractField(
+        message: String,
+        field: String,
+    ): String =
+        try {
+            val map = objectMapper.readValue(message, Map::class.java) as Map<String, Any>
+            map[field]?.toString() ?: "unknown"
+        } catch (e: Exception) {
+            "unknown"
+        }
 
     @Suppress("UNCHECKED_CAST")
     private fun extractRetryCount(message: String): Int =


### PR DESCRIPTION
## Summary
- analytics-service / inventory-service の DeadLetterQueueConsumer で、PERMANENT FAILURE ログに完全なメッセージペイロード(PII含む可能性)を出力していたのを修正
- ERROR レベルでは eventId と eventType のみを出力
- 完全なペイロードは DEBUG レベルに移動(本番では出力されない)
- リトライ時の WARN ログにも eventId/eventType を追加し、トラブルシューティングを容易に

## Test plan
- [x] `./gradlew :services:analytics-service:test :services:inventory-service:test` 全テスト通過確認済み

Closes #496