### PR TITLE
security: Egress NetworkPolicy 追加（インフラ通信のみ許可）

### DIFF
--- a/infra/k8s/network-policy.yaml
+++ b/infra/k8s/network-policy.yaml
@@ -95,6 +95,37 @@ spec:
         - protocol: TCP
           port: 9000
 ---
+## Allow backend services to reach infrastructure (DB, Redis, RabbitMQ, Hydra)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-infra-egress
+  namespace: openpos
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: openpos
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 5432 # PostgreSQL
+        - protocol: TCP
+          port: 6379 # Redis
+        - protocol: TCP
+          port: 5672 # RabbitMQ AMQP
+        - protocol: TCP
+          port: 4444 # Hydra Public
+        - protocol: TCP
+          port: 4445 # Hydra Admin
+        - protocol: TCP
+          port: 8080 # inter-service HTTP
+        - protocol: TCP
+          port: 9000 # inter-service gRPC
+---
 ## Allow DNS resolution for all pods
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Summary
- `allow-infra-egress` NetworkPolicy 追加
- openpos Pod からインフラ（DB/Redis/RabbitMQ/Hydra）への egress のみ許可

Closes #656