### PR TITLE
feat: add H2-based integration test profile for product-service

### DIFF
--- a/services/product-service/src/test/kotlin/com/openpos/product/integration/H2IntegrationTestProfile.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/integration/H2IntegrationTestProfile.kt
@@ -1,0 +1,12 @@
+package com.openpos.product.integration
+
+import io.quarkus.test.junit.QuarkusTestProfile
+
+/**
+ * H2 ベースの結合テストプロファイル。
+ * application-integration.properties を使用し、Testcontainers を必要としない軽量プロファイル。
+ * Redis / RabbitMQ も無効化し、DB アクセスのみをテスト対象とする。
+ */
+class H2IntegrationTestProfile : QuarkusTestProfile {
+    override fun getConfigProfile(): String = "integration"
+}

--- a/services/product-service/src/test/kotlin/com/openpos/product/integration/ProductServiceIntegrationTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/integration/ProductServiceIntegrationTest.kt
@@ -1,0 +1,108 @@
+package com.openpos.product.integration
+
+import com.openpos.product.config.OrganizationIdHolder
+import com.openpos.product.config.TenantFilterService
+import com.openpos.product.entity.ProductEntity
+import com.openpos.product.repository.ProductRepository
+import com.openpos.product.service.ProductService
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import jakarta.persistence.EntityManager
+import jakarta.transaction.Transactional
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * ProductService の結合テスト（H2 ベース）。
+ * CDI コンテナ内で Service → Repository → DB の一連の流れを検証する。
+ */
+@QuarkusTest
+@TestProfile(H2IntegrationTestProfile::class)
+class ProductServiceIntegrationTest {
+    @Inject
+    lateinit var productService: ProductService
+
+    @Inject
+    lateinit var productRepository: ProductRepository
+
+    @Inject
+    lateinit var organizationIdHolder: OrganizationIdHolder
+
+    @Inject
+    lateinit var tenantFilterService: TenantFilterService
+
+    @Inject
+    lateinit var entityManager: EntityManager
+
+    private val testOrgId: UUID = UUID.randomUUID()
+
+    @BeforeEach
+    @Transactional
+    fun setUp() {
+        entityManager.createNativeQuery("DELETE FROM product_schema.products").executeUpdate()
+        organizationIdHolder.organizationId = testOrgId
+        tenantFilterService.enableFilter()
+    }
+
+    @Test
+    @Transactional
+    fun `service layer persists and retrieves product through repository`() {
+        // Arrange
+        val product =
+            ProductEntity().apply {
+                organizationId = testOrgId
+                name = "結合テスト商品"
+                description = "Service経由のテスト"
+                price = 15000L
+                displayOrder = 0
+                isActive = true
+            }
+        productRepository.persist(product)
+
+        // Act
+        val found = productRepository.findById(product.id)
+
+        // Assert
+        assertNotNull(found)
+        requireNotNull(found)
+        assertEquals("結合テスト商品", found.name)
+        assertEquals(15000L, found.price)
+    }
+
+    @Test
+    @Transactional
+    fun `tenant isolation prevents cross-organization access`() {
+        // Arrange: create product under testOrgId
+        val product =
+            ProductEntity().apply {
+                organizationId = testOrgId
+                name = "テナント分離テスト"
+                price = 20000L
+                displayOrder = 0
+                isActive = true
+            }
+        productRepository.persist(product)
+        entityManager.flush()
+
+        // Act: switch to different org and search
+        val differentOrgId = UUID.randomUUID()
+        organizationIdHolder.organizationId = differentOrgId
+        tenantFilterService.enableFilter()
+
+        val results =
+            productRepository.search(
+                null,
+                null,
+                false,
+                io.quarkus.panache.common.Page
+                    .ofSize(10),
+            )
+
+        // Assert: should not find product from different org
+        assertEquals(0, results.size)
+    }
+}

--- a/services/product-service/src/test/resources/application-integration.properties
+++ b/services/product-service/src/test/resources/application-integration.properties
@@ -1,0 +1,34 @@
+# Integration test profile configuration
+# Activated via: -Dquarkus.test.profile=integration
+# or via @TestProfile(IntegrationTestProfile::class)
+
+# Database: H2 in-memory (PostgreSQL compatibility mode)
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:integration_testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS product_schema
+quarkus.datasource.username=sa
+quarkus.datasource.password=
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.database.default-schema=product_schema
+
+# Flyway: disable (Hibernate manages schema in H2 mode)
+quarkus.flyway.migrate-at-start=false
+
+# Redis: disable
+quarkus.redis.devservices.enabled=false
+
+# RabbitMQ: disable
+quarkus.rabbitmq.devservices.enabled=false
+
+# gRPC: random test port
+quarkus.grpc.server.port=0
+quarkus.grpc.server.test-port=0
+
+# HTTP: random test port
+quarkus.http.port=0
+quarkus.http.test-port=0
+
+# Datasource health check: disable (no real DB)
+quarkus.datasource.health.enabled=false
+
+# OpenTelemetry: disable
+quarkus.otel.enabled=false


### PR DESCRIPTION
## Summary
- Added `application-integration.properties` with H2 in-memory DB (PostgreSQL compat mode)
- Redis and RabbitMQ disabled in integration profile
- Added `H2IntegrationTestProfile` for lightweight tests without Testcontainers
- Added `ProductServiceIntegrationTest` with persistence and tenant isolation tests

## Test plan
- [x] `./gradlew :services:product-service:compileTestKotlin` compiles
- [x] `./gradlew :services:product-service:test` passes

Closes #635