### PR TITLE
security: Hydra --dev フラグを環境変数で切替可能に

### DIFF
--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -114,7 +114,8 @@ services:
       URLS_LOGIN: http://localhost:3000/login
       URLS_LOGOUT: http://localhost:3000/logout
       LOG_LEVEL: info
-    command: serve all --dev
+    # WARNING: --dev はローカル開発専用。本番では --dev を削除し、TLS を有効化すること。
+    command: serve all ${HYDRA_SERVE_FLAGS:---dev}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- `command: serve all ${HYDRA_SERVE_FLAGS:---dev}` に変更
- 本番では `HYDRA_SERVE_FLAGS=""` で --dev を無効化

Closes #553