### PR TITLE
docs: K8s secrets.yaml に本番シークレット直編集禁止の WARNING 追加

### DIFF
--- a/infra/k8s/secrets.yaml
+++ b/infra/k8s/secrets.yaml
@@ -1,6 +1,9 @@
-# Kubernetes Secret for sensitive configuration values.
-# In production, use SealedSecrets, SOPS, or an external-secrets operator
-# to inject real values. The placeholders below must be replaced before apply.
+# WARNING: このファイルを本番シークレットで直接編集しないでください。
+# 本番環境では以下のいずれかを使用すること:
+#   - GCP Secret Manager + External Secrets Operator
+#   - SealedSecrets (Bitnami)
+#   - SOPS + age/GPG
+# このファイルはテンプレートとしてのみ使用し、実際の値をGitにコミットしないこと。
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## Summary
- `infra/k8s/secrets.yaml` のコメントを日本語のセキュリティ警告に置換
- GCP Secret Manager / SealedSecrets / SOPS の使用を推奨
- テンプレートとしてのみ使用し、実際の値を Git にコミットしないよう注意喚起

Closes #561