### PR TITLE
レビュー指摘 HIGH/MEDIUM 項目を一括修正

### DIFF
--- a/apps/admin-dashboard/src/routes/dashboard.tsx
+++ b/apps/admin-dashboard/src/routes/dashboard.tsx
@@ -139,7 +139,7 @@ export function DashboardPage() {
               <DollarSign className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">
+              <div className="text-2xl font-bold" data-testid="summary-value">
                 {todaySummary ? formatMoney(todaySummary.totalGross) : '...'}
               </div>
               {salesDiff !== null && (
@@ -165,7 +165,7 @@ export function DashboardPage() {
               <ShoppingCart className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">
+              <div className="text-2xl font-bold" data-testid="summary-value">
                 {todaySummary ? todaySummary.totalTransactions.toLocaleString() : '...'}
               </div>
             </CardContent>
@@ -177,7 +177,7 @@ export function DashboardPage() {
               <UserCheck className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">
+              <div className="text-2xl font-bold" data-testid="summary-value">
                 {todaySummary ? formatMoney(todaySummary.averageTransaction) : '...'}
               </div>
             </CardContent>
@@ -189,7 +189,7 @@ export function DashboardPage() {
               <BarChart3 className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">
+              <div className="text-2xl font-bold" data-testid="summary-value">
                 {yesterdaySummary ? formatMoney(yesterdaySummary.totalGross) : '...'}
               </div>
             </CardContent>
@@ -239,7 +239,7 @@ export function DashboardPage() {
                 <card.icon className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">
+                <div className="text-2xl font-bold" data-testid="summary-value">
                   {card.value !== null ? card.value.toLocaleString() : '...'}
                 </div>
               </CardContent>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 allprojects {
     group = "com.openpos"
-    version = "0.1.0-SNAPSHOT"
+    version = "1.0.0"
 
     repositories {
         mavenCentral()
@@ -77,6 +77,9 @@ subprojects {
                     rule {
                         limit {
                             counter = "LINE"
+                            // TODO: 段階的に 80% へ引き上げ予定。現状は全サービスで 80% を満たしていないため
+                            //       ビルドを壊さないよう 30% に設定。新規コードは 80%+ を目標とすること。
+                            //       ロードマップ: 30% → 50% → 65% → 80%
                             minimum = "0.30".toBigDecimal()
                         }
                     }

--- a/e2e/tests/admin-products.spec.ts
+++ b/e2e/tests/admin-products.spec.ts
@@ -17,13 +17,13 @@ test.describe('Admin Smoke', () => {
     const staffCard = page.getByTestId('summary-card-staff')
     const txCard = page.getByTestId('summary-card-transactions')
 
-    await expect(productCard.locator('.text-2xl')).toHaveText('40', { timeout: 15_000 })
-    await expect(storeCard.locator('.text-2xl')).toHaveText('2', { timeout: 15_000 })
-    await expect(staffCard.locator('.text-2xl')).toHaveText('3', { timeout: 15_000 })
+    await expect(productCard.getByTestId('summary-value')).toHaveText('40', { timeout: 15_000 })
+    await expect(storeCard.getByTestId('summary-value')).toHaveText('2', { timeout: 15_000 })
+    await expect(staffCard.getByTestId('summary-value')).toHaveText('3', { timeout: 15_000 })
     await expect
       .poll(
         async () => {
-          const text = await txCard.locator('.text-2xl').textContent()
+          const text = await txCard.getByTestId('summary-value').textContent()
           return Number(text?.trim() ?? '0')
         },
         { timeout: 15_000 },

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/RateLimitFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/RateLimitFilter.kt
@@ -58,7 +58,7 @@ class RateLimitFilter :
 
         val tenantKey = tenantContext.organizationId?.toString() ?: ANONYMOUS_KEY
         val minuteKey = currentMinuteKey()
-        val redisKey = "ratelimit:$tenantKey:$minuteKey"
+        val redisKey = "openpos:api-gateway:ratelimit:$tenantKey:$minuteKey"
 
         val currentCount = tryIncrement(redisKey)
 

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -8,7 +8,7 @@ quarkus.http.port=${QUARKUS_HTTP_PORT:8080}
 
 # CORS
 quarkus.http.cors.enabled=true
-quarkus.http.cors.origins=http://localhost:5173,http://localhost:5174
+quarkus.http.cors.origins=${CORS_ORIGINS:http://localhost:5173,http://localhost:5174}
 quarkus.http.cors.methods=GET,POST,PUT,DELETE,PATCH,OPTIONS
 quarkus.http.cors.headers=accept,authorization,content-type,x-requested-with,x-organization-id
 quarkus.http.cors.exposed-headers=location

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -450,7 +450,7 @@ class TransactionService {
 
     private fun generateTransactionNumber(): String {
         val date = LocalDate.now(ZoneOffset.UTC)
-        val seq = (System.nanoTime() % 1_000_000).toString().padStart(6, '0')
+        val seq = UUID.randomUUID().toString().take(8)
         return "T-$date-$seq"
     }
 


### PR DESCRIPTION
## Summary

コードレビューで指摘された HIGH / MEDIUM 優先度の項目をまとめて修正。

- **H-1**: CORS origins をハードコードから環境変数 `${CORS_ORIGINS}` に変更（デフォルト値は既存値を維持）
- **H-3**: `TransactionService.generateTransactionNumber()` の連番部分を `System.nanoTime() % 1_000_000` から `UUID.randomUUID().toString().take(8)` に変更し、衝突リスクを低減
- **H-4**: ダッシュボードの summary card value に `data-testid="summary-value"` を追加し、E2E テストの CSS セレクタ `.text-2xl` を `getByTestId('summary-value')` に置換
- **H-5**: JaCoCo 閾値は現状 30% のまま据え置き。80% へのロードマップコメントを追記
- **M-1**: プロジェクトバージョンを `0.1.0-SNAPSHOT` から `1.0.0` に更新
- **M-2**: RateLimitFilter の Redis キー名を `openpos:api-gateway:ratelimit:{tenant}:{minute}` 形式に変更（CLAUDE.md のキー名規約に準拠）

## Test plan

- [x] `./gradlew build -x test` ビルド成功を確認
- [x] `pnpm -r typecheck && pnpm -r lint` 成功を確認
- [ ] CI パイプラインの全チェックが通ること
- [ ] E2E テスト (`admin-products.spec.ts`) がダッシュボードテストを通過すること