### PR TITLE
fix: transactions_archive に欠落していた5カラムを追加

### DIFF
--- a/services/pos-service/src/main/resources/db/migration/V11__fix_transactions_archive_missing_columns.sql
+++ b/services/pos-service/src/main/resources/db/migration/V11__fix_transactions_archive_missing_columns.sql
@@ -1,0 +1,9 @@
+-- Fix: transactions_archive missing columns added in V5/V5_4/V7 (#617)
+-- These columns exist in the transactions table but were omitted from V8.
+
+ALTER TABLE pos_schema.transactions_archive
+    ADD COLUMN IF NOT EXISTS change_amount  BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS table_number   VARCHAR(20),
+    ADD COLUMN IF NOT EXISTS memo           TEXT,
+    ADD COLUMN IF NOT EXISTS is_training    BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS customer_id    UUID;


### PR DESCRIPTION
## Summary
- V11 マイグレーションで transactions_archive テーブルに5カラム追加
- change_amount, table_number, memo, is_training, customer_id

Closes #617

## Test plan
- [ ] マイグレーション実行で transactions_archive にカラムが追加されること
- [ ] 既存データに影響がないこと（IF NOT EXISTS 使用）