### PR TITLE
fix: GiftCard.redeem() に悲観的ロック追加（残高二重利用防止）

### DIFF
--- a/services/store-service/src/main/kotlin/com/openpos/store/repository/GiftCardRepository.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/repository/GiftCardRepository.kt
@@ -3,9 +3,12 @@ package com.openpos.store.repository
 import com.openpos.store.entity.GiftCardEntity
 import io.quarkus.hibernate.orm.panache.kotlin.PanacheRepositoryBase
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.persistence.LockModeType
 import java.util.UUID
 
 @ApplicationScoped
 class GiftCardRepository : PanacheRepositoryBase<GiftCardEntity, UUID> {
     fun findByCode(code: String): GiftCardEntity? = find("code", code).firstResult()
+
+    fun findByCodeForUpdate(code: String): GiftCardEntity? = find("code", code).withLock(LockModeType.PESSIMISTIC_WRITE).firstResult()
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/GiftCardService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/GiftCardService.kt
@@ -64,7 +64,7 @@ class GiftCardService {
         amount: Long,
     ): GiftCardEntity? {
         tenantFilterService.enableFilter()
-        val entity = giftCardRepository.findByCode(code) ?: return null
+        val entity = giftCardRepository.findByCodeForUpdate(code) ?: return null
         if (entity.status != "ACTIVE" || entity.balance < amount) return null
         entity.balance -= amount
         if (entity.balance <= 0) entity.status = "USED"

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/GiftCardServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/GiftCardServiceTest.kt
@@ -59,7 +59,7 @@ class GiftCardServiceTest {
                 initialBalance = 500000
                 status = "ACTIVE"
             }
-        whenever(giftCardRepository.findByCode("GIFT-001")).thenReturn(card)
+        whenever(giftCardRepository.findByCodeForUpdate("GIFT-001")).thenReturn(card)
 
         // Act
         val result = service.redeem("GIFT-001", 20000) // 200 yen > 100 yen
@@ -80,7 +80,7 @@ class GiftCardServiceTest {
                 initialBalance = 10000
                 status = "ACTIVE"
             }
-        whenever(giftCardRepository.findByCode("GIFT-001")).thenReturn(card)
+        whenever(giftCardRepository.findByCodeForUpdate("GIFT-001")).thenReturn(card)
 
         // Act
         val result = service.redeem("GIFT-001", 10000)
@@ -125,7 +125,7 @@ class GiftCardServiceTest {
                 initialBalance = 10000
                 status = "USED"
             }
-        whenever(giftCardRepository.findByCode("GIFT-001")).thenReturn(card)
+        whenever(giftCardRepository.findByCodeForUpdate("GIFT-001")).thenReturn(card)
 
         // Act
         val result = service.redeem("GIFT-001", 5000)


### PR DESCRIPTION
## Summary
- GiftCardRepository に `findByCodeForUpdate()` (SELECT FOR UPDATE) 追加
- GiftCardService.redeem() で悲観的ロックを使用し並行残高消費を防止
- テストのモックを findByCodeForUpdate に修正

Closes #569

## Test plan
- [ ] redeem で同時リクエスト時に残高二重消費が発生しないこと
- [ ] 既存テストが全て通ること