### PR TITLE
fix: BatchGetProducts RPC で N+1 gRPC 呼び出しを解消

### DIFF
--- a/proto/openpos/product/v1/product.proto
+++ b/proto/openpos/product/v1/product.proto
@@ -23,6 +23,8 @@ service ProductService {
   rpc DeleteProduct(DeleteProductRequest) returns (DeleteProductResponse);
   // バーコードで商品を検索する（POS スキャン時に使用）
   rpc GetProductByBarcode(GetProductByBarcodeRequest) returns (GetProductByBarcodeResponse);
+  // 複数商品を一括取得する（N+1 RPC 防止）
+  rpc BatchGetProducts(BatchGetProductsRequest) returns (BatchGetProductsResponse);
 
   // カテゴリを作成する
   rpc CreateCategory(CreateCategoryRequest) returns (CreateCategoryResponse);
@@ -525,4 +527,16 @@ message ValidateCouponResponse {
   Discount discount = 3;
   // 無効理由（is_valid=false の場合に設定: 例 "EXPIRED", "MAX_USES_REACHED"）
   string reason = 4;
+}
+
+// 複数商品一括取得リクエスト
+message BatchGetProductsRequest {
+  // 取得対象の商品IDリスト（UUID）
+  repeated string ids = 1;
+}
+
+// 複数商品一括取得レスポンス
+message BatchGetProductsResponse {
+  // 取得された商品リスト（見つからなかったIDは含まれない）
+  repeated Product products = 1;
 }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ProductServiceClient.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ProductServiceClient.kt
@@ -13,6 +13,7 @@ import io.quarkus.grpc.GrpcClient
 import io.quarkus.redis.datasource.RedisDataSource
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import openpos.product.v1.BatchGetProductsRequest
 import openpos.product.v1.DiscountType
 import openpos.product.v1.GetProductRequest
 import openpos.product.v1.ListDiscountsRequest
@@ -193,29 +194,33 @@ class ProductServiceClient {
         val taxRatesResponse = stub.listTaxRates(ListTaxRatesRequest.getDefaultInstance())
         val taxRatesById = taxRatesResponse.taxRatesList.associateBy { it.id }
 
-        // 各商品を取得してスナップショットを構築
-        return productIds
-            .distinct()
-            .mapNotNull { productId ->
-                try {
-                    val productResponse =
-                        stub.getProduct(
-                            GetProductRequest.newBuilder().setId(productId.toString()).build(),
-                        )
-                    val product = productResponse.product
-                    val matchedTaxRate = taxRatesById[product.taxRateId] ?: return@mapNotNull null
+        // BatchGetProducts で一括取得（N+1 RPC 防止）
+        val distinctIds = productIds.distinct()
+        val batchRequest =
+            BatchGetProductsRequest
+                .newBuilder()
+                .addAllIds(distinctIds.map { it.toString() })
+                .build()
+        val batchResponse = stub.batchGetProducts(batchRequest)
 
-                    productId to
-                        ProductSnapshot(
-                            name = product.name,
-                            price = product.price,
-                            taxRateName = matchedTaxRate.name,
-                            taxRate = matchedTaxRate.rate,
-                            isReduced = matchedTaxRate.isReduced,
-                        )
-                } catch (_: StatusRuntimeException) {
-                    null
-                }
+        return batchResponse.productsList
+            .mapNotNull { product ->
+                val productId =
+                    try {
+                        UUID.fromString(product.id)
+                    } catch (_: IllegalArgumentException) {
+                        return@mapNotNull null
+                    }
+                val matchedTaxRate = taxRatesById[product.taxRateId] ?: return@mapNotNull null
+
+                productId to
+                    ProductSnapshot(
+                        name = product.name,
+                        price = product.price,
+                        taxRateName = matchedTaxRate.name,
+                        taxRate = matchedTaxRate.rate,
+                        isReduced = matchedTaxRate.isReduced,
+                    )
             }.toMap()
     }
 

--- a/services/product-service/src/main/kotlin/com/openpos/product/grpc/ProductGrpcService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/grpc/ProductGrpcService.kt
@@ -16,6 +16,8 @@ import io.smallrye.common.annotation.Blocking
 import jakarta.inject.Inject
 import jakarta.persistence.OptimisticLockException
 import openpos.common.v1.PaginationResponse
+import openpos.product.v1.BatchGetProductsRequest
+import openpos.product.v1.BatchGetProductsResponse
 import openpos.product.v1.Category
 import openpos.product.v1.Coupon
 import openpos.product.v1.CreateCategoryRequest
@@ -210,6 +212,22 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
                 ?: throw Status.NOT_FOUND.withDescription("Product not found for barcode: ${request.barcode}").asRuntimeException()
         responseObserver.onNext(
             GetProductByBarcodeResponse.newBuilder().setProduct(entity.toProto()).build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun batchGetProducts(
+        request: BatchGetProductsRequest,
+        responseObserver: io.grpc.stub.StreamObserver<BatchGetProductsResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val ids = request.idsList.map { it.toUUID() }
+        val entities = productService.findByIds(ids)
+        responseObserver.onNext(
+            BatchGetProductsResponse
+                .newBuilder()
+                .addAllProducts(entities.map { it.toProto() })
+                .build(),
         )
         responseObserver.onCompleted()
     }

--- a/services/product-service/src/main/kotlin/com/openpos/product/repository/ProductRepository.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/repository/ProductRepository.kt
@@ -19,6 +19,14 @@ class ProductRepository : PanacheRepositoryBase<ProductEntity, UUID> {
     fun findByBarcode(barcode: String): ProductEntity? = find("barcode = ?1", barcode).firstResult()
 
     /**
+     * 複数の商品IDで商品を一括取得する。
+     */
+    fun findByIds(ids: List<UUID>): List<ProductEntity> {
+        if (ids.isEmpty()) return emptyList()
+        return list("id IN ?1 AND deletedAt IS NULL", ids)
+    }
+
+    /**
      * カテゴリIDで商品一覧を取得する。
      */
     fun findByCategoryId(categoryId: UUID): List<ProductEntity> = list("categoryId = ?1 ORDER BY displayOrder ASC", categoryId)

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/ProductService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/ProductService.kt
@@ -72,6 +72,14 @@ class ProductService {
     }
 
     /**
+     * 複数IDで商品を一括取得する。
+     */
+    fun findByIds(ids: List<UUID>): List<ProductEntity> {
+        tenantFilterService.enableFilter()
+        return productRepository.findByIds(ids)
+    }
+
+    /**
      * バーコードで商品を検索する。
      */
     fun findByBarcode(barcode: String): ProductEntity? {


### PR DESCRIPTION
## Summary
- `rpc BatchGetProducts(BatchGetProductsRequest) returns (BatchGetProductsResponse)` を proto に追加
- product-service: `ProductRepository.findByIds(ids: List<UUID>)` を追加（`IN` クエリで一括取得）
- product-service: `ProductGrpcService.batchGetProducts()` を実装
- pos-service: `ProductServiceClient.getProductSnapshots()` を個別 `GetProduct` ループから `BatchGetProducts` 1回に変更

## Test plan
- [x] `buf lint` / `buf format -w` 通過
- [x] `./gradlew test` 全テスト通過（6サービス）
- [x] proto 後方互換性維持（新規 RPC 追加のみ）

Closes #492