### PR TITLE
feat: 電子帳簿保存法対応 — 取引のSHA-256ハッシュ生成

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/entity/TransactionEntity.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/entity/TransactionEntity.kt
@@ -70,6 +70,10 @@ class TransactionEntity : BaseEntity() {
     @Column(name = "deleted", nullable = false)
     var deleted: Boolean = false
 
+    /** 取引内容のSHA-256ハッシュ（電子帳簿保存法 真正性確保） */
+    @Column(name = "content_hash", length = 64)
+    var contentHash: String? = null
+
     /**
      * 楽観的ロック用バージョン番号。
      */

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -334,6 +334,7 @@ class TransactionService {
 
         tx.status = "COMPLETED"
         tx.completedAt = Instant.now()
+        tx.contentHash = computeContentHash(tx, items)
         transactionRepository.persist(tx)
 
         publishSaleCompletedEvent(tx, items)
@@ -453,6 +454,32 @@ class TransactionService {
         val date = LocalDate.now(ZoneOffset.UTC)
         val seq = UUID.randomUUID().toString().take(8)
         return "T-$date-$seq"
+    }
+
+    /**
+     * 取引内容のSHA-256ハッシュを計算する（電子帳簿保存法 真正性確保）。
+     */
+    private fun computeContentHash(
+        tx: TransactionEntity,
+        items: List<TransactionItemEntity>,
+    ): String {
+        val content =
+            buildString {
+                append(tx.id)
+                append(tx.transactionNumber)
+                append(tx.subtotal)
+                append(tx.taxTotal)
+                append(tx.discountTotal)
+                append(tx.total)
+                items.sortedBy { it.id }.forEach { item ->
+                    append(item.productId)
+                    append(item.quantity)
+                    append(item.unitPrice)
+                    append(item.subtotal)
+                }
+            }
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        return digest.digest(content.toByteArray()).joinToString("") { "%02x".format(it) }
     }
 
     private fun publishSaleCompletedEvent(

--- a/services/pos-service/src/main/resources/db/migration/V13__add_content_hash_to_transactions.sql
+++ b/services/pos-service/src/main/resources/db/migration/V13__add_content_hash_to_transactions.sql
@@ -1,0 +1,5 @@
+-- 電子帳簿保存法: 取引データの真正性確保（SHA-256ハッシュ） (#597)
+ALTER TABLE pos_schema.transactions
+    ADD COLUMN IF NOT EXISTS content_hash VARCHAR(64);
+
+COMMENT ON COLUMN pos_schema.transactions.content_hash IS '取引内容のSHA-256ハッシュ。電子帳簿保存法の真正性確保要件。';


### PR DESCRIPTION
## Summary
- V13 migration: `content_hash VARCHAR(64)` カラム追加
- TransactionEntity に `contentHash` フィールド追加
- `computeContentHash()` で取引内容のSHA-256を計算
- `finalizeTransaction()` でハッシュを自動生成・保存

Closes #597