### PR TITLE
fix: CheckoutDialog を4ファイルに分割

### DIFF
--- a/apps/pos-terminal/src/components/checkout-dialog.tsx
+++ b/apps/pos-terminal/src/components/checkout-dialog.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -11,23 +10,11 @@ import { Input } from '@/components/ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Separator } from '@/components/ui/separator'
 import { Badge } from '@/components/ui/badge'
-import { useCartStore, getCartSubtotal } from '@/stores/cart-store'
-import { useAuthStore } from '@/stores/auth-store'
-import { useDiscountStore } from '@/stores/discount-store'
-import { api } from '@/lib/api'
-import { saveOfflineTransaction } from '@/lib/offline-db'
-import type { OfflineTransactionItem, OfflinePayment } from '@/lib/offline-db'
-import {
-  ApiError,
-  FinalizeTransactionResponseSchema,
-  formatMoney,
-  TransactionSchema,
-  ValidateCouponResponseSchema,
-} from '@shared-types/openpos'
-import { toast } from '@/hooks/use-toast'
+import { useCheckout, PAYMENT_METHOD_LABELS } from '@/hooks/use-checkout'
+import { PaymentCashTab } from '@/components/payment-cash-tab'
+import { PaymentCardTab } from '@/components/payment-card-tab'
 import { ReceiptDialog } from '@/components/receipt-dialog'
-import { useTaxRates } from '@/hooks/use-tax-rates'
-import { getCartEstimatedTotal } from '@/lib/cart-totals'
+import { formatMoney } from '@shared-types/openpos'
 import { CreditCard, Loader2, Percent, QrCode, Receipt, Tag, Wallet, X } from 'lucide-react'
 
 interface CheckoutDialogProps {
@@ -35,372 +22,50 @@ interface CheckoutDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
-type PaymentMethod = 'CASH' | 'CREDIT_CARD' | 'QR_CODE'
-
-interface PaymentEntry {
-  id: string
-  method: PaymentMethod
-  amount: number
-  reference?: string
-  received?: number
-}
-
-const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
-  CASH: '現金',
-  CREDIT_CARD: 'カード',
-  QR_CODE: 'QR',
-}
-
-const QUICK_CASH_AMOUNTS = [100, 500, 1000, 5000, 10000]
-const CASH_KEYPAD_ROWS = [
-  ['1', '2', '3'],
-  ['4', '5', '6'],
-  ['7', '8', '9'],
-  ['00', '0', '⌫'],
-]
-
-function parseYenInput(value: string): number {
-  const digits = value.replace(/[^\d]/g, '')
-  if (!digits) return 0
-  return Number.parseInt(digits, 10) * 100
-}
-
-function ceilToWholeYen(amount: number): number {
-  if (amount <= 0) return 0
-  return Math.ceil(amount / 100) * 100
-}
-
-function normalizeNumericInput(value: string): string {
-  const digits = value.replace(/[^\d]/g, '')
-  if (!digits) return ''
-  return String(Number.parseInt(digits, 10))
-}
-
-function createPaymentEntryId(): string {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-}
-
 export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
-  const items = useCartStore((s) => s.items)
-  const clearCart = useCartStore((s) => s.clearCart)
-  const { storeId, terminalId, staff } = useAuthStore()
-
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('CASH')
-  const [paymentAmount, setPaymentAmount] = useState('')
-  const [receivedAmount, setReceivedAmount] = useState('')
-  const [reference, setReference] = useState('')
-  const [addedPayments, setAddedPayments] = useState<PaymentEntry[]>([])
-  const [processing, setProcessing] = useState(false)
-  const [receiptData, setReceiptData] = useState<string | null>(null)
-  const [receiptOpen, setReceiptOpen] = useState(false)
-  const [couponCode, setCouponCode] = useState('')
-  const [couponValidating, setCouponValidating] = useState(false)
-  const taxRates = useTaxRates()
-  const appliedDiscounts = useDiscountStore((s) => s.appliedDiscounts)
-  const addDiscount = useDiscountStore((s) => s.addDiscount)
-  const removeDiscount = useDiscountStore((s) => s.removeDiscount)
-  const clearDiscounts = useDiscountStore((s) => s.clearDiscounts)
-
-  const subtotal = getCartSubtotal(items)
-  const grossTotal = getCartEstimatedTotal(items, taxRates)
-  const taxTotal = grossTotal - subtotal
-  const discountTotal = appliedDiscounts.reduce((sum, d) => sum + d.amount, 0)
-  const total = Math.max(grossTotal - discountTotal, 0)
-
-  const paidAmount = addedPayments.reduce((sum, payment) => sum + payment.amount, 0)
-  const remainingAmount = Math.max(total - paidAmount, 0)
-  const roundedRemainingAmount = ceilToWholeYen(remainingAmount)
-  const parsedPaymentAmount = parseYenInput(paymentAmount)
-  const parsedReceivedAmount = parseYenInput(receivedAmount)
-
-  const currentCoverageAmount =
-    paymentMethod === 'CASH'
-      ? parsedReceivedAmount >= roundedRemainingAmount
-        ? remainingAmount
-        : 0
-      : Math.min(parsedPaymentAmount, remainingAmount)
-  const paymentTotalWithCurrent = paidAmount + currentCoverageAmount
-  const remainingAfterCurrent = Math.max(total - paymentTotalWithCurrent, 0)
-  const currentChange =
-    paymentMethod === 'CASH' && parsedReceivedAmount > roundedRemainingAmount
-      ? parsedReceivedAmount - roundedRemainingAmount
-      : 0
-  const cashShortfall =
-    paymentMethod === 'CASH' ? Math.max(roundedRemainingAmount - parsedReceivedAmount, 0) : 0
-  const nonCashShortfall =
-    paymentMethod !== 'CASH' ? Math.max(total - (paidAmount + parsedPaymentAmount), 0) : 0
-  const nonCashOverpayment =
-    paymentMethod !== 'CASH' ? Math.max(parsedPaymentAmount - remainingAmount, 0) : 0
-  const canAddCurrentPayment =
-    paymentMethod !== 'CASH' &&
-    parsedPaymentAmount > 0 &&
-    parsedPaymentAmount <= remainingAmount &&
-    reference.trim().length > 0 &&
-    paidAmount < total
-  const canFinalize =
-    items.length > 0 &&
-    (paidAmount >= total ||
-      (paymentMethod === 'CASH'
-        ? remainingAmount > 0 && parsedReceivedAmount >= roundedRemainingAmount
-        : parsedPaymentAmount > 0 &&
-          parsedPaymentAmount <= remainingAmount &&
-          paidAmount + parsedPaymentAmount >= total))
-
-  async function handleFinalize() {
-    if (!storeId || !terminalId || !staff) return
-
-    const payments: Array<{
-      method: PaymentMethod
-      amount: number
-      reference?: string
-      received?: number
-    }> = addedPayments.map(({ method, amount, reference: paymentReference, received }) => ({
-      method,
-      amount,
-      ...(paymentReference ? { reference: paymentReference } : {}),
-      ...(received != null ? { received } : {}),
-    }))
-
-    if (payments.reduce((sum, payment) => sum + payment.amount, 0) < total) {
-      if (paymentMethod === 'CASH') {
-        if (remainingAmount <= 0 || parsedReceivedAmount < roundedRemainingAmount) return
-        payments.push({
-          method: 'CASH',
-          amount: remainingAmount,
-          received: parsedReceivedAmount,
-        })
-      } else {
-        if (parsedPaymentAmount <= 0 || parsedPaymentAmount > remainingAmount) return
-        payments.push({
-          method: paymentMethod,
-          amount: parsedPaymentAmount,
-          ...(reference.trim() ? { reference: reference.trim() } : {}),
-        })
-      }
-    }
-
-    setProcessing(true)
-    try {
-      const tx = await api.post(
-        '/api/transactions',
-        { storeId, terminalId, staffId: staff.id },
-        TransactionSchema,
-      )
-
-      for (const item of items) {
-        await api.post(
-          `/api/transactions/${tx.id}/items`,
-          { productId: item.product.id, quantity: item.quantity },
-          TransactionSchema,
-        )
-      }
-
-      for (const entry of appliedDiscounts) {
-        await api.post(
-          `/api/transactions/${tx.id}/discount`,
-          { couponCode: entry.couponCode },
-          TransactionSchema,
-        )
-      }
-
-      const result = await api.post(
-        `/api/transactions/${tx.id}/finalize`,
-        { payments },
-        FinalizeTransactionResponseSchema,
-      )
-
-      setReceiptData(result.receipt.receiptData)
-      setReceiptOpen(true)
-      onOpenChange(false)
-    } catch (err) {
-      // ネットワークエラー時（fetch の TypeError）はオフライン保存にフォールバック
-      const isNetworkError =
-        err instanceof TypeError || (!navigator.onLine && !(err instanceof ApiError))
-      if (isNetworkError && storeId && terminalId && staff) {
-        try {
-          const offlineItems: OfflineTransactionItem[] = items.map((item) => ({
-            productId: item.product.id,
-            productName: item.product.name,
-            unitPrice: item.product.price,
-            quantity: item.quantity,
-            taxRateName: '',
-            taxRate: '0',
-            isReducedTax: false,
-          }))
-          const offlinePayments: OfflinePayment[] = payments.map((p) => ({
-            method: p.method,
-            amount: p.amount,
-            ...(p.received != null ? { received: p.received } : {}),
-            ...(p.reference ? { reference: p.reference } : {}),
-          }))
-          await saveOfflineTransaction({
-            clientId: crypto.randomUUID(),
-            storeId,
-            terminalId,
-            staffId: staff.id,
-            items: offlineItems,
-            payments: offlinePayments,
-            createdAt: new Date().toISOString(),
-            syncStatus: 'pending',
-          })
-          toast({
-            title: 'オフライン保存',
-            description:
-              'ネットワークに接続できません。取引をローカルに保存しました。オンライン復帰時に自動同期されます。',
-          })
-          clearCart()
-          clearDiscounts()
-          resetDialogState()
-          onOpenChange(false)
-        } catch {
-          toast({
-            title: 'エラー',
-            description: 'オフライン保存にも失敗しました',
-            variant: 'destructive',
-          })
-        }
-      } else {
-        const message = err instanceof Error ? err.message : '決済処理に失敗しました'
-        toast({ title: 'エラー', description: message, variant: 'destructive' })
-      }
-    } finally {
-      setProcessing(false)
-    }
-  }
-
-  async function handleApplyCoupon() {
-    const code = couponCode.trim()
-    if (!code) return
-    if (appliedDiscounts.some((d) => d.couponCode === code)) {
-      toast({ title: 'このクーポンは既に適用されています', variant: 'destructive' })
-      return
-    }
-
-    setCouponValidating(true)
-    try {
-      const result = await api.get(
-        `/api/coupons/validate/${encodeURIComponent(code)}`,
-        ValidateCouponResponseSchema,
-      )
-
-      if (!result.isValid || !result.discount) {
-        toast({
-          title: 'クーポン無効',
-          description: result.reason ?? 'このクーポンは使用できません。',
-          variant: 'destructive',
-        })
-        return
-      }
-
-      addDiscount(code, result.discount, grossTotal)
-      setCouponCode('')
-      toast({ title: `クーポン「${code}」を適用しました` })
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'クーポンの検証に失敗しました'
-      toast({ title: 'エラー', description: message, variant: 'destructive' })
-    } finally {
-      setCouponValidating(false)
-    }
-  }
-
-  function resetDialogState() {
-    setPaymentMethod('CASH')
-    setPaymentAmount('')
-    setReceivedAmount('')
-    setReference('')
-    setAddedPayments([])
-    setCouponCode('')
-  }
-
-  function handleReceiptClose() {
-    setReceiptOpen(false)
-    setReceiptData(null)
-    clearCart()
-    clearDiscounts()
-    resetDialogState()
-  }
-
-  function handleClose(isOpen: boolean) {
-    if (!processing) {
-      onOpenChange(isOpen)
-      if (!isOpen) resetDialogState()
-    }
-  }
-
-  function handleMethodChange(nextMethod: string) {
-    const method = nextMethod as PaymentMethod
-    setPaymentMethod(method)
-    if (method !== 'CASH' && !paymentAmount) {
-      setPaymentAmount(String(Math.ceil(remainingAmount / 100)))
-    }
-  }
-
-  function handleCashKeypadPress(key: string) {
-    if (key === '⌫') {
-      setReceivedAmount((current) => current.slice(0, -1))
-      return
-    }
-
-    setReceivedAmount((current) => normalizeNumericInput(`${current}${key}`))
-  }
-
-  function handleAddCurrentPayment() {
-    if (!canAddCurrentPayment) return
-
-    setAddedPayments((current) => [
-      ...current,
-      {
-        id: createPaymentEntryId(),
-        method: paymentMethod,
-        amount: parsedPaymentAmount,
-        reference: reference.trim(),
-      },
-    ])
-    setPaymentAmount('')
-    setReference('')
-    setPaymentMethod('CASH')
-  }
-
-  function handleRemovePayment(paymentId: string) {
-    setAddedPayments((current) => current.filter((payment) => payment.id !== paymentId))
-  }
+  const checkout = useCheckout(onOpenChange)
 
   return (
     <>
-      <Dialog open={open} onOpenChange={handleClose}>
+      <Dialog open={open} onOpenChange={checkout.handleClose}>
         <DialogContent className="max-h-[90vh] max-w-xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>お会計</DialogTitle>
           </DialogHeader>
 
           <div className="grid gap-4">
+            {/* 合計金額サマリー */}
             <div className="rounded-2xl bg-muted/50 p-4">
               <div className="grid gap-3 md:grid-cols-[1.1fr_0.9fr]">
                 <div className="space-y-1">
                   <p className="text-sm text-muted-foreground">合計金額</p>
-                  <p className="text-3xl font-bold">{formatMoney(total)}</p>
+                  <p className="text-3xl font-bold">{formatMoney(checkout.total)}</p>
                   <p className="text-sm text-muted-foreground">
-                    小計 {formatMoney(subtotal)} / 税額 {formatMoney(taxTotal)}
-                    {discountTotal > 0 && ` / 割引 -${formatMoney(discountTotal)}`}
+                    小計 {formatMoney(checkout.subtotal)} / 税額 {formatMoney(checkout.taxTotal)}
+                    {checkout.discountTotal > 0 &&
+                      ` / 割引 -${formatMoney(checkout.discountTotal)}`}
                   </p>
                 </div>
                 <div className="grid gap-2 rounded-xl border bg-background/80 p-3 text-sm">
                   <div className="flex items-center justify-between">
                     <span className="text-muted-foreground">支払済</span>
-                    <span className="font-medium">{formatMoney(paidAmount)}</span>
+                    <span className="font-medium">{formatMoney(checkout.paidAmount)}</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-muted-foreground">残額</span>
-                    <span className="font-medium">{formatMoney(remainingAmount)}</span>
+                    <span className="font-medium">{formatMoney(checkout.remainingAmount)}</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-muted-foreground">今回の支払後</span>
-                    <span className="font-medium">{formatMoney(remainingAfterCurrent)}</span>
+                    <span className="font-medium">
+                      {formatMoney(checkout.remainingAfterCurrent)}
+                    </span>
                   </div>
                 </div>
               </div>
             </div>
 
+            {/* 割引・クーポン */}
             <div className="space-y-3">
               <div className="flex items-center gap-2">
                 <Tag className="h-4 w-4 text-muted-foreground" />
@@ -412,30 +77,34 @@ export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
                   <label className="text-sm font-medium">クーポンコード</label>
                   <Input
                     placeholder="クーポンコードを入力"
-                    value={couponCode}
-                    onChange={(event) => setCouponCode(event.target.value)}
+                    value={checkout.couponCode}
+                    onChange={(event) => checkout.setCouponCode(event.target.value)}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter') {
                         event.preventDefault()
-                        void handleApplyCoupon()
+                        void checkout.handleApplyCoupon()
                       }
                     }}
                     className="mt-1"
-                    disabled={couponValidating}
+                    disabled={checkout.couponValidating}
                   />
                 </div>
                 <Button
                   variant="outline"
-                  onClick={() => void handleApplyCoupon()}
-                  disabled={couponValidating || !couponCode.trim()}
+                  onClick={() => void checkout.handleApplyCoupon()}
+                  disabled={checkout.couponValidating || !checkout.couponCode.trim()}
                 >
-                  {couponValidating ? <Loader2 className="h-4 w-4 animate-spin" /> : '適用'}
+                  {checkout.couponValidating ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    '適用'
+                  )}
                 </Button>
               </div>
 
-              {appliedDiscounts.length > 0 && (
+              {checkout.appliedDiscounts.length > 0 && (
                 <div className="space-y-2">
-                  {appliedDiscounts.map((entry) => (
+                  {checkout.appliedDiscounts.map((entry) => (
                     <div
                       key={entry.couponCode}
                       className="flex items-center justify-between rounded-xl border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950"
@@ -458,7 +127,7 @@ export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
                       <Button
                         variant="ghost"
                         size="icon"
-                        onClick={() => removeDiscount(entry.couponCode)}
+                        onClick={() => checkout.removeDiscount(entry.couponCode)}
                         aria-label={`クーポン ${entry.couponCode} を削除`}
                       >
                         <X className="h-4 w-4" />
@@ -469,14 +138,15 @@ export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
               )}
             </div>
 
-            {addedPayments.length > 0 && (
+            {/* 追加済みの支払 */}
+            {checkout.addedPayments.length > 0 && (
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
                   <Receipt className="h-4 w-4 text-muted-foreground" />
                   <p className="text-sm font-medium">追加済みの支払</p>
                 </div>
                 <div className="space-y-2">
-                  {addedPayments.map((payment) => (
+                  {checkout.addedPayments.map((payment) => (
                     <div
                       key={payment.id}
                       className="flex items-center justify-between rounded-xl border bg-background p-3"
@@ -495,7 +165,7 @@ export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
                       <Button
                         variant="ghost"
                         size="icon"
-                        onClick={() => handleRemovePayment(payment.id)}
+                        onClick={() => checkout.handleRemovePayment(payment.id)}
                         aria-label={`${PAYMENT_METHOD_LABELS[payment.method]} 支払を削除`}
                       >
                         <X className="h-4 w-4" />
@@ -508,10 +178,11 @@ export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
 
             <Separator />
 
+            {/* 支払方法タブ */}
             <Tabs
               data-testid="payment-tabs"
-              value={paymentMethod}
-              onValueChange={handleMethodChange}
+              value={checkout.paymentMethod}
+              onValueChange={checkout.handleMethodChange}
             >
               <TabsList className="grid w-full grid-cols-3">
                 <TabsTrigger data-testid="payment-tab-cash" value="CASH" className="gap-2">
@@ -528,199 +199,57 @@ export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
                 </TabsTrigger>
               </TabsList>
 
-              <TabsContent value="CASH" className="space-y-4">
-                <div className="rounded-xl border bg-muted/40 p-4">
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="text-muted-foreground">今回の現金充当額</span>
-                    <span className="font-medium">{formatMoney(remainingAmount)}</span>
-                  </div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    残額を現金で支払う前提です。分割払い時は先にカードまたは QR を追加してください。
-                  </p>
-                </div>
-
-                <div>
-                  <label className="text-sm font-medium">お預かり金額（円）</label>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="0"
-                    value={receivedAmount}
-                    onChange={(event) =>
-                      setReceivedAmount(normalizeNumericInput(event.target.value))
-                    }
-                    className="mt-1 text-right text-lg"
-                  />
-                </div>
-
-                <div className="flex flex-wrap gap-2">
-                  <Button
-                    data-testid="checkout-exact-btn"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setReceivedAmount(String(Math.ceil(remainingAmount / 100)))}
-                  >
-                    ぴったり
-                  </Button>
-                  {QUICK_CASH_AMOUNTS.map((yen) => (
-                    <Button
-                      key={yen}
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setReceivedAmount(String(yen))}
-                    >
-                      ¥{yen.toLocaleString('ja-JP')}
-                    </Button>
-                  ))}
-                  <Button variant="ghost" size="sm" onClick={() => setReceivedAmount('')}>
-                    C
-                  </Button>
-                </div>
-
-                <div className="grid grid-cols-3 gap-2">
-                  {CASH_KEYPAD_ROWS.flat().map((key) => (
-                    <Button
-                      key={key}
-                      variant="outline"
-                      size="lg"
-                      className="h-12"
-                      onClick={() => handleCashKeypadPress(key)}
-                    >
-                      {key}
-                    </Button>
-                  ))}
-                </div>
-
-                {cashShortfall > 0 && parsedReceivedAmount > 0 && (
-                  <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
-                    あと {formatMoney(cashShortfall)} 不足しています。
-                  </div>
-                )}
-
-                {parsedReceivedAmount >= roundedRemainingAmount && remainingAmount > 0 && (
-                  <div className="rounded-lg bg-muted p-3 text-center">
-                    <p className="text-sm text-muted-foreground">お釣り</p>
-                    <p className="text-xl font-bold">{formatMoney(currentChange)}</p>
-                  </div>
-                )}
+              <TabsContent value="CASH">
+                <PaymentCashTab
+                  remainingAmount={checkout.remainingAmount}
+                  receivedAmount={checkout.receivedAmount}
+                  setReceivedAmount={checkout.setReceivedAmount}
+                  handleCashKeypadPress={checkout.handleCashKeypadPress}
+                  cashShortfall={checkout.cashShortfall}
+                  parsedReceivedAmount={checkout.parsedReceivedAmount}
+                  roundedRemainingAmount={checkout.roundedRemainingAmount}
+                  currentChange={checkout.currentChange}
+                />
               </TabsContent>
 
-              <TabsContent value="CREDIT_CARD" className="space-y-4">
-                <div className="rounded-xl border bg-muted/40 p-4">
-                  <div className="flex items-center gap-2">
-                    <CreditCard className="h-4 w-4 text-muted-foreground" />
-                    <p className="text-sm font-medium">カード端末プレースホルダー</p>
-                  </div>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    端末で承認が完了したら承認番号を入力し、必要に応じて残額の一部だけを追加できます。
-                  </p>
-                </div>
-                <div>
-                  <label className="text-sm font-medium">決済金額（円）</label>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="残額を入力"
-                    value={paymentAmount}
-                    onChange={(event) =>
-                      setPaymentAmount(normalizeNumericInput(event.target.value))
-                    }
-                    className="mt-1"
-                  />
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setPaymentAmount(String(Math.ceil(remainingAmount / 100)))}
-                    >
-                      残額
-                    </Button>
-                  </div>
-                </div>
-                <div>
-                  <label className="text-sm font-medium">参照番号</label>
-                  <Input
-                    placeholder="カード承認番号"
-                    value={reference}
-                    onChange={(event) => setReference(event.target.value)}
-                    className="mt-1"
-                  />
-                </div>
-                {nonCashShortfall > 0 && parsedPaymentAmount > 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    この支払後も {formatMoney(nonCashShortfall)} 残ります。
-                  </p>
-                )}
-                {nonCashOverpayment > 0 && (
-                  <p className="text-sm text-destructive">残額を超える金額は追加できません。</p>
-                )}
+              <TabsContent value="CREDIT_CARD">
+                <PaymentCardTab
+                  mode="CREDIT_CARD"
+                  paymentAmount={checkout.paymentAmount}
+                  setPaymentAmount={checkout.setPaymentAmount}
+                  reference={checkout.reference}
+                  setReference={checkout.setReference}
+                  remainingAmount={checkout.remainingAmount}
+                  nonCashShortfall={checkout.nonCashShortfall}
+                  nonCashOverpayment={checkout.nonCashOverpayment}
+                  parsedPaymentAmount={checkout.parsedPaymentAmount}
+                />
               </TabsContent>
 
-              <TabsContent value="QR_CODE" className="space-y-4">
-                <div className="rounded-xl border bg-muted/40 p-4">
-                  <div className="flex items-center gap-2">
-                    <QrCode className="h-4 w-4 text-muted-foreground" />
-                    <p className="text-sm font-medium">QR 決済プレースホルダー</p>
-                  </div>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    決済アプリで QR を読み取り、決済 ID を控えてから追加してください。
-                  </p>
-                  <div className="mt-3 rounded-lg border border-dashed bg-background px-4 py-6 text-center">
-                    <p className="text-xs text-muted-foreground">決済コード</p>
-                    <p className="mt-2 font-mono text-lg tracking-[0.2em]">OPENPOS-QR</p>
-                  </div>
-                </div>
-                <div>
-                  <label className="text-sm font-medium">決済金額（円）</label>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="残額を入力"
-                    value={paymentAmount}
-                    onChange={(event) =>
-                      setPaymentAmount(normalizeNumericInput(event.target.value))
-                    }
-                    className="mt-1"
-                  />
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setPaymentAmount(String(Math.ceil(remainingAmount / 100)))}
-                    >
-                      残額
-                    </Button>
-                  </div>
-                </div>
-                <div>
-                  <label className="text-sm font-medium">参照番号</label>
-                  <Input
-                    placeholder="決済ID"
-                    value={reference}
-                    onChange={(event) => setReference(event.target.value)}
-                    className="mt-1"
-                  />
-                </div>
-                {nonCashShortfall > 0 && parsedPaymentAmount > 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    この支払後も {formatMoney(nonCashShortfall)} 残ります。
-                  </p>
-                )}
-                {nonCashOverpayment > 0 && (
-                  <p className="text-sm text-destructive">残額を超える金額は追加できません。</p>
-                )}
+              <TabsContent value="QR_CODE">
+                <PaymentCardTab
+                  mode="QR_CODE"
+                  paymentAmount={checkout.paymentAmount}
+                  setPaymentAmount={checkout.setPaymentAmount}
+                  reference={checkout.reference}
+                  setReference={checkout.setReference}
+                  remainingAmount={checkout.remainingAmount}
+                  nonCashShortfall={checkout.nonCashShortfall}
+                  nonCashOverpayment={checkout.nonCashOverpayment}
+                  parsedPaymentAmount={checkout.parsedPaymentAmount}
+                />
               </TabsContent>
             </Tabs>
           </div>
 
           <DialogFooter className="flex-col gap-2 sm:flex-col">
-            {paymentMethod !== 'CASH' && (
+            {checkout.paymentMethod !== 'CASH' && (
               <Button
                 variant="outline"
                 className="w-full"
                 size="lg"
-                disabled={processing || !canAddCurrentPayment}
-                onClick={handleAddCurrentPayment}
+                disabled={checkout.processing || !checkout.canAddCurrentPayment}
+                onClick={checkout.handleAddCurrentPayment}
               >
                 この支払を追加
               </Button>
@@ -729,10 +258,10 @@ export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
               data-testid="checkout-confirm-btn"
               className="w-full"
               size="lg"
-              disabled={processing || !canFinalize}
-              onClick={handleFinalize}
+              disabled={checkout.processing || !checkout.canFinalize}
+              onClick={checkout.handleFinalize}
             >
-              {processing ? (
+              {checkout.processing ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
                   処理中...
@@ -745,7 +274,11 @@ export function CheckoutDialog({ open, onOpenChange }: CheckoutDialogProps) {
         </DialogContent>
       </Dialog>
 
-      <ReceiptDialog open={receiptOpen} receiptData={receiptData} onClose={handleReceiptClose} />
+      <ReceiptDialog
+        open={checkout.receiptOpen}
+        receiptData={checkout.receiptData}
+        onClose={checkout.handleReceiptClose}
+      />
     </>
   )
 }

--- a/apps/pos-terminal/src/components/payment-card-tab.tsx
+++ b/apps/pos-terminal/src/components/payment-card-tab.tsx
@@ -1,0 +1,96 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { normalizeNumericInput } from '@/hooks/use-checkout'
+import { formatMoney } from '@shared-types/openpos'
+import { CreditCard, QrCode } from 'lucide-react'
+
+interface PaymentCardTabProps {
+  mode: 'CREDIT_CARD' | 'QR_CODE'
+  paymentAmount: string
+  setPaymentAmount: (value: string) => void
+  reference: string
+  setReference: (value: string) => void
+  remainingAmount: number
+  nonCashShortfall: number
+  nonCashOverpayment: number
+  parsedPaymentAmount: number
+}
+
+export function PaymentCardTab({
+  mode,
+  paymentAmount,
+  setPaymentAmount,
+  reference,
+  setReference,
+  remainingAmount,
+  nonCashShortfall,
+  nonCashOverpayment,
+  parsedPaymentAmount,
+}: PaymentCardTabProps) {
+  const isCard = mode === 'CREDIT_CARD'
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border bg-muted/40 p-4">
+        <div className="flex items-center gap-2">
+          {isCard ? (
+            <CreditCard className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <QrCode className="h-4 w-4 text-muted-foreground" />
+          )}
+          <p className="text-sm font-medium">
+            {isCard ? 'カード端末プレースホルダー' : 'QR 決済プレースホルダー'}
+          </p>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {isCard
+            ? '端末で承認が完了したら承認番号を入力し、必要に応じて残額の一部だけを追加できます。'
+            : '決済アプリで QR を読み取り、決済 ID を控えてから追加してください。'}
+        </p>
+        {!isCard && (
+          <div className="mt-3 rounded-lg border border-dashed bg-background px-4 py-6 text-center">
+            <p className="text-xs text-muted-foreground">決済コード</p>
+            <p className="mt-2 font-mono text-lg tracking-[0.2em]">OPENPOS-QR</p>
+          </div>
+        )}
+      </div>
+      <div>
+        <label className="text-sm font-medium">決済金額（円）</label>
+        <Input
+          type="number"
+          inputMode="numeric"
+          placeholder="残額を入力"
+          value={paymentAmount}
+          onChange={(event) => setPaymentAmount(normalizeNumericInput(event.target.value))}
+          className="mt-1"
+        />
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPaymentAmount(String(Math.ceil(remainingAmount / 100)))}
+          >
+            残額
+          </Button>
+        </div>
+      </div>
+      <div>
+        <label className="text-sm font-medium">参照番号</label>
+        <Input
+          placeholder={isCard ? 'カード承認番号' : '決済ID'}
+          value={reference}
+          onChange={(event) => setReference(event.target.value)}
+          className="mt-1"
+        />
+      </div>
+      {nonCashShortfall > 0 && parsedPaymentAmount > 0 && (
+        <p className="text-sm text-muted-foreground">
+          この支払後も {formatMoney(nonCashShortfall)} 残ります。
+        </p>
+      )}
+      {nonCashOverpayment > 0 && (
+        <p className="text-sm text-destructive">残額を超える金額は追加できません。</p>
+      )}
+    </div>
+  )
+}

--- a/apps/pos-terminal/src/components/payment-cash-tab.tsx
+++ b/apps/pos-terminal/src/components/payment-cash-tab.tsx
@@ -1,0 +1,103 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { QUICK_CASH_AMOUNTS, CASH_KEYPAD_ROWS, normalizeNumericInput } from '@/hooks/use-checkout'
+import { formatMoney } from '@shared-types/openpos'
+
+interface PaymentCashTabProps {
+  remainingAmount: number
+  receivedAmount: string
+  setReceivedAmount: (value: string) => void
+  handleCashKeypadPress: (key: string) => void
+  cashShortfall: number
+  parsedReceivedAmount: number
+  roundedRemainingAmount: number
+  currentChange: number
+}
+
+export function PaymentCashTab({
+  remainingAmount,
+  receivedAmount,
+  setReceivedAmount,
+  handleCashKeypadPress,
+  cashShortfall,
+  parsedReceivedAmount,
+  roundedRemainingAmount,
+  currentChange,
+}: PaymentCashTabProps) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border bg-muted/40 p-4">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">今回の現金充当額</span>
+          <span className="font-medium">{formatMoney(remainingAmount)}</span>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          残額を現金で支払う前提です。分割払い時は先にカードまたは QR を追加してください。
+        </p>
+      </div>
+
+      <div>
+        <label className="text-sm font-medium">お預かり金額（円）</label>
+        <Input
+          type="number"
+          inputMode="numeric"
+          placeholder="0"
+          value={receivedAmount}
+          onChange={(event) => setReceivedAmount(normalizeNumericInput(event.target.value))}
+          className="mt-1 text-right text-lg"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          data-testid="checkout-exact-btn"
+          variant="outline"
+          size="sm"
+          onClick={() => setReceivedAmount(String(Math.ceil(remainingAmount / 100)))}
+        >
+          ぴったり
+        </Button>
+        {QUICK_CASH_AMOUNTS.map((yen) => (
+          <Button
+            key={yen}
+            variant="outline"
+            size="sm"
+            onClick={() => setReceivedAmount(String(yen))}
+          >
+            ¥{yen.toLocaleString('ja-JP')}
+          </Button>
+        ))}
+        <Button variant="ghost" size="sm" onClick={() => setReceivedAmount('')}>
+          C
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        {CASH_KEYPAD_ROWS.flat().map((key) => (
+          <Button
+            key={key}
+            variant="outline"
+            size="lg"
+            className="h-12"
+            onClick={() => handleCashKeypadPress(key)}
+          >
+            {key}
+          </Button>
+        ))}
+      </div>
+
+      {cashShortfall > 0 && parsedReceivedAmount > 0 && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          あと {formatMoney(cashShortfall)} 不足しています。
+        </div>
+      )}
+
+      {parsedReceivedAmount >= roundedRemainingAmount && remainingAmount > 0 && (
+        <div className="rounded-lg bg-muted p-3 text-center">
+          <p className="text-sm text-muted-foreground">お釣り</p>
+          <p className="text-xl font-bold">{formatMoney(currentChange)}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/pos-terminal/src/hooks/use-checkout.ts
+++ b/apps/pos-terminal/src/hooks/use-checkout.ts
@@ -1,0 +1,398 @@
+import { useState } from 'react'
+import { useCartStore, getCartSubtotal } from '@/stores/cart-store'
+import { useAuthStore } from '@/stores/auth-store'
+import { useDiscountStore } from '@/stores/discount-store'
+import { api } from '@/lib/api'
+import { saveOfflineTransaction } from '@/lib/offline-db'
+import type { OfflineTransactionItem, OfflinePayment } from '@/lib/offline-db'
+import {
+  ApiError,
+  FinalizeTransactionResponseSchema,
+  TransactionSchema,
+  ValidateCouponResponseSchema,
+} from '@shared-types/openpos'
+import { toast } from '@/hooks/use-toast'
+import { useTaxRates } from '@/hooks/use-tax-rates'
+import { getCartEstimatedTotal } from '@/lib/cart-totals'
+
+export type PaymentMethod = 'CASH' | 'CREDIT_CARD' | 'QR_CODE'
+
+export interface PaymentEntry {
+  id: string
+  method: PaymentMethod
+  amount: number
+  reference?: string
+  received?: number
+}
+
+export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
+  CASH: '現金',
+  CREDIT_CARD: 'カード',
+  QR_CODE: 'QR',
+}
+
+export const QUICK_CASH_AMOUNTS = [100, 500, 1000, 5000, 10000]
+export const CASH_KEYPAD_ROWS = [
+  ['1', '2', '3'],
+  ['4', '5', '6'],
+  ['7', '8', '9'],
+  ['00', '0', '⌫'],
+]
+
+export function parseYenInput(value: string): number {
+  const digits = value.replace(/[^\d]/g, '')
+  if (!digits) return 0
+  return Number.parseInt(digits, 10) * 100
+}
+
+export function ceilToWholeYen(amount: number): number {
+  if (amount <= 0) return 0
+  return Math.ceil(amount / 100) * 100
+}
+
+export function normalizeNumericInput(value: string): string {
+  const digits = value.replace(/[^\d]/g, '')
+  if (!digits) return ''
+  return String(Number.parseInt(digits, 10))
+}
+
+function createPaymentEntryId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export function useCheckout(onOpenChange: (open: boolean) => void) {
+  const items = useCartStore((s) => s.items)
+  const clearCart = useCartStore((s) => s.clearCart)
+  const { storeId, terminalId, staff } = useAuthStore()
+
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('CASH')
+  const [paymentAmount, setPaymentAmount] = useState('')
+  const [receivedAmount, setReceivedAmount] = useState('')
+  const [reference, setReference] = useState('')
+  const [addedPayments, setAddedPayments] = useState<PaymentEntry[]>([])
+  const [processing, setProcessing] = useState(false)
+  const [receiptData, setReceiptData] = useState<string | null>(null)
+  const [receiptOpen, setReceiptOpen] = useState(false)
+  const [couponCode, setCouponCode] = useState('')
+  const [couponValidating, setCouponValidating] = useState(false)
+  const taxRates = useTaxRates()
+  const appliedDiscounts = useDiscountStore((s) => s.appliedDiscounts)
+  const addDiscount = useDiscountStore((s) => s.addDiscount)
+  const removeDiscount = useDiscountStore((s) => s.removeDiscount)
+  const clearDiscounts = useDiscountStore((s) => s.clearDiscounts)
+
+  const subtotal = getCartSubtotal(items)
+  const grossTotal = getCartEstimatedTotal(items, taxRates)
+  const taxTotal = grossTotal - subtotal
+  const discountTotal = appliedDiscounts.reduce((sum, d) => sum + d.amount, 0)
+  const total = Math.max(grossTotal - discountTotal, 0)
+
+  const paidAmount = addedPayments.reduce((sum, payment) => sum + payment.amount, 0)
+  const remainingAmount = Math.max(total - paidAmount, 0)
+  const roundedRemainingAmount = ceilToWholeYen(remainingAmount)
+  const parsedPaymentAmount = parseYenInput(paymentAmount)
+  const parsedReceivedAmount = parseYenInput(receivedAmount)
+
+  const currentCoverageAmount =
+    paymentMethod === 'CASH'
+      ? parsedReceivedAmount >= roundedRemainingAmount
+        ? remainingAmount
+        : 0
+      : Math.min(parsedPaymentAmount, remainingAmount)
+  const paymentTotalWithCurrent = paidAmount + currentCoverageAmount
+  const remainingAfterCurrent = Math.max(total - paymentTotalWithCurrent, 0)
+  const currentChange =
+    paymentMethod === 'CASH' && parsedReceivedAmount > roundedRemainingAmount
+      ? parsedReceivedAmount - roundedRemainingAmount
+      : 0
+  const cashShortfall =
+    paymentMethod === 'CASH' ? Math.max(roundedRemainingAmount - parsedReceivedAmount, 0) : 0
+  const nonCashShortfall =
+    paymentMethod !== 'CASH' ? Math.max(total - (paidAmount + parsedPaymentAmount), 0) : 0
+  const nonCashOverpayment =
+    paymentMethod !== 'CASH' ? Math.max(parsedPaymentAmount - remainingAmount, 0) : 0
+  const canAddCurrentPayment =
+    paymentMethod !== 'CASH' &&
+    parsedPaymentAmount > 0 &&
+    parsedPaymentAmount <= remainingAmount &&
+    reference.trim().length > 0 &&
+    paidAmount < total
+  const canFinalize =
+    items.length > 0 &&
+    (paidAmount >= total ||
+      (paymentMethod === 'CASH'
+        ? remainingAmount > 0 && parsedReceivedAmount >= roundedRemainingAmount
+        : parsedPaymentAmount > 0 &&
+          parsedPaymentAmount <= remainingAmount &&
+          paidAmount + parsedPaymentAmount >= total))
+
+  function resetDialogState() {
+    setPaymentMethod('CASH')
+    setPaymentAmount('')
+    setReceivedAmount('')
+    setReference('')
+    setAddedPayments([])
+    setCouponCode('')
+  }
+
+  async function handleFinalize() {
+    if (!storeId || !terminalId || !staff) return
+
+    const payments: Array<{
+      method: PaymentMethod
+      amount: number
+      reference?: string
+      received?: number
+    }> = addedPayments.map(({ method, amount, reference: paymentReference, received }) => ({
+      method,
+      amount,
+      ...(paymentReference ? { reference: paymentReference } : {}),
+      ...(received != null ? { received } : {}),
+    }))
+
+    if (payments.reduce((sum, payment) => sum + payment.amount, 0) < total) {
+      if (paymentMethod === 'CASH') {
+        if (remainingAmount <= 0 || parsedReceivedAmount < roundedRemainingAmount) return
+        payments.push({
+          method: 'CASH',
+          amount: remainingAmount,
+          received: parsedReceivedAmount,
+        })
+      } else {
+        if (parsedPaymentAmount <= 0 || parsedPaymentAmount > remainingAmount) return
+        payments.push({
+          method: paymentMethod,
+          amount: parsedPaymentAmount,
+          ...(reference.trim() ? { reference: reference.trim() } : {}),
+        })
+      }
+    }
+
+    setProcessing(true)
+    try {
+      const tx = await api.post(
+        '/api/transactions',
+        { storeId, terminalId, staffId: staff.id },
+        TransactionSchema,
+      )
+
+      for (const item of items) {
+        await api.post(
+          `/api/transactions/${tx.id}/items`,
+          { productId: item.product.id, quantity: item.quantity },
+          TransactionSchema,
+        )
+      }
+
+      for (const entry of appliedDiscounts) {
+        await api.post(
+          `/api/transactions/${tx.id}/discount`,
+          { couponCode: entry.couponCode },
+          TransactionSchema,
+        )
+      }
+
+      const result = await api.post(
+        `/api/transactions/${tx.id}/finalize`,
+        { payments },
+        FinalizeTransactionResponseSchema,
+      )
+
+      setReceiptData(result.receipt.receiptData)
+      setReceiptOpen(true)
+      onOpenChange(false)
+    } catch (err) {
+      const isNetworkError =
+        err instanceof TypeError || (!navigator.onLine && !(err instanceof ApiError))
+      if (isNetworkError && storeId && terminalId && staff) {
+        try {
+          const offlineItems: OfflineTransactionItem[] = items.map((item) => ({
+            productId: item.product.id,
+            productName: item.product.name,
+            unitPrice: item.product.price,
+            quantity: item.quantity,
+            taxRateName: '',
+            taxRate: '0',
+            isReducedTax: false,
+          }))
+          const offlinePayments: OfflinePayment[] = payments.map((p) => ({
+            method: p.method,
+            amount: p.amount,
+            ...(p.received != null ? { received: p.received } : {}),
+            ...(p.reference ? { reference: p.reference } : {}),
+          }))
+          await saveOfflineTransaction({
+            clientId: crypto.randomUUID(),
+            storeId,
+            terminalId,
+            staffId: staff.id,
+            items: offlineItems,
+            payments: offlinePayments,
+            createdAt: new Date().toISOString(),
+            syncStatus: 'pending',
+          })
+          toast({
+            title: 'オフライン保存',
+            description:
+              'ネットワークに接続できません。取引をローカルに保存しました。オンライン復帰時に自動同期されます。',
+          })
+          clearCart()
+          clearDiscounts()
+          resetDialogState()
+          onOpenChange(false)
+        } catch {
+          toast({
+            title: 'エラー',
+            description: 'オフライン保存にも失敗しました',
+            variant: 'destructive',
+          })
+        }
+      } else {
+        const message = err instanceof Error ? err.message : '決済処理に失敗しました'
+        toast({ title: 'エラー', description: message, variant: 'destructive' })
+      }
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  async function handleApplyCoupon() {
+    const code = couponCode.trim()
+    if (!code) return
+    if (appliedDiscounts.some((d) => d.couponCode === code)) {
+      toast({ title: 'このクーポンは既に適用されています', variant: 'destructive' })
+      return
+    }
+
+    setCouponValidating(true)
+    try {
+      const result = await api.get(
+        `/api/coupons/validate/${encodeURIComponent(code)}`,
+        ValidateCouponResponseSchema,
+      )
+
+      if (!result.isValid || !result.discount) {
+        toast({
+          title: 'クーポン無効',
+          description: result.reason ?? 'このクーポンは使用できません。',
+          variant: 'destructive',
+        })
+        return
+      }
+
+      addDiscount(code, result.discount, grossTotal)
+      setCouponCode('')
+      toast({ title: `クーポン「${code}」を適用しました` })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'クーポンの検証に失敗しました'
+      toast({ title: 'エラー', description: message, variant: 'destructive' })
+    } finally {
+      setCouponValidating(false)
+    }
+  }
+
+  function handleReceiptClose() {
+    setReceiptOpen(false)
+    setReceiptData(null)
+    clearCart()
+    clearDiscounts()
+    resetDialogState()
+  }
+
+  function handleClose(isOpen: boolean) {
+    if (!processing) {
+      onOpenChange(isOpen)
+      if (!isOpen) resetDialogState()
+    }
+  }
+
+  function handleMethodChange(nextMethod: string) {
+    const method = nextMethod as PaymentMethod
+    setPaymentMethod(method)
+    if (method !== 'CASH' && !paymentAmount) {
+      setPaymentAmount(String(Math.ceil(remainingAmount / 100)))
+    }
+  }
+
+  function handleCashKeypadPress(key: string) {
+    if (key === '⌫') {
+      setReceivedAmount((current) => current.slice(0, -1))
+      return
+    }
+
+    setReceivedAmount((current) => normalizeNumericInput(`${current}${key}`))
+  }
+
+  function handleAddCurrentPayment() {
+    if (!canAddCurrentPayment) return
+
+    setAddedPayments((current) => [
+      ...current,
+      {
+        id: createPaymentEntryId(),
+        method: paymentMethod,
+        amount: parsedPaymentAmount,
+        reference: reference.trim(),
+      },
+    ])
+    setPaymentAmount('')
+    setReference('')
+    setPaymentMethod('CASH')
+  }
+
+  function handleRemovePayment(paymentId: string) {
+    setAddedPayments((current) => current.filter((payment) => payment.id !== paymentId))
+  }
+
+  return {
+    // State
+    items,
+    paymentMethod,
+    paymentAmount,
+    receivedAmount,
+    reference,
+    addedPayments,
+    processing,
+    receiptData,
+    receiptOpen,
+    couponCode,
+    couponValidating,
+    appliedDiscounts,
+
+    // Computed
+    subtotal,
+    grossTotal,
+    taxTotal,
+    discountTotal,
+    total,
+    paidAmount,
+    remainingAmount,
+    roundedRemainingAmount,
+    parsedPaymentAmount,
+    parsedReceivedAmount,
+    remainingAfterCurrent,
+    currentChange,
+    cashShortfall,
+    nonCashShortfall,
+    nonCashOverpayment,
+    canAddCurrentPayment,
+    canFinalize,
+
+    // Setters
+    setPaymentAmount,
+    setReceivedAmount,
+    setReference,
+    setCouponCode,
+
+    // Handlers
+    handleFinalize,
+    handleApplyCoupon,
+    handleReceiptClose,
+    handleClose,
+    handleMethodChange,
+    handleCashKeypadPress,
+    handleAddCurrentPayment,
+    handleRemovePayment,
+    removeDiscount,
+  }
+}


### PR DESCRIPTION
## Summary
- `checkout-dialog.tsx`（745行）を4ファイルに分割
  - `checkout-dialog.tsx` -- 外枠・状態管理のみ（約240行）
  - `payment-cash-tab.tsx` -- 現金支払UI
  - `payment-card-tab.tsx` -- カード/QR支払UI（`mode` propで切替）
  - `use-checkout.ts` -- ビジネスロジックカスタムフック

## Test plan
- [x] `pnpm --filter pos-terminal test` 全187テスト通過
- [x] checkout-dialog.test.tsx の既存14テスト全てパス
- [x] 機能変更なし（リファクタリングのみ）

Closes #482