### PR TITLE
security: Grafana 匿名アクセスをデフォルト無効化

### DIFF
--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -428,7 +428,7 @@ services:
       # WARNING: 本番環境では GRAFANA_ADMIN_PASSWORD を変更し、匿名アクセスを無効にしてください
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
-      GF_AUTH_ANONYMOUS_ENABLED: '${GRAFANA_ANONYMOUS_ENABLED:-true}'
+      GF_AUTH_ANONYMOUS_ENABLED: '${GRAFANA_ANONYMOUS_ENABLED:-false}'
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
     volumes:
       - openpos-grafana:/var/lib/grafana


### PR DESCRIPTION
## Summary
- `GF_AUTH_ANONYMOUS_ENABLED` デフォルト true → false

Closes #660