### PR TITLE
fix(cd): CD パイプラインを tag push 時のみに変更

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,7 +72,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v4
 
       - name: Build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198e362a7d2c83 # v7
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v7
         with:
           context: .
           file: infra/docker/Dockerfile.service


### PR DESCRIPTION
main push のたびに Docker ビルドが走っていた問題を修正。v* タグ時のみに限定。