### PR TITLE
RabbitMQ failure-strategy を reject に変更

### DIFF
--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -46,7 +46,7 @@ mp.messaging.incoming.sale-completed-events.queue.declare=false
 mp.messaging.incoming.sale-completed-events.exchange.name=openpos.events
 mp.messaging.incoming.sale-completed-events.exchange.declare=false
 mp.messaging.incoming.sale-completed-events.routing-keys=sale.completed
-mp.messaging.incoming.sale-completed-events.failure-strategy=accept
+mp.messaging.incoming.sale-completed-events.failure-strategy=reject
 mp.messaging.incoming.sale-completed-events.reconnect-attempts=10
 mp.messaging.incoming.sale-completed-events.reconnect-interval=5
 
@@ -56,7 +56,7 @@ mp.messaging.incoming.sale-voided-events.queue.declare=false
 mp.messaging.incoming.sale-voided-events.exchange.name=openpos.events
 mp.messaging.incoming.sale-voided-events.exchange.declare=false
 mp.messaging.incoming.sale-voided-events.routing-keys=sale.voided
-mp.messaging.incoming.sale-voided-events.failure-strategy=accept
+mp.messaging.incoming.sale-voided-events.failure-strategy=reject
 mp.messaging.incoming.sale-voided-events.reconnect-attempts=10
 mp.messaging.incoming.sale-voided-events.reconnect-interval=5
 
@@ -67,7 +67,7 @@ mp.messaging.incoming.dlq-analytics-sale-completed.queue.declare=false
 mp.messaging.incoming.dlq-analytics-sale-completed.exchange.name=openpos.events.dlx
 mp.messaging.incoming.dlq-analytics-sale-completed.exchange.declare=false
 mp.messaging.incoming.dlq-analytics-sale-completed.routing-keys=dlq.analytics.sale-completed
-mp.messaging.incoming.dlq-analytics-sale-completed.failure-strategy=accept
+mp.messaging.incoming.dlq-analytics-sale-completed.failure-strategy=reject
 
 mp.messaging.incoming.dlq-analytics-sale-voided.connector=smallrye-rabbitmq
 mp.messaging.incoming.dlq-analytics-sale-voided.queue.name=dlq.analytics.sale-voided
@@ -75,7 +75,7 @@ mp.messaging.incoming.dlq-analytics-sale-voided.queue.declare=false
 mp.messaging.incoming.dlq-analytics-sale-voided.exchange.name=openpos.events.dlx
 mp.messaging.incoming.dlq-analytics-sale-voided.exchange.declare=false
 mp.messaging.incoming.dlq-analytics-sale-voided.routing-keys=dlq.analytics.sale-voided
-mp.messaging.incoming.dlq-analytics-sale-voided.failure-strategy=accept
+mp.messaging.incoming.dlq-analytics-sale-voided.failure-strategy=reject
 
 # RabbitMQ Outgoing (DLQ Retry)
 mp.messaging.outgoing.sale-completed-retry.connector=smallrye-rabbitmq

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -41,7 +41,7 @@ mp.messaging.incoming.sale-completed.queue.declare=false
 mp.messaging.incoming.sale-completed.exchange.name=openpos.events
 mp.messaging.incoming.sale-completed.exchange.declare=false
 mp.messaging.incoming.sale-completed.routing-keys=sale.completed
-mp.messaging.incoming.sale-completed.failure-strategy=accept
+mp.messaging.incoming.sale-completed.failure-strategy=reject
 mp.messaging.incoming.sale-completed.reconnect-attempts=10
 mp.messaging.incoming.sale-completed.reconnect-interval=5
 
@@ -51,7 +51,7 @@ mp.messaging.incoming.sale-voided.queue.declare=false
 mp.messaging.incoming.sale-voided.exchange.name=openpos.events
 mp.messaging.incoming.sale-voided.exchange.declare=false
 mp.messaging.incoming.sale-voided.routing-keys=sale.voided
-mp.messaging.incoming.sale-voided.failure-strategy=accept
+mp.messaging.incoming.sale-voided.failure-strategy=reject
 mp.messaging.incoming.sale-voided.reconnect-attempts=10
 mp.messaging.incoming.sale-voided.reconnect-interval=5
 
@@ -78,7 +78,7 @@ mp.messaging.incoming.dlq-inventory-sale-completed.queue.declare=false
 mp.messaging.incoming.dlq-inventory-sale-completed.exchange.name=openpos.events.dlx
 mp.messaging.incoming.dlq-inventory-sale-completed.exchange.declare=false
 mp.messaging.incoming.dlq-inventory-sale-completed.routing-keys=dlq.inventory.sale-completed
-mp.messaging.incoming.dlq-inventory-sale-completed.failure-strategy=accept
+mp.messaging.incoming.dlq-inventory-sale-completed.failure-strategy=reject
 
 mp.messaging.incoming.dlq-inventory-sale-voided.connector=smallrye-rabbitmq
 mp.messaging.incoming.dlq-inventory-sale-voided.queue.name=dlq.inventory.sale-voided
@@ -86,7 +86,7 @@ mp.messaging.incoming.dlq-inventory-sale-voided.queue.declare=false
 mp.messaging.incoming.dlq-inventory-sale-voided.exchange.name=openpos.events.dlx
 mp.messaging.incoming.dlq-inventory-sale-voided.exchange.declare=false
 mp.messaging.incoming.dlq-inventory-sale-voided.routing-keys=dlq.inventory.sale-voided
-mp.messaging.incoming.dlq-inventory-sale-voided.failure-strategy=accept
+mp.messaging.incoming.dlq-inventory-sale-voided.failure-strategy=reject
 
 # RabbitMQ Outgoing (DLQ Retry)
 mp.messaging.outgoing.sale-completed-retry.connector=smallrye-rabbitmq


### PR DESCRIPTION
## Summary
- analytics-service / inventory-service の全 RabbitMQ incoming チャンネルで `failure-strategy` を `accept` から `reject` に変更
- `accept` では失敗メッセージが暗黙的に acknowledge され破棄されていた
- `reject` に変更することで、失敗メッセージが RabbitMQ の DLX (Dead Letter Exchange) に適切にルーティングされ、DLQ コンシューマーによるリトライ処理が正しく機能する

## Test plan
- [x] `./gradlew build -x test` ビルド成功確認済み

Closes #493