### PR TITLE
fix: DLQ Consumer Thread.sleep をノンブロッキングに置換

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumer.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumer.kt
@@ -2,11 +2,14 @@ package com.openpos.analytics.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
 import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.eclipse.microprofile.reactive.messaging.Metadata
 import org.jboss.logging.Logger
 import java.util.concurrent.CompletionStage
 
@@ -16,6 +19,9 @@ import java.util.concurrent.CompletionStage
  * 最大 3 回のリトライ（指数バックオフ: 1s, 5s, 25s）を試み、
  * それを超えた場合は永久失敗としてログに記録する。
  * 明示的に ack/nack を行う。
+ *
+ * バックオフは Thread.sleep ではなく RabbitMQ メッセージの expiration（TTL）で実現する。
+ * TTL 付きメッセージは RabbitMQ 側で遅延後に配信されるため、スレッドをブロックしない。
  */
 @ApplicationScoped
 class DeadLetterQueueConsumer {
@@ -41,8 +47,15 @@ class DeadLetterQueueConsumer {
     fun onDlqSaleCompleted(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
         try {
             val body = message.payload
-            handleDeadLetter(body, "analytics.sale-completed") { retryMessage ->
-                saleCompletedRetryEmitter.send(retryMessage)
+            handleDeadLetter(body, "analytics.sale-completed") { retryMessage, delayMs ->
+                val metadata =
+                    OutgoingRabbitMQMetadata
+                        .builder()
+                        .withExpiration(delayMs.toString())
+                        .build()
+                saleCompletedRetryEmitter.send(
+                    Message.of(retryMessage, Metadata.of(metadata)),
+                )
             }
             message.ack()
         } catch (e: Exception) {
@@ -54,8 +67,15 @@ class DeadLetterQueueConsumer {
     fun onDlqSaleVoided(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
         try {
             val body = message.payload
-            handleDeadLetter(body, "analytics.sale-voided") { retryMessage ->
-                saleVoidedRetryEmitter.send(retryMessage)
+            handleDeadLetter(body, "analytics.sale-voided") { retryMessage, delayMs ->
+                val metadata =
+                    OutgoingRabbitMQMetadata
+                        .builder()
+                        .withExpiration(delayMs.toString())
+                        .build()
+                saleVoidedRetryEmitter.send(
+                    Message.of(retryMessage, Metadata.of(metadata)),
+                )
             }
             message.ack()
         } catch (e: Exception) {
@@ -66,7 +86,7 @@ class DeadLetterQueueConsumer {
     private fun handleDeadLetter(
         messageBody: String,
         originalQueue: String,
-        republish: (String) -> Unit,
+        republish: (String, Long) -> Unit,
     ) {
         val retryCount = extractRetryCount(messageBody)
         val eventId = extractField(messageBody, "eventId")
@@ -84,10 +104,8 @@ class DeadLetterQueueConsumer {
                 delayMs,
             )
 
-            Thread.sleep(delayMs)
-
             val updatedMessage = incrementRetryCount(messageBody, retryCount)
-            republish(updatedMessage)
+            republish(updatedMessage, delayMs)
         } else {
             log.errorf(
                 "PERMANENT FAILURE: DLQ message exceeded max retries (%d) for queue=%s, eventId=%s, eventType=%s",

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumerTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumerTest.kt
@@ -2,7 +2,10 @@ package com.openpos.analytics.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata
 import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -57,7 +60,7 @@ class DeadLetterQueueConsumerTest {
     @Nested
     inner class OnDlqSaleCompleted {
         @Test
-        fun `初回リトライ時はsaleCompletedRetryEmitterに再送する`() {
+        fun `初回リトライ時はメッセージTTL付きで再送する`() {
             // Arrange
             val body = buildMessageBody(retryCount = 0)
             val message = mockMessage(body)
@@ -66,11 +69,18 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleCompleted(message)
 
             // Assert
-            val captor = argumentCaptor<String>()
+            val captor = argumentCaptor<Message<String>>()
             verify(saleCompletedRetryEmitter).send(captor.capture())
 
-            val sentMessage = objectMapper.readValue(captor.firstValue, Map::class.java)
-            assertTrue(sentMessage["retryCount"] == 1)
+            val sentMsg = captor.firstValue
+            val sentBody = objectMapper.readValue(sentMsg.payload, Map::class.java)
+            assertTrue(sentBody["retryCount"] == 1)
+
+            // メッセージに OutgoingRabbitMQMetadata（expiration）が設定されていることを検証
+            val rabbitMetadata = sentMsg.metadata.get(OutgoingRabbitMQMetadata::class.java)
+            assertTrue(rabbitMetadata.isPresent, "OutgoingRabbitMQMetadata should be present")
+            assertEquals("1000", rabbitMetadata.get().expiration)
+
             verify(message).ack()
         }
 
@@ -84,11 +94,11 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleCompleted(message)
 
             // Assert
-            val captor = argumentCaptor<String>()
+            val captor = argumentCaptor<Message<String>>()
             verify(saleCompletedRetryEmitter).send(captor.capture())
 
-            val sentMessage = objectMapper.readValue(captor.firstValue, Map::class.java)
-            assertTrue(sentMessage["retryCount"] == 1)
+            val sentBody = objectMapper.readValue(captor.firstValue.payload, Map::class.java)
+            assertTrue(sentBody["retryCount"] == 1)
             verify(message).ack()
         }
 
@@ -102,12 +112,12 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleCompleted(message)
 
             // Assert
-            verify(saleCompletedRetryEmitter, never()).send(any())
+            verify(saleCompletedRetryEmitter, never()).send(any<Message<String>>())
             verify(message).ack()
         }
 
         @Test
-        fun `2回目のリトライでretryCountが正しくインクリメントされる`() {
+        fun `2回目のリトライでretryCountが正しくインクリメントされTTLが5秒に設定される`() {
             // Arrange
             val body = buildMessageBody(retryCount = 1)
             val message = mockMessage(body)
@@ -116,11 +126,17 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleCompleted(message)
 
             // Assert
-            val captor = argumentCaptor<String>()
+            val captor = argumentCaptor<Message<String>>()
             verify(saleCompletedRetryEmitter).send(captor.capture())
 
-            val sentMessage = objectMapper.readValue(captor.firstValue, Map::class.java)
-            assertTrue(sentMessage["retryCount"] == 2)
+            val sentMsg = captor.firstValue
+            val sentBody = objectMapper.readValue(sentMsg.payload, Map::class.java)
+            assertTrue(sentBody["retryCount"] == 2)
+
+            val rabbitMetadata = sentMsg.metadata.get(OutgoingRabbitMQMetadata::class.java)
+            assertTrue(rabbitMetadata.isPresent)
+            assertEquals("5000", rabbitMetadata.get().expiration)
+
             verify(message).ack()
         }
     }
@@ -128,7 +144,7 @@ class DeadLetterQueueConsumerTest {
     @Nested
     inner class OnDlqSaleVoided {
         @Test
-        fun `初回リトライ時はsaleVoidedRetryEmitterに再送する`() {
+        fun `初回リトライ時はsaleVoidedRetryEmitterにメッセージTTL付きで再送する`() {
             // Arrange
             val body = buildMessageBody(retryCount = 0)
             val message = mockMessage(body)
@@ -137,7 +153,7 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleVoided(message)
 
             // Assert
-            verify(saleVoidedRetryEmitter).send(any())
+            verify(saleVoidedRetryEmitter).send(any<Message<String>>())
             verify(message).ack()
         }
 
@@ -151,7 +167,7 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleVoided(message)
 
             // Assert
-            verify(saleVoidedRetryEmitter, never()).send(any())
+            verify(saleVoidedRetryEmitter, never()).send(any<Message<String>>())
             verify(message).ack()
         }
     }

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumer.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumer.kt
@@ -2,11 +2,14 @@ package com.openpos.inventory.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Channel
 import org.eclipse.microprofile.reactive.messaging.Emitter
 import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.eclipse.microprofile.reactive.messaging.Metadata
 import org.jboss.logging.Logger
 import java.util.concurrent.CompletionStage
 
@@ -16,6 +19,9 @@ import java.util.concurrent.CompletionStage
  * 最大 3 回のリトライ（指数バックオフ: 1s, 5s, 25s）を試み、
  * それを超えた場合は永久失敗としてログに記録する。
  * 明示的に ack/nack を行う。
+ *
+ * バックオフは Thread.sleep ではなく RabbitMQ メッセージの expiration（TTL）で実現する。
+ * TTL 付きメッセージは RabbitMQ 側で遅延後に配信されるため、スレッドをブロックしない。
  */
 @ApplicationScoped
 class DeadLetterQueueConsumer {
@@ -41,8 +47,15 @@ class DeadLetterQueueConsumer {
     fun onDlqSaleCompleted(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
         try {
             val body = message.payload
-            handleDeadLetter(body, "inventory.sale-completed") { retryMessage ->
-                saleCompletedRetryEmitter.send(retryMessage)
+            handleDeadLetter(body, "inventory.sale-completed") { retryMessage, delayMs ->
+                val metadata =
+                    OutgoingRabbitMQMetadata
+                        .builder()
+                        .withExpiration(delayMs.toString())
+                        .build()
+                saleCompletedRetryEmitter.send(
+                    Message.of(retryMessage, Metadata.of(metadata)),
+                )
             }
             message.ack()
         } catch (e: Exception) {
@@ -54,8 +67,15 @@ class DeadLetterQueueConsumer {
     fun onDlqSaleVoided(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
         try {
             val body = message.payload
-            handleDeadLetter(body, "inventory.sale-voided") { retryMessage ->
-                saleVoidedRetryEmitter.send(retryMessage)
+            handleDeadLetter(body, "inventory.sale-voided") { retryMessage, delayMs ->
+                val metadata =
+                    OutgoingRabbitMQMetadata
+                        .builder()
+                        .withExpiration(delayMs.toString())
+                        .build()
+                saleVoidedRetryEmitter.send(
+                    Message.of(retryMessage, Metadata.of(metadata)),
+                )
             }
             message.ack()
         } catch (e: Exception) {
@@ -66,7 +86,7 @@ class DeadLetterQueueConsumer {
     private fun handleDeadLetter(
         messageBody: String,
         originalQueue: String,
-        republish: (String) -> Unit,
+        republish: (String, Long) -> Unit,
     ) {
         val retryCount = extractRetryCount(messageBody)
         val eventId = extractField(messageBody, "eventId")
@@ -84,10 +104,8 @@ class DeadLetterQueueConsumer {
                 delayMs,
             )
 
-            Thread.sleep(delayMs)
-
             val updatedMessage = incrementRetryCount(messageBody, retryCount)
-            republish(updatedMessage)
+            republish(updatedMessage, delayMs)
         } else {
             log.errorf(
                 "PERMANENT FAILURE: DLQ message exceeded max retries (%d) for queue=%s, eventId=%s, eventType=%s",

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumerTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumerTest.kt
@@ -2,7 +2,10 @@ package com.openpos.inventory.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata
 import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.eclipse.microprofile.reactive.messaging.Message
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -57,7 +60,7 @@ class DeadLetterQueueConsumerTest {
     @Nested
     inner class OnDlqSaleCompleted {
         @Test
-        fun `初回リトライ時はsaleCompletedRetryEmitterに再送する`() {
+        fun `初回リトライ時はメッセージTTL付きで再送する`() {
             // Arrange
             val body = buildMessageBody(retryCount = 0)
             val message = mockMessage(body)
@@ -66,11 +69,18 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleCompleted(message)
 
             // Assert
-            val captor = argumentCaptor<String>()
+            val captor = argumentCaptor<Message<String>>()
             verify(saleCompletedRetryEmitter).send(captor.capture())
 
-            val sentMessage = objectMapper.readValue(captor.firstValue, Map::class.java)
-            assertTrue(sentMessage["retryCount"] == 1)
+            val sentMsg = captor.firstValue
+            val sentBody = objectMapper.readValue(sentMsg.payload, Map::class.java)
+            assertTrue(sentBody["retryCount"] == 1)
+
+            // メッセージに OutgoingRabbitMQMetadata（expiration）が設定されていることを検証
+            val rabbitMetadata = sentMsg.metadata.get(OutgoingRabbitMQMetadata::class.java)
+            assertTrue(rabbitMetadata.isPresent, "OutgoingRabbitMQMetadata should be present")
+            assertEquals("1000", rabbitMetadata.get().expiration)
+
             verify(message).ack()
         }
 
@@ -84,11 +94,11 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleCompleted(message)
 
             // Assert
-            val captor = argumentCaptor<String>()
+            val captor = argumentCaptor<Message<String>>()
             verify(saleCompletedRetryEmitter).send(captor.capture())
 
-            val sentMessage = objectMapper.readValue(captor.firstValue, Map::class.java)
-            assertTrue(sentMessage["retryCount"] == 1)
+            val sentBody = objectMapper.readValue(captor.firstValue.payload, Map::class.java)
+            assertTrue(sentBody["retryCount"] == 1)
             verify(message).ack()
         }
 
@@ -102,12 +112,12 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleCompleted(message)
 
             // Assert
-            verify(saleCompletedRetryEmitter, never()).send(any())
+            verify(saleCompletedRetryEmitter, never()).send(any<Message<String>>())
             verify(message).ack()
         }
 
         @Test
-        fun `2回目のリトライでretryCountが正しくインクリメントされる`() {
+        fun `2回目のリトライでretryCountが正しくインクリメントされTTLが5秒に設定される`() {
             // Arrange
             val body = buildMessageBody(retryCount = 1)
             val message = mockMessage(body)
@@ -116,11 +126,17 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleCompleted(message)
 
             // Assert
-            val captor = argumentCaptor<String>()
+            val captor = argumentCaptor<Message<String>>()
             verify(saleCompletedRetryEmitter).send(captor.capture())
 
-            val sentMessage = objectMapper.readValue(captor.firstValue, Map::class.java)
-            assertTrue(sentMessage["retryCount"] == 2)
+            val sentMsg = captor.firstValue
+            val sentBody = objectMapper.readValue(sentMsg.payload, Map::class.java)
+            assertTrue(sentBody["retryCount"] == 2)
+
+            val rabbitMetadata = sentMsg.metadata.get(OutgoingRabbitMQMetadata::class.java)
+            assertTrue(rabbitMetadata.isPresent)
+            assertEquals("5000", rabbitMetadata.get().expiration)
+
             verify(message).ack()
         }
     }
@@ -128,7 +144,7 @@ class DeadLetterQueueConsumerTest {
     @Nested
     inner class OnDlqSaleVoided {
         @Test
-        fun `初回リトライ時はsaleVoidedRetryEmitterに再送する`() {
+        fun `初回リトライ時はsaleVoidedRetryEmitterにメッセージTTL付きで再送する`() {
             // Arrange
             val body = buildMessageBody(retryCount = 0)
             val message = mockMessage(body)
@@ -137,7 +153,7 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleVoided(message)
 
             // Assert
-            verify(saleVoidedRetryEmitter).send(any())
+            verify(saleVoidedRetryEmitter).send(any<Message<String>>())
             verify(message).ack()
         }
 
@@ -151,7 +167,7 @@ class DeadLetterQueueConsumerTest {
             consumer.onDlqSaleVoided(message)
 
             // Assert
-            verify(saleVoidedRetryEmitter, never()).send(any())
+            verify(saleVoidedRetryEmitter, never()).send(any<Message<String>>())
             verify(message).ack()
         }
     }


### PR DESCRIPTION
## Summary
- analytics-service / inventory-service の `DeadLetterQueueConsumer` で `Thread.sleep(delayMs)` を削除
- 代わりに `OutgoingRabbitMQMetadata.builder().withExpiration(delayMs.toString())` でメッセージ TTL を設定して再パブリッシュ
- RabbitMQ 側で TTL 経過後にメッセージが配信されるため、コンシューマスレッドをブロックしない
- テストを更新: `Message<String>` + `OutgoingRabbitMQMetadata` の expiration を検証

## Test plan
- [x] `./gradlew :services:analytics-service:test` 通過
- [x] `./gradlew :services:inventory-service:test` 通過

Closes #477