### PR TITLE
a11y: テーブルステータス色依存解消 + aria-label追加

### DIFF
--- a/apps/pos-terminal/src/components/payment-cash-tab.tsx
+++ b/apps/pos-terminal/src/components/payment-cash-tab.tsx
@@ -53,6 +53,7 @@ export function PaymentCashTab({
           data-testid="checkout-exact-btn"
           variant="outline"
           size="sm"
+          aria-label="正確な金額を自動計算"
           onClick={() => setReceivedAmount(String(Math.ceil(remainingAmount / 100)))}
         >
           ぴったり
@@ -62,12 +63,18 @@ export function PaymentCashTab({
             key={yen}
             variant="outline"
             size="sm"
+            aria-label={`${yen}円を設定`}
             onClick={() => setReceivedAmount(String(yen))}
           >
             ¥{yen.toLocaleString('ja-JP')}
           </Button>
         ))}
-        <Button variant="ghost" size="sm" onClick={() => setReceivedAmount('')}>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="金額をクリア"
+          onClick={() => setReceivedAmount('')}
+        >
           C
         </Button>
       </div>
@@ -87,8 +94,13 @@ export function PaymentCashTab({
       </div>
 
       {cashShortfall > 0 && parsedReceivedAmount > 0 && (
-        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
-          あと {formatMoney(cashShortfall)} 不足しています。
+        <div
+          role="alert"
+          aria-live="polite"
+          className="rounded-lg border-2 border-destructive bg-destructive/5 p-3 text-sm text-destructive"
+        >
+          <span className="font-bold">不足：</span>あと {formatMoney(cashShortfall)}{' '}
+          不足しています。
         </div>
       )}
 

--- a/apps/pos-terminal/src/components/table-layout.tsx
+++ b/apps/pos-terminal/src/components/table-layout.tsx
@@ -35,6 +35,12 @@ const statusLabels: Record<TableStatus, string> = {
   BILL_REQUESTED: '会計待ち',
 }
 
+const statusIcons: Record<TableStatus, string> = {
+  OPEN: '○',
+  OCCUPIED: '●',
+  BILL_REQUESTED: '△',
+}
+
 export function TableLayout({
   tables,
   onSelectTable,
@@ -52,6 +58,7 @@ export function TableLayout({
         {tables.map((table) => (
           <button
             key={table.tableNumber}
+            aria-label={`テーブル${table.tableNumber}: ${statusLabels[table.status]}${table.status !== 'OPEN' ? `, ${table.guestCount}名, ${formatMoney(table.totalAmount)}` : ''}`}
             className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-colors min-h-[100px] ${
               statusColors[table.status]
             } ${selectedTable === table.tableNumber ? 'ring-2 ring-primary' : ''}`}
@@ -62,7 +69,10 @@ export function TableLayout({
             data-testid={`table-${table.tableNumber}`}
           >
             <span className="text-lg font-bold">{table.tableNumber}</span>
-            <span className="text-xs mt-1">{statusLabels[table.status]}</span>
+            <span className="text-xs mt-1" aria-hidden="true">
+              {statusIcons[table.status]}
+            </span>
+            <span className="text-xs">{statusLabels[table.status]}</span>
             {table.status !== 'OPEN' && (
               <>
                 <span className="text-xs mt-1">{table.guestCount}名</span>


### PR DESCRIPTION
## Summary
- テーブルボタンに aria-label + ステータスアイコン（色以外の区別）
- 決済パネルのボタンに aria-label
- 金額不足エラーに role="alert"

Closes #642