### PR TITLE
fix: analytics productName プレースホルダーを実商品名に置換

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventDtos.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventDtos.kt
@@ -1,6 +1,9 @@
 package com.openpos.analytics.event
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
 // Re-use same DTO structure as pos-service (shared via JSON contract)
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class EventEnvelopeDto(
     val eventId: String,
     val eventType: String,
@@ -10,6 +13,7 @@ data class EventEnvelopeDto(
     val source: String,
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class SaleCompletedPayload(
     val transactionId: String,
     val storeId: String,
@@ -19,6 +23,7 @@ data class SaleCompletedPayload(
     val transactedAt: String,
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class SaleVoidedPayload(
     val originalTransactionId: String,
     val voidTransactionId: String,
@@ -27,9 +32,11 @@ data class SaleVoidedPayload(
     val originalTransactedAt: String,
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class SaleItemPayload(
     val productId: String,
     val quantity: Int,
     val unitPrice: Long,
     val subtotal: Long,
+    val productName: String? = null,
 )

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/SalesEventProcessor.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/SalesEventProcessor.kt
@@ -49,6 +49,7 @@ class SalesEventProcessor {
                 organizationId,
                 storeId,
                 UUID.fromString(item.productId),
+                item.productName,
                 saleDate,
                 item.quantity,
                 item.subtotal,
@@ -116,6 +117,7 @@ class SalesEventProcessor {
         organizationId: UUID,
         storeId: UUID,
         productId: UUID,
+        productName: String?,
         saleDate: LocalDate,
         quantity: Int,
         subtotal: Long,
@@ -128,7 +130,7 @@ class SalesEventProcessor {
                     this.storeId = storeId
                     this.productId = productId
                     this.date = saleDate
-                    this.productName = "Product-$productId"
+                    this.productName = productName?.ifBlank { "Product-$productId" } ?: "Product-$productId"
                 }
         productSales.quantitySold += quantity
         productSales.totalAmount += subtotal

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/event/SaleCompletedEventDto.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/event/SaleCompletedEventDto.kt
@@ -15,6 +15,7 @@ data class SaleCompletedEventDto(
 
 data class SaleItemDto(
     val productId: String,
+    val productName: String,
     val quantity: Int,
     val unitPrice: Long,
     val subtotal: Long,

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -467,6 +467,7 @@ class TransactionService {
                     items.map { item ->
                         SaleItemDto(
                             productId = item.productId.toString(),
+                            productName = item.productName,
                             quantity = item.quantity,
                             unitPrice = item.unitPrice,
                             subtotal = item.subtotal,
@@ -491,6 +492,7 @@ class TransactionService {
                     items.map { item ->
                         SaleItemDto(
                             productId = item.productId.toString(),
+                            productName = item.productName,
                             quantity = item.quantity,
                             unitPrice = item.unitPrice,
                             subtotal = item.subtotal,


### PR DESCRIPTION
## Summary
- `SaleItemDto` に `productName` フィールド追加（pos-service）
- `SaleItemPayload` に `productName` フィールド追加（analytics-service、nullable、後方互換）
- `SalesEventProcessor.updateProductSales()` で実商品名を使用

## Test plan
- [x] pos-service ビルド・テスト pass
- [x] analytics-service ビルド・テスト pass
- [ ] CI green 確認

Closes #570