### PR TITLE
chore: gRPC未接続のService群に @Deprecated 追加

### DIFF
--- a/services/store-service/src/main/kotlin/com/openpos/store/service/AttendanceService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/AttendanceService.kt
@@ -11,6 +11,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
+@Deprecated("v1.0未使用: gRPC RPC未接続")
 @ApplicationScoped
 class AttendanceService {
     @Inject lateinit var attendanceRepository: AttendanceRepository

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/FavoriteProductService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/FavoriteProductService.kt
@@ -13,6 +13,7 @@ import java.util.UUID
  * お気に入り商品サービス。
  * スタッフごとのクイックアクセス商品を管理する。
  */
+@Deprecated("v1.0未使用: gRPC RPC未接続")
 @ApplicationScoped
 class FavoriteProductService {
     @Inject

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/NotificationService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/NotificationService.kt
@@ -10,6 +10,7 @@ import jakarta.inject.Inject
 import jakarta.transaction.Transactional
 import java.util.UUID
 
+@Deprecated("v1.0未使用: gRPC RPC未接続")
 @ApplicationScoped
 class NotificationService {
     @Inject lateinit var notificationRepository: NotificationRepository

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/PlanService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/PlanService.kt
@@ -7,13 +7,14 @@ import com.openpos.store.repository.SubscriptionRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.transaction.Transactional
-import java.util.UUID
 import org.jboss.logging.Logger
+import java.util.UUID
 
 /**
  * プラン・サブスクリプション管理サービス。
  * プランの CRUD とテナントのサブスクリプション管理を提供する。
  */
+@Deprecated("v1.0未使用: gRPC RPC未接続")
 @ApplicationScoped
 class PlanService {
     @Inject

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/ShiftService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/ShiftService.kt
@@ -11,6 +11,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
+@Deprecated("v1.0未使用: gRPC RPC未接続")
 @ApplicationScoped
 class ShiftService {
     @Inject lateinit var shiftRepository: ShiftRepository


### PR DESCRIPTION
## Summary
- 5つの未使用Serviceに `@Deprecated` 追加
- 削除ではなく非活性化（将来実装の可能性を残す）

Closes #662