### PR TITLE
feat: add error reporter and enhance Error Boundary

### DIFF
--- a/apps/pos-terminal/src/components/error-boundary.tsx
+++ b/apps/pos-terminal/src/components/error-boundary.tsx
@@ -1,6 +1,7 @@
 import { Component } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
+import { reportError } from '@/lib/error-reporter'
 
 interface ErrorBoundaryProps {
   children: ReactNode
@@ -22,9 +23,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return { hasError: true, error }
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    // eslint-disable-next-line no-console -- intentional error logging for debugging
-    console.error('ErrorBoundary caught an error:', error, errorInfo)
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    reportError(error, { componentStack: _errorInfo.componentStack ?? undefined })
   }
 
   handleReset = () => {

--- a/apps/pos-terminal/src/lib/error-reporter.test.ts
+++ b/apps/pos-terminal/src/lib/error-reporter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { initErrorReporter, reportError, onErrorReport } from './error-reporter'
+
+describe('error-reporter', () => {
+  let cleanup: (() => void) | undefined
+
+  beforeEach(() => {
+    cleanup = undefined
+  })
+
+  afterEach(() => {
+    cleanup?.()
+  })
+
+  it('reportErrorでリスナーに通知される', () => {
+    const listener = vi.fn()
+    const unsub = onErrorReport(listener)
+
+    reportError(new Error('test error'))
+
+    expect(listener).toHaveBeenCalledOnce()
+    expect(listener.mock.calls[0]?.[0]).toMatchObject({
+      message: 'test error',
+    })
+
+    unsub()
+  })
+
+  it('文字列エラーも報告できる', () => {
+    const listener = vi.fn()
+    const unsub = onErrorReport(listener)
+
+    reportError('string error')
+
+    expect(listener).toHaveBeenCalledOnce()
+    expect(listener.mock.calls[0]?.[0]).toMatchObject({
+      message: 'string error',
+    })
+
+    unsub()
+  })
+
+  it('unsubscribeでリスナーが解除される', () => {
+    const listener = vi.fn()
+    const unsub = onErrorReport(listener)
+    unsub()
+
+    reportError('after unsub')
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('initErrorReporterがクリーンアップ関数を返す', () => {
+    cleanup = initErrorReporter()
+    expect(typeof cleanup).toBe('function')
+  })
+
+  it('ErrorReportにタイムスタンプとURLが含まれる', () => {
+    const listener = vi.fn()
+    const unsub = onErrorReport(listener)
+
+    reportError(new Error('with metadata'))
+
+    const report = listener.mock.calls[0]?.[0]
+    expect(report).toHaveProperty('timestamp')
+    expect(report).toHaveProperty('url')
+    expect(report).toHaveProperty('userAgent')
+
+    unsub()
+  })
+})

--- a/apps/pos-terminal/src/lib/error-reporter.ts
+++ b/apps/pos-terminal/src/lib/error-reporter.ts
@@ -1,0 +1,119 @@
+/**
+ * Error reporter for centralized error monitoring.
+ *
+ * Captures unhandled errors and promise rejections via window event listeners.
+ * Currently logs to console.error; replace with Sentry SDK initialization
+ * when a DSN is configured.
+ *
+ * Usage:
+ *   import { initErrorReporter, reportError } from '@/lib/error-reporter'
+ *   initErrorReporter()  // Call once at app startup
+ *   reportError(error)   // Manual error reporting
+ */
+
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('ErrorReporter')
+
+export interface ErrorReport {
+  message: string
+  stack?: string
+  source?: string
+  lineno?: number
+  colno?: number
+  timestamp: string
+  userAgent: string
+  url: string
+}
+
+type ErrorReportListener = (report: ErrorReport) => void
+
+const listeners: Set<ErrorReportListener> = new Set()
+let initialized = false
+
+function buildReport(
+  error: Error | string,
+  extra?: { source?: string; lineno?: number; colno?: number },
+): ErrorReport {
+  const isError = error instanceof Error
+  return {
+    message: isError ? error.message : String(error),
+    stack: isError ? error.stack : undefined,
+    source: extra?.source,
+    lineno: extra?.lineno,
+    colno: extra?.colno,
+    timestamp: new Date().toISOString(),
+    userAgent: navigator.userAgent,
+    url: window.location.href,
+  }
+}
+
+function notifyListeners(report: ErrorReport): void {
+  for (const listener of listeners) {
+    try {
+      listener(report)
+    } catch {
+      // Prevent listener errors from causing infinite loops
+    }
+  }
+}
+
+/**
+ * Subscribe to error reports. Returns an unsubscribe function.
+ */
+export function onErrorReport(listener: ErrorReportListener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * Manually report an error.
+ */
+export function reportError(error: Error | string, context?: Record<string, unknown>): void {
+  const report = buildReport(error)
+  log.error(report.message, { ...report, context })
+  notifyListeners(report)
+}
+
+/**
+ * Initialize global error handlers. Call once at app startup.
+ * Returns a cleanup function to remove event listeners.
+ */
+export function initErrorReporter(): () => void {
+  if (initialized) {
+    log.warn('ErrorReporter already initialized')
+    return () => {}
+  }
+
+  initialized = true
+
+  function handleError(event: ErrorEvent): void {
+    const report = buildReport(event.error instanceof Error ? event.error : event.message, {
+      source: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+    })
+    log.error('Unhandled error', report)
+    notifyListeners(report)
+  }
+
+  function handleUnhandledRejection(event: PromiseRejectionEvent): void {
+    const error = event.reason instanceof Error ? event.reason : String(event.reason)
+    const report = buildReport(error)
+    log.error('Unhandled promise rejection', report)
+    notifyListeners(report)
+  }
+
+  window.addEventListener('error', handleError)
+  window.addEventListener('unhandledrejection', handleUnhandledRejection)
+
+  log.info('Error reporter initialized')
+
+  return () => {
+    window.removeEventListener('error', handleError)
+    window.removeEventListener('unhandledrejection', handleUnhandledRejection)
+    initialized = false
+  }
+}


### PR DESCRIPTION
## Summary
- Added `error-reporter.ts` with global `window.onerror` and `window.onunhandledrejection` capture
- Structured error reports with timestamp, URL, user agent, and stack traces
- Enhanced `ErrorBoundary` to report errors via the centralized reporter
- Sentry DSN integration point ready (add listener via `onErrorReport`)

## Test plan
- [x] `pnpm --filter pos-terminal typecheck` passes
- [x] `pnpm --filter pos-terminal test` — all tests pass (5 new)

Closes #634