### PR TITLE
docs: CORS 設定にワイルドカード禁止の WARNING コメント追加

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -7,6 +7,7 @@ quarkus.generate-code.grpc.kotlin.generate=false
 quarkus.http.port=${QUARKUS_HTTP_PORT:8080}
 
 # CORS
+# WARNING: 本番では CORS_ORIGINS に実際のドメインを設定すること（ワイルドカード * は禁止）
 quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=${CORS_ORIGINS:http://localhost:5173,http://localhost:5174}
 quarkus.http.cors.methods=GET,POST,PUT,DELETE,PATCH,OPTIONS


### PR DESCRIPTION
## Summary
- api-gateway の application.properties に CORS_ORIGINS のワイルドカード禁止の警告コメントを追加
- 本番デプロイ時の設定ミスを防止

Closes #556