### PR TITLE
security: Webhook secret 最小長バリデーション（32文字以上）

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/WebhookResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/WebhookResource.kt
@@ -74,6 +74,12 @@ class WebhookResource {
         validateWebhookUrl(body.url)?.let {
             return Response.status(Response.Status.BAD_REQUEST).entity(mapOf("error" to it)).build()
         }
+        if (body.secret.length < 32) {
+            return Response
+                .status(Response.Status.BAD_REQUEST)
+                .entity(mapOf("error" to "Webhook secret must be at least 32 characters for HMAC-SHA256 security"))
+                .build()
+        }
         val registration =
             webhookStore.register(
                 WebhookRegistration(


### PR DESCRIPTION
## Summary
- `WebhookResource.create()` に secret.length < 32 チェック追加

Closes #568