### PR TITLE
fix: StockEventProcessor で OrganizationIdHolder を設定（在庫減算クラッシュ修正）

### DIFF
--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/StockEventProcessor.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/StockEventProcessor.kt
@@ -1,5 +1,6 @@
 package com.openpos.inventory.event
 
+import com.openpos.inventory.config.OrganizationIdHolder
 import com.openpos.inventory.service.StockService
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -13,10 +14,14 @@ class StockEventProcessor {
     @Inject
     lateinit var stockService: StockService
 
+    @Inject
+    lateinit var organizationIdHolder: OrganizationIdHolder
+
     fun processSaleCompleted(
         organizationId: UUID,
         payload: SaleCompletedPayload,
     ) {
+        organizationIdHolder.organizationId = organizationId
         val storeId = UUID.fromString(payload.storeId)
         for (item in payload.items) {
             stockService.adjustStock(
@@ -34,6 +39,7 @@ class StockEventProcessor {
         organizationId: UUID,
         payload: SaleVoidedPayload,
     ) {
+        organizationIdHolder.organizationId = organizationId
         val storeId = UUID.fromString(payload.storeId)
         for (item in payload.items) {
             stockService.adjustStock(


### PR DESCRIPTION
## Summary
- `processSaleCompleted/Voided` で `organizationIdHolder.organizationId = organizationId` を設定
- RabbitMQ コンテキストでの在庫減算失敗を修正

Closes #564