### PR TITLE
fix: MicroProfile Fault Tolerance 導入（Timeout/CircuitBreaker/Retry）

### DIFF
--- a/services/api-gateway/build.gradle.kts
+++ b/services/api-gateway/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("io.quarkus:quarkus-smallrye-openapi")
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-smallrye-fault-tolerance")
 
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.quarkus:quarkus-junit5-mockito")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AnalyticsResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AnalyticsResource.kt
@@ -17,9 +17,11 @@ import openpos.analytics.v1.GetHourlySalesRequest
 import openpos.analytics.v1.GetSalesForecastRequest
 import openpos.analytics.v1.GetSalesSummaryRequest
 import openpos.common.v1.DateRange
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/analytics")
 @Blocking
+@Timeout(30000)
 class AnalyticsResource {
     @Inject
     @GrpcClient("analytics-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CategoryResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CategoryResource.kt
@@ -18,9 +18,11 @@ import openpos.product.v1.DeleteCategoryRequest
 import openpos.product.v1.ListCategoriesRequest
 import openpos.product.v1.ProductServiceGrpc
 import openpos.product.v1.UpdateCategoryRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/categories")
 @Blocking
+@Timeout(30000)
 class CategoryResource {
     @Inject
     @GrpcClient("product-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/DrawerResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/DrawerResource.kt
@@ -14,9 +14,11 @@ import openpos.pos.v1.CloseDrawerRequest
 import openpos.pos.v1.GetDrawerStatusRequest
 import openpos.pos.v1.OpenDrawerRequest
 import openpos.pos.v1.PosServiceGrpc
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/drawers")
 @Blocking
+@Timeout(30000)
 class DrawerResource {
     @Inject
     @GrpcClient("pos-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GdprResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GdprResource.kt
@@ -16,6 +16,7 @@ import openpos.store.v1.DeleteOrganizationDataRequest
 import openpos.store.v1.GetConsentRequest
 import openpos.store.v1.RecordConsentRequest
 import openpos.store.v1.StoreServiceGrpc
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 /**
  * GDPR / 個人情報保護 REST エンドポイント。
@@ -23,6 +24,7 @@ import openpos.store.v1.StoreServiceGrpc
  */
 @Path("/api/organizations/{id}")
 @Blocking
+@Timeout(30000)
 class GdprResource {
     @Inject
     @GrpcClient("store-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GiftCardResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GiftCardResource.kt
@@ -12,6 +12,7 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 /**
  * ギフトカード REST リソース (#142)。
@@ -19,6 +20,7 @@ import jakarta.ws.rs.core.Response
  */
 @Path("/api/gift-cards")
 @Blocking
+@Timeout(30000)
 class GiftCardResource {
     @Inject
     lateinit var grpc: GrpcClientHelper

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/InventoryResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/InventoryResource.kt
@@ -29,9 +29,11 @@ import openpos.inventory.v1.PurchaseOrderItemInput
 import openpos.inventory.v1.PurchaseOrderStatus
 import openpos.inventory.v1.ReceivedItemInput
 import openpos.inventory.v1.UpdatePurchaseOrderStatusRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/inventory")
 @Blocking
+@Timeout(30000)
 class InventoryResource {
     @Inject
     @GrpcClient("inventory-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/JournalResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/JournalResource.kt
@@ -14,9 +14,11 @@ import openpos.common.v1.DateRange
 import openpos.common.v1.PaginationRequest
 import openpos.pos.v1.ListJournalEntriesRequest
 import openpos.pos.v1.PosServiceGrpc
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/journal")
 @Blocking
+@Timeout(30000)
 class JournalResource {
     @Inject
     @GrpcClient("pos-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/OrganizationResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/OrganizationResource.kt
@@ -15,9 +15,11 @@ import openpos.store.v1.CreateOrganizationRequest
 import openpos.store.v1.GetOrganizationRequest
 import openpos.store.v1.StoreServiceGrpc
 import openpos.store.v1.UpdateOrganizationRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/organizations")
 @Blocking
+@Timeout(30000)
 class OrganizationResource {
     @Inject
     @GrpcClient("store-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductResource.kt
@@ -29,9 +29,11 @@ import openpos.product.v1.ProductServiceGrpc
 import openpos.product.v1.UpdateProductRequest
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/products")
 @Blocking
+@Timeout(30000)
 @Tag(name = "Products", description = "商品管理API")
 class ProductResource {
     @Inject

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SettlementResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SettlementResource.kt
@@ -13,9 +13,11 @@ import jakarta.ws.rs.core.Response
 import openpos.pos.v1.CreateSettlementRequest
 import openpos.pos.v1.GetSettlementRequest
 import openpos.pos.v1.PosServiceGrpc
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/settlements")
 @Blocking
+@Timeout(30000)
 class SettlementResource {
     @Inject
     @GrpcClient("pos-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
@@ -25,9 +25,11 @@ import openpos.store.v1.ListStaffRequest
 import openpos.store.v1.StaffRole
 import openpos.store.v1.StoreServiceGrpc
 import openpos.store.v1.UpdateStaffRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/staff")
 @Blocking
+@Timeout(30000)
 class StaffResource {
     @Inject
     @GrpcClient("store-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StoreResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StoreResource.kt
@@ -24,9 +24,11 @@ import openpos.store.v1.RegisterTerminalRequest
 import openpos.store.v1.StoreServiceGrpc
 import openpos.store.v1.UpdateStoreRequest
 import openpos.store.v1.UpdateTerminalSyncRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/stores")
 @Blocking
+@Timeout(30000)
 class StoreResource {
     @Inject
     @GrpcClient("store-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SyncResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SyncResource.kt
@@ -12,9 +12,11 @@ import openpos.pos.v1.PaymentInput
 import openpos.pos.v1.PaymentMethod
 import openpos.pos.v1.PosServiceGrpc
 import openpos.pos.v1.SyncOfflineTransactionsRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/sync")
 @Blocking
+@Timeout(30000)
 class SyncResource {
     @Inject
     @GrpcClient("pos-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SystemSettingResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SystemSettingResource.kt
@@ -16,9 +16,11 @@ import openpos.store.v1.GetSystemSettingRequest
 import openpos.store.v1.ListSystemSettingsRequest
 import openpos.store.v1.SystemSettingServiceGrpc
 import openpos.store.v1.UpsertSystemSettingRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/settings")
 @Blocking
+@Timeout(30000)
 class SystemSettingResource {
     @Inject
     @GrpcClient("store-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TaxRateResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TaxRateResource.kt
@@ -16,9 +16,11 @@ import openpos.product.v1.CreateTaxRateRequest
 import openpos.product.v1.ListTaxRatesRequest
 import openpos.product.v1.ProductServiceGrpc
 import openpos.product.v1.UpdateTaxRateRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/tax-rates")
 @Blocking
+@Timeout(30000)
 class TaxRateResource {
     @Inject
     @GrpcClient("product-service")

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TransactionResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TransactionResource.kt
@@ -34,9 +34,11 @@ import openpos.pos.v1.TransactionStatus
 import openpos.pos.v1.TransactionType
 import openpos.pos.v1.UpdateTransactionItemRequest
 import openpos.pos.v1.VoidTransactionRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 @Path("/api/transactions")
 @Blocking
+@Timeout(30000)
 class TransactionResource {
     @Inject
     @GrpcClient("pos-service")

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -76,3 +76,8 @@ quarkus.grpc.clients.inventory-service.keep-alive-time=30s
 quarkus.grpc.clients.inventory-service.keep-alive-timeout=5s
 quarkus.grpc.clients.analytics-service.keep-alive-time=30s
 quarkus.grpc.clients.analytics-service.keep-alive-timeout=5s
+
+# MicroProfile Fault Tolerance
+# デフォルトで無効。本番プロファイルのみ有効化。
+MP_Fault_Tolerance_NonFallback_Enabled=false
+%prod.MP_Fault_Tolerance_NonFallback_Enabled=true

--- a/services/pos-service/build.gradle.kts
+++ b/services/pos-service/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("io.quarkus:quarkus-scheduler")
     implementation("io.quarkus:quarkus-arc")
+    implementation("io.quarkus:quarkus-smallrye-fault-tolerance")
 
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.quarkus:quarkus-junit5-mockito")

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ProductServiceClient.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ProductServiceClient.kt
@@ -20,6 +20,8 @@ import openpos.product.v1.ListTaxRatesRequest
 import openpos.product.v1.ProductServiceGrpc
 import openpos.product.v1.TaxRate
 import openpos.product.v1.ValidateCouponRequest
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker
+import org.eclipse.microprofile.faulttolerance.Retry
 import org.jboss.logging.Logger
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -52,6 +54,8 @@ class ProductServiceClient {
         private const val GRPC_DEADLINE_SECONDS = 5L
     }
 
+    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 10000)
+    @Retry(maxRetries = 2, delay = 500)
     fun getProductSnapshot(
         productId: UUID,
         organizationId: UUID,
@@ -177,6 +181,8 @@ class ProductServiceClient {
      * 複数商品のスナップショットを一括取得する（N+1 クエリ防止）。
      * 税率一覧は 1 回だけ取得し、商品ごとの個別取得をまとめて実行する。
      */
+    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 10000)
+    @Retry(maxRetries = 2, delay = 500)
     fun getProductSnapshots(
         productIds: List<UUID>,
         organizationId: UUID,

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -73,6 +73,11 @@ quarkus.otel.propagators=tracecontext,baggage
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 
+# MicroProfile Fault Tolerance
+# デフォルトで無効。本番プロファイルのみ有効化。
+MP_Fault_Tolerance_NonFallback_Enabled=false
+%prod.MP_Fault_Tolerance_NonFallback_Enabled=true
+
 # GCP Secret Manager (prod only)
 # %prod.quarkus.gcp.secret-manager.enabled=true
 


### PR DESCRIPTION
## Summary
- `quarkus-smallrye-fault-tolerance` を api-gateway と pos-service に追加
- api-gateway: gRPC 呼び出しを行う全16リソースクラスに `@Timeout(30000)` を付与
- pos-service `ProductServiceClient`: READ メソッドに `@CircuitBreaker(requestVolumeThreshold=10, failureRatio=0.5, delay=10000)` + `@Retry(maxRetries=2, delay=500)` を付与
- `MP_Fault_Tolerance_NonFallback_Enabled=false` をデフォルトに設定し、本番のみ `%prod.=true` で有効化（CI/E2E 障害防止）

## Test plan
- [x] `./gradlew test` 全テスト通過（6サービス）
- [x] 非本番プロファイルでは Fault Tolerance が無効のため既存テストに影響なし

Closes #503