### PR TITLE
fix: クーポン割引計算を grossTotal → subtotal ベースに修正

### DIFF
--- a/apps/pos-terminal/src/hooks/use-checkout.ts
+++ b/apps/pos-terminal/src/hooks/use-checkout.ts
@@ -280,7 +280,7 @@ export function useCheckout(onOpenChange: (open: boolean) => void) {
         return
       }
 
-      addDiscount(code, result.discount, grossTotal)
+      addDiscount(code, result.discount, subtotal)
       setCouponCode('')
       toast({ title: `クーポン「${code}」を適用しました` })
     } catch (err) {


### PR DESCRIPTION
## Summary
- use-checkout.ts: addDiscount の計算基準を grossTotal から subtotal に変更
- 税込総額ではなく小計に対して割引を適用するよう修正

Closes #604

## Test plan
- [ ] クーポン適用時の割引額が subtotal ベースで計算されること