### PR TITLE
fix: StockEventProcessor でイベント処理前に OrganizationId を設定

### DIFF
--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/StockEventProcessor.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/StockEventProcessor.kt
@@ -1,5 +1,6 @@
 package com.openpos.inventory.event
 
+import com.openpos.inventory.config.OrganizationIdHolder
 import com.openpos.inventory.service.StockService
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -13,10 +14,14 @@ class StockEventProcessor {
     @Inject
     lateinit var stockService: StockService
 
+    @Inject
+    lateinit var organizationIdHolder: OrganizationIdHolder
+
     fun processSaleCompleted(
         organizationId: UUID,
         payload: SaleCompletedPayload,
     ) {
+        organizationIdHolder.organizationId = organizationId
         val storeId = UUID.fromString(payload.storeId)
         for (item in payload.items) {
             stockService.adjustStock(
@@ -34,6 +39,7 @@ class StockEventProcessor {
         organizationId: UUID,
         payload: SaleVoidedPayload,
     ) {
+        organizationIdHolder.organizationId = organizationId
         val storeId = UUID.fromString(payload.storeId)
         for (item in payload.items) {
             stockService.adjustStock(


### PR DESCRIPTION
## Summary
- `StockEventProcessor.processSaleCompleted()` と `processSaleVoided()` で `OrganizationIdHolder` に organizationId を設定
- RabbitMQ イベント経由の在庫調整時に Hibernate テナントフィルタが正しく機能するようになる

Closes #564