### PR TITLE
fix: TenantRequestFilter が不正 UUID を 400 Bad Request で拒否

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/TenantRequestFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/TenantRequestFilter.kt
@@ -5,6 +5,7 @@ import jakarta.inject.Inject
 import jakarta.ws.rs.Priorities
 import jakarta.ws.rs.container.ContainerRequestContext
 import jakarta.ws.rs.container.ContainerRequestFilter
+import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.Provider
 import java.util.UUID
 
@@ -22,7 +23,12 @@ class TenantRequestFilter : ContainerRequestFilter {
             try {
                 tenantContext.organizationId = UUID.fromString(orgIdHeader)
             } catch (_: IllegalArgumentException) {
-                // Invalid UUID — will be caught downstream if required
+                requestContext.abortWith(
+                    Response
+                        .status(Response.Status.BAD_REQUEST)
+                        .entity(mapOf("error" to "Invalid X-Organization-Id header: not a valid UUID"))
+                        .build(),
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- 不正な X-Organization-Id ヘッダー値を受け取った場合、400 Bad Request でリクエストを拒否
- 従来はサイレントに無視していたが、明示的なエラーレスポンスを返すよう修正

Closes #552

## Test plan
- [ ] 不正な UUID を X-Organization-Id に設定して 400 が返ること
- [ ] 正常な UUID の場合は問題なく通過すること