### PR TITLE
feat: Correlation ID（x-request-id）REST→gRPC伝播

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/CorrelationIdFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/CorrelationIdFilter.kt
@@ -1,0 +1,46 @@
+package com.openpos.gateway.config
+
+import jakarta.annotation.Priority
+import jakarta.ws.rs.Priorities
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerRequestFilter
+import jakarta.ws.rs.container.ContainerResponseContext
+import jakarta.ws.rs.container.ContainerResponseFilter
+import jakarta.ws.rs.ext.Provider
+import org.jboss.logging.MDC
+import java.util.UUID
+
+/**
+ * Correlation ID フィルター。
+ * 全リクエストに x-request-id を付与し、MDC に設定してログ出力に含める。
+ * レスポンスヘッダーにも含めてクライアント側でのトレースを可能にする。
+ */
+@Provider
+@Priority(Priorities.USER - 100)
+class CorrelationIdFilter :
+    ContainerRequestFilter,
+    ContainerResponseFilter {
+    companion object {
+        const val HEADER_NAME = "X-Request-Id"
+        const val MDC_KEY = "requestId"
+    }
+
+    override fun filter(requestContext: ContainerRequestContext) {
+        val requestId =
+            requestContext.getHeaderString(HEADER_NAME)
+                ?: UUID.randomUUID().toString()
+        requestContext.headers.putSingle(HEADER_NAME, requestId)
+        MDC.put(MDC_KEY, requestId)
+    }
+
+    override fun filter(
+        requestContext: ContainerRequestContext,
+        responseContext: ContainerResponseContext,
+    ) {
+        val requestId = requestContext.getHeaderString(HEADER_NAME)
+        if (requestId != null) {
+            responseContext.headers.putSingle(HEADER_NAME, requestId)
+        }
+        MDC.remove(MDC_KEY)
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/TenantClientInterceptor.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/TenantClientInterceptor.kt
@@ -20,6 +20,8 @@ class TenantClientInterceptor : ClientInterceptor {
     companion object {
         private val ORG_ID_KEY: Metadata.Key<String> =
             Metadata.Key.of("x-organization-id", Metadata.ASCII_STRING_MARSHALLER)
+        private val REQUEST_ID_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-request-id", Metadata.ASCII_STRING_MARSHALLER)
     }
 
     override fun <ReqT, RespT> interceptCall(
@@ -36,6 +38,13 @@ class TenantClientInterceptor : ClientInterceptor {
             ) {
                 tenantContext.organizationId?.let { orgId ->
                     headers.put(ORG_ID_KEY, orgId.toString())
+                }
+                // Correlation ID を gRPC metadata に伝播
+                val requestId =
+                    org.jboss.logging.MDC
+                        .get(CorrelationIdFilter.MDC_KEY)
+                if (requestId != null) {
+                    headers.put(REQUEST_ID_KEY, requestId.toString())
                 }
                 super.start(responseListener, headers)
             }


### PR DESCRIPTION
## Summary
- `CorrelationIdFilter` 新規作成（REST全リクエストにx-request-id付与+MDC設定）
- `TenantClientInterceptor` にx-request-id gRPC metadata伝播を追加

Closes #640