### PR TITLE
fix: クーポン割引計算を grossTotal → subtotal ベースに修正

### DIFF
--- a/apps/pos-terminal/src/hooks/use-checkout.ts
+++ b/apps/pos-terminal/src/hooks/use-checkout.ts
@@ -280,7 +280,7 @@ export function useCheckout(onOpenChange: (open: boolean) => void) {
         return
       }
 
-      addDiscount(code, result.discount, grossTotal)
+      addDiscount(code, result.discount, subtotal)
       setCouponCode('')
       toast({ title: `クーポン「${code}」を適用しました` })
     } catch (err) {


### PR DESCRIPTION
## Summary
- `use-checkout.ts:283` の `addDiscount(code, result.discount, grossTotal)` を `subtotal` に修正

## Test plan
- [x] pos-terminal typecheck + 187 tests pass
- [ ] CI green 確認

Closes #604