### PR TITLE
fix: ProductServiceClient クーポン系メソッドに CircuitBreaker/Retry 追加

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ProductServiceClient.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ProductServiceClient.kt
@@ -114,6 +114,8 @@ class ProductServiceClient {
     /**
      * クーポンコードを検証し、紐付く割引情報を取得する。
      */
+    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 10000)
+    @Retry(maxRetries = 2, delay = 500)
     fun validateCoupon(
         couponCode: String,
         organizationId: UUID,
@@ -149,6 +151,8 @@ class ProductServiceClient {
     /**
      * 割引IDから割引マスタ情報を取得する。
      */
+    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 10000)
+    @Retry(maxRetries = 2, delay = 500)
     fun getDiscount(
         discountId: UUID,
         organizationId: UUID,


### PR DESCRIPTION
## Summary
- `ProductServiceClient.validateCoupon()` と `getDiscount()` に `@CircuitBreaker` と `@Retry` アノテーションを追加
- product-service が障害時にカスケード障害を防止し、一定回数リトライ後にサーキットブレーカーが開く

## Changes
- `@CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 10000)`
- `@Retry(maxRetries = 2, delay = 500)`

Closes #641