### PR TITLE
security: API Gateway にセキュリティレスポンスヘッダーを追加

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -6,6 +6,13 @@ quarkus.shutdown.timeout=30s
 quarkus.generate-code.grpc.kotlin.generate=false
 quarkus.http.port=${QUARKUS_HTTP_PORT:8080}
 
+# Security Headers
+quarkus.http.header."X-Content-Type-Options".value=nosniff
+quarkus.http.header."X-Frame-Options".value=DENY
+quarkus.http.header."Referrer-Policy".value=strict-origin-when-cross-origin
+quarkus.http.header."Permissions-Policy".value=camera=(), microphone=(), geolocation=()
+%prod.quarkus.http.header."Strict-Transport-Security".value=max-age=31536000; includeSubDomains
+
 # CORS
 quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=${CORS_ORIGINS:http://localhost:5173,http://localhost:5174}


### PR DESCRIPTION
## Summary
- X-Content-Type-Options: nosniff（MIME sniffing 防止）
- X-Frame-Options: DENY（クリックジャッキング防止）
- Referrer-Policy: strict-origin-when-cross-origin
- Permissions-Policy: camera/microphone/geolocation 無効化
- Strict-Transport-Security: 本番のみ HSTS 有効化（1年）

Closes #555