### PR TITLE
feat: add property-based tests for money calculations

### DIFF
--- a/apps/pos-terminal/package.json
+++ b/apps/pos-terminal/package.json
@@ -54,6 +54,7 @@
     "eslint": "^10.0.3",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^7.0.0",
+    "fast-check": "^4.6.0",
     "jsdom": "^28.1.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^4.2.1",

--- a/apps/pos-terminal/src/lib/money.property.test.ts
+++ b/apps/pos-terminal/src/lib/money.property.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import { getCartItemSubtotal, getCartEstimatedTax, getCartEstimatedTotal } from './cart-totals'
+import type { CartItem } from '@/stores/cart-store'
+import type { TaxRate } from '@shared-types/openpos'
+
+/**
+ * Property-based tests for money calculations.
+ * Verifies algebraic invariants that must hold for any valid input.
+ */
+
+// Arbitrary for generating valid money amounts (銭単位, non-negative integer)
+const moneyAmount = fc.integer({ min: 0, max: 100_000_000 })
+
+// Arbitrary for generating valid quantities (1-999)
+const quantity = fc.integer({ min: 1, max: 999 })
+
+// Arbitrary for generating valid tax rates (0% to 100%, as decimal string)
+const taxRateValue = fc.integer({ min: 0, max: 10000 }).map((v) => (v / 10000).toString())
+
+const now = '2026-01-01T00:00:00Z'
+
+function makeCartItem(price: number, qty: number, taxRateId?: string): CartItem {
+  return {
+    product: {
+      id: 'prod-1',
+      organizationId: 'org-1',
+      name: 'Test',
+      price,
+      taxRateId: taxRateId ?? null,
+      categoryId: null,
+      barcode: null,
+      isActive: true,
+      displayOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+    },
+    quantity: qty,
+  }
+}
+
+function makeTaxRate(id: string, rate: string): TaxRate {
+  return {
+    id,
+    organizationId: 'org-1',
+    name: 'Standard',
+    rate,
+    isReduced: false,
+    isDefault: false,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+describe('Money property-based tests', () => {
+  it('小計は常に非負である', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, (price, qty) => {
+        const item = makeCartItem(price, qty)
+        expect(getCartItemSubtotal(item)).toBeGreaterThanOrEqual(0)
+      }),
+    )
+  })
+
+  it('小計 = 単価 * 数量 である', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, (price, qty) => {
+        const item = makeCartItem(price, qty)
+        expect(getCartItemSubtotal(item)).toBe(price * qty)
+      }),
+    )
+  })
+
+  it('税額は常に非負である', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, taxRateValue, (price, qty, rate) => {
+        const item = makeCartItem(price, qty, 'tax-1')
+        const taxRates = [makeTaxRate('tax-1', rate)]
+        expect(getCartEstimatedTax([item], taxRates)).toBeGreaterThanOrEqual(0)
+      }),
+    )
+  })
+
+  it('合計 >= 小計 である（税率が非負の場合）', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, taxRateValue, (price, qty, rate) => {
+        const item = makeCartItem(price, qty, 'tax-1')
+        const taxRates = [makeTaxRate('tax-1', rate)]
+        const items = [item]
+        const subtotal = price * qty
+        const total = getCartEstimatedTotal(items, taxRates)
+        expect(total).toBeGreaterThanOrEqual(subtotal)
+      }),
+    )
+  })
+
+  it('税額は Math.floor で切り捨てられる（端数処理の一貫性）', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, taxRateValue, (price, qty, rate) => {
+        const item = makeCartItem(price, qty, 'tax-1')
+        const taxRates = [makeTaxRate('tax-1', rate)]
+        const tax = getCartEstimatedTax([item], taxRates)
+        expect(Number.isInteger(tax)).toBe(true)
+      }),
+    )
+  })
+
+  it('加算の可換性: items の順番を変えても合計は同じ', () => {
+    fc.assert(
+      fc.property(
+        moneyAmount,
+        moneyAmount,
+        quantity,
+        quantity,
+        taxRateValue,
+        (price1, price2, qty1, qty2, rate) => {
+          const item1 = makeCartItem(price1, qty1, 'tax-1')
+          const item2 = makeCartItem(price2, qty2, 'tax-1')
+          // same tax rate -> grouped together, so order shouldn't matter
+          item2.product.id = 'prod-2'
+          const taxRates = [makeTaxRate('tax-1', rate)]
+
+          const totalA = getCartEstimatedTotal([item1, item2], taxRates)
+          const totalB = getCartEstimatedTotal([item2, item1], taxRates)
+          expect(totalA).toBe(totalB)
+        },
+      ),
+    )
+  })
+
+  it('数量0の商品は小計0になる', () => {
+    fc.assert(
+      fc.property(moneyAmount, (price) => {
+        const item = makeCartItem(price, 0)
+        expect(getCartItemSubtotal(item)).toBe(0)
+      }),
+    )
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.0
         version: 7.0.1(eslint@10.0.3(jiti@2.6.1))
+      fast-check:
+        specifier: ^4.6.0
+        version: 4.6.0
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0
@@ -2621,6 +2624,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-check@4.6.0:
+    resolution: {integrity: sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3326,6 +3333,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.3.0:
+    resolution: {integrity: sha512-1ws1Ab8fnsf4bvpL+SujgBnr3KFs5abgCLVzavBp+f2n8Ld5YTOZlkv/ccYPhu3X9s+MEeqPRMqKlJz/kWDK8A==}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -6567,6 +6577,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-check@4.6.0:
+    dependencies:
+      pure-rand: 8.3.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -7238,6 +7252,8 @@ snapshots:
       react-is: 16.13.1
 
   punycode@2.3.1: {}
+
+  pure-rand@8.3.0: {}
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary
- Added `fast-check` as devDependency to pos-terminal
- Created `money.property.test.ts` with 7 property-based tests verifying algebraic invariants:
  - Non-negativity of subtotals and tax
  - Subtotal = price * quantity identity
  - Total >= subtotal for non-negative tax rates
  - Integer tax amounts (floor rounding consistency)
  - Commutativity of item addition
  - Zero quantity edge case

## Test plan
- [x] `pnpm --filter pos-terminal typecheck` passes
- [x] `pnpm --filter pos-terminal test` — all 194 tests pass (7 new property tests)

Closes #652