### PR TITLE
refactor: java.util.logging を org.jboss.logging に統一

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/DailyReportJob.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/DailyReportJob.kt
@@ -5,7 +5,7 @@ import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import java.time.LocalDate
-import java.util.logging.Logger
+import org.jboss.logging.Logger
 
 /**
  * 日次レポートジョブ。
@@ -18,7 +18,7 @@ class DailyReportJob {
     lateinit var dailySalesRepository: DailySalesRepository
 
     companion object {
-        private val logger: Logger = Logger.getLogger(DailyReportJob::class.java.name)
+        private val logger: Logger = Logger.getLogger(DailyReportJob::class::class.java)
     }
 
     /**

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/AuthFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/AuthFilter.kt
@@ -10,7 +10,7 @@ import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.Provider
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.jwt.JsonWebToken
-import java.util.logging.Logger
+import org.jboss.logging.Logger
 
 /**
  * JWT 認証フィルター。
@@ -33,7 +33,7 @@ class AuthFilter : ContainerRequestFilter {
     lateinit var skipPaths: String
 
     companion object {
-        private val logger: Logger = Logger.getLogger(AuthFilter::class.java.name)
+        private val logger: Logger = Logger.getLogger(AuthFilter::class::class.java)
     }
 
     override fun filter(requestContext: ContainerRequestContext) {
@@ -56,7 +56,7 @@ class AuthFilter : ContainerRequestFilter {
         // Authorization ヘッダーの取得
         val authHeader = requestContext.getHeaderString("Authorization")
         if (authHeader == null || !authHeader.startsWith("Bearer ", ignoreCase = true)) {
-            logger.fine { "Missing or invalid Authorization header for path: $path" }
+            logger.debugf("Missing or invalid Authorization header for path: %s", path)
             requestContext.abortWith(
                 Response
                     .status(Response.Status.UNAUTHORIZED)
@@ -70,7 +70,7 @@ class AuthFilter : ContainerRequestFilter {
         // トークンが無効なら jwt.name は null になる。
         val subject = jwt.subject
         if (subject.isNullOrBlank()) {
-            logger.fine { "JWT validation failed: no subject claim" }
+            logger.debug("JWT validation failed: no subject claim")
             requestContext.abortWith(
                 Response
                     .status(Response.Status.UNAUTHORIZED)

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/AutoReorderHandler.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/AutoReorderHandler.kt
@@ -5,8 +5,8 @@ import com.openpos.inventory.repository.StockRepository
 import com.openpos.inventory.service.PurchaseOrderService
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import org.jboss.logging.Logger
 import java.util.UUID
-import java.util.logging.Logger
 
 /**
  * 在庫自動発注ハンドラー。
@@ -24,7 +24,7 @@ class AutoReorderHandler {
     lateinit var tenantFilterService: TenantFilterService
 
     companion object {
-        private val logger: Logger = Logger.getLogger(AutoReorderHandler::class.java.name)
+        private val logger: Logger = Logger.getLogger(AutoReorderHandler::class::class.java)
     }
 
     /**
@@ -41,7 +41,7 @@ class AutoReorderHandler {
         val stock = stockRepository.findByStoreAndProduct(storeId, productId) ?: return
 
         if (stock.reorderPoint <= 0 || stock.reorderQuantity <= 0) {
-            logger.fine("Auto-reorder skipped: reorderPoint or reorderQuantity not configured for product=$productId")
+            logger.debug("Auto-reorder skipped: reorderPoint or reorderQuantity not configured for product=$productId")
             return
         }
 

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateScheduleService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateScheduleService.kt
@@ -11,7 +11,7 @@ import jakarta.transaction.Transactional
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
-import java.util.logging.Logger
+import org.jboss.logging.Logger
 
 /**
  * 税率変更スケジュールサービス。
@@ -32,7 +32,7 @@ class TaxRateScheduleService {
     lateinit var organizationIdHolder: OrganizationIdHolder
 
     companion object {
-        private val logger: Logger = Logger.getLogger(TaxRateScheduleService::class.java.name)
+        private val logger: Logger = Logger.getLogger(TaxRateScheduleService::class::class.java)
     }
 
     fun listByTaxRateId(taxRateId: UUID): List<TaxRateScheduleEntity> {

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/AuditLogService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/AuditLogService.kt
@@ -5,8 +5,8 @@ import com.openpos.store.repository.AuditLogRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.transaction.Transactional
+import org.jboss.logging.Logger
 import java.util.UUID
-import java.util.logging.Logger
 
 /**
  * 監査ログサービス。
@@ -19,7 +19,7 @@ class AuditLogService {
     lateinit var auditLogRepository: AuditLogRepository
 
     companion object {
-        private val logger: Logger = Logger.getLogger(AuditLogService::class.java.name)
+        private val logger: Logger = Logger.getLogger(AuditLogService::class::class.java)
     }
 
     /**
@@ -54,7 +54,7 @@ class AuditLogService {
                 this.ipAddress = maskIpAddress(ipAddress)
             }
         auditLogRepository.persist(entity)
-        logger.fine { "Audit: $action $entityType ${entityId ?: "(none)"} by ${staffId ?: "system"}" }
+        logger.debugf("Audit: %s %s %s by %s", action, entityType, entityId ?: "(none)", staffId ?: "system")
     }
 
     /**

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/GdprService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/GdprService.kt
@@ -22,7 +22,7 @@ import jakarta.inject.Inject
 import jakarta.transaction.Transactional
 import java.time.Instant
 import java.util.UUID
-import java.util.logging.Logger
+import org.jboss.logging.Logger
 
 /**
  * GDPR / 個人情報保護サービス。
@@ -63,7 +63,7 @@ class GdprService {
     @Inject lateinit var consentRepository: DataProcessingConsentRepository
 
     companion object {
-        private val logger: Logger = Logger.getLogger(GdprService::class.java.name)
+        private val logger: Logger = Logger.getLogger(GdprService::class::class.java)
 
         /** 匿名化に使う固定文字列 */
         const val ANONYMIZED_NAME = "[削除済み]"

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/PlanService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/PlanService.kt
@@ -8,7 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.transaction.Transactional
 import java.util.UUID
-import java.util.logging.Logger
+import org.jboss.logging.Logger
 
 /**
  * プラン・サブスクリプション管理サービス。
@@ -23,7 +23,7 @@ class PlanService {
     lateinit var subscriptionRepository: SubscriptionRepository
 
     companion object {
-        private val logger: Logger = Logger.getLogger(PlanService::class.java.name)
+        private val logger: Logger = Logger.getLogger(PlanService::class::class.java)
     }
 
     fun listPlans(): List<PlanEntity> = planRepository.findActive()

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/WebhookService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/WebhookService.kt
@@ -8,7 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.transaction.Transactional
 import java.util.UUID
-import java.util.logging.Logger
+import org.jboss.logging.Logger
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -29,7 +29,7 @@ class WebhookService {
     lateinit var organizationIdHolder: OrganizationIdHolder
 
     companion object {
-        private val logger: Logger = Logger.getLogger(WebhookService::class.java.name)
+        private val logger: Logger = Logger.getLogger(WebhookService::class::class.java)
     }
 
     fun listByOrganizationId(organizationId: UUID): List<WebhookEntity> {


### PR DESCRIPTION
## Summary
- 8ファイルで `java.util.logging.Logger` を `org.jboss.logging.Logger` に置換
- `logger.fine` を `logger.debug`/`logger.debugf` に変更
- Quarkus の構造化ログ（JSON出力）パイプラインと統合

## Changed files
- analytics-service: DailyReportJob
- api-gateway: AuthFilter
- inventory-service: AutoReorderHandler
- product-service: TaxRateScheduleService
- store-service: AuditLogService, GdprService, PlanService, WebhookService

Closes #618