### PR TITLE
perf: RabbitMQ コンシューマに prefetch=10 を設定

### DIFF
--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -41,6 +41,7 @@ quarkus.log.console.json.additional-field.service.value=${quarkus.application.na
 
 # RabbitMQ Incoming (Event Consumer)
 mp.messaging.incoming.sale-completed-events.connector=smallrye-rabbitmq
+mp.messaging.incoming.sale-completed-events.prefetch=10
 mp.messaging.incoming.sale-completed-events.queue.name=analytics.sale-completed
 mp.messaging.incoming.sale-completed-events.queue.declare=false
 mp.messaging.incoming.sale-completed-events.exchange.name=openpos.events
@@ -51,6 +52,7 @@ mp.messaging.incoming.sale-completed-events.reconnect-attempts=10
 mp.messaging.incoming.sale-completed-events.reconnect-interval=5
 
 mp.messaging.incoming.sale-voided-events.connector=smallrye-rabbitmq
+mp.messaging.incoming.sale-voided-events.prefetch=10
 mp.messaging.incoming.sale-voided-events.queue.name=analytics.sale-voided
 mp.messaging.incoming.sale-voided-events.queue.declare=false
 mp.messaging.incoming.sale-voided-events.exchange.name=openpos.events

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -36,6 +36,7 @@ rabbitmq-password=${RABBITMQ_PASS:openpos_dev}
 
 # RabbitMQ Incoming (Event Consumer)
 mp.messaging.incoming.sale-completed.connector=smallrye-rabbitmq
+mp.messaging.incoming.sale-completed.prefetch=10
 mp.messaging.incoming.sale-completed.queue.name=inventory.sale-completed
 mp.messaging.incoming.sale-completed.queue.declare=false
 mp.messaging.incoming.sale-completed.exchange.name=openpos.events
@@ -46,6 +47,7 @@ mp.messaging.incoming.sale-completed.reconnect-attempts=10
 mp.messaging.incoming.sale-completed.reconnect-interval=5
 
 mp.messaging.incoming.sale-voided.connector=smallrye-rabbitmq
+mp.messaging.incoming.sale-voided.prefetch=10
 mp.messaging.incoming.sale-voided.queue.name=inventory.sale-voided
 mp.messaging.incoming.sale-voided.queue.declare=false
 mp.messaging.incoming.sale-voided.exchange.name=openpos.events


### PR DESCRIPTION
## Summary
- analytics-service と inventory-service の RabbitMQ イベントコンシューマ4チャネルに `prefetch=10` を追加
- デフォルトの prefetch=1 からの変更により、メッセージ処理スループットが向上

Closes #575