### PR TITLE
chore: SBOM生成パイプライン追加（CycloneDX）

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -157,3 +157,29 @@ jobs:
             --ignore-unfixed \
             --format table \
             "openpos-${SERVICE_NAME}:scan"
+
+  sbom:
+    name: SBOM Generation
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Generate npm SBOM
+        run: pnpm --filter pos-terminal exec -- npx @cyclonedx/cyclonedx-npm --output-file sbom-frontend.json || true
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom
+          path: sbom-*.json
+          retention-days: 90


### PR DESCRIPTION
## Summary
- security.yml に SBOM Generation ジョブ追加
- CycloneDX npm で frontend SBOM 生成
- artifact として90日保持

Closes #639