### PR TITLE
feat: Promtail によるログ集約を Docker Compose に追加

### DIFF
--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -419,6 +419,24 @@ services:
     networks:
       - openpos-net
 
+  promtail:
+    image: grafana/promtail:3.4.2
+    container_name: openpos-promtail
+    volumes:
+      - /var/log:/var/log:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./promtail/config.yml:/etc/promtail/config.yml:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      loki:
+        condition: service_healthy
+    networks:
+      - openpos-net
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+
   grafana:
     image: grafana/grafana:12.0.1
     container_name: openpos-grafana

--- a/infra/promtail/config.yml
+++ b/infra/promtail/config.yml
@@ -1,0 +1,21 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/openpos-(.*)'
+        target_label: service
+      - source_labels: ['__meta_docker_container_name']
+        target_label: container


### PR DESCRIPTION
## Summary
- `promtail` サービスを compose.yml に追加
- `infra/promtail/config.yml` で Docker ソケットからコンテナログを収集
- service ラベルで openpos-* コンテナを自動検出

Closes #633