### PR TITLE
test: raise backend JaCoCo threshold to 95%

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,14 @@ subprojects {
                                     "**/entity/**",
                                     "**/config/**",
                                     "**/resource/**",
+                                    "**/repository/**",
                                     "openpos/**",
+                                    "**/ServiceHealthCheck*",
+                                    "**/ServiceLivenessCheck*",
+                                    "**/ServiceReadinessCheck*",
+                                    "**/HealthResource*",
+                                    "**/ProcessedEventEntity*",
+                                    "**/ProcessedEventRepository*",
                                 )
                             }
                         },
@@ -77,7 +84,7 @@ subprojects {
                     rule {
                         limit {
                             counter = "LINE"
-                            minimum = "0.80".toBigDecimal()
+                            minimum = "0.95".toBigDecimal()
                         }
                     }
                 }
@@ -91,7 +98,14 @@ subprojects {
                                     "**/entity/**",
                                     "**/config/**",
                                     "**/resource/**",
+                                    "**/repository/**",
                                     "openpos/**",
+                                    "**/ServiceHealthCheck*",
+                                    "**/ServiceLivenessCheck*",
+                                    "**/ServiceReadinessCheck*",
+                                    "**/HealthResource*",
+                                    "**/ProcessedEventEntity*",
+                                    "**/ProcessedEventRepository*",
                                 )
                             }
                         },

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/service/ProductAlertServiceUnitTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/service/ProductAlertServiceUnitTest.kt
@@ -1,0 +1,135 @@
+package com.openpos.analytics.service
+
+import com.openpos.analytics.config.OrganizationIdHolder
+import com.openpos.analytics.config.TenantFilterService
+import com.openpos.analytics.entity.ProductAlertEntity
+import com.openpos.analytics.repository.ProductAlertRepository
+import io.quarkus.panache.common.Page
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class ProductAlertServiceUnitTest {
+    private lateinit var service: ProductAlertService
+    private lateinit var productAlertRepository: ProductAlertRepository
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var tenantFilterService: TenantFilterService
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        productAlertRepository = mock()
+        organizationIdHolder = OrganizationIdHolder()
+        tenantFilterService = mock()
+
+        service = ProductAlertService()
+        service.productAlertRepository = productAlertRepository
+        service.organizationIdHolder = organizationIdHolder
+        service.tenantFilterService = tenantFilterService
+
+        organizationIdHolder.organizationId = orgId
+        doNothing().whenever(tenantFilterService).enableFilter()
+        doNothing().whenever(productAlertRepository).persist(any<ProductAlertEntity>())
+    }
+
+    @Nested
+    inner class ListByOrganization {
+        @Test
+        fun `returns alerts with total count`() {
+            val alerts = listOf(createAlert(), createAlert())
+            whenever(productAlertRepository.findByOrganizationId(any(), any<Page>())).thenReturn(alerts)
+            whenever(productAlertRepository.countByOrganizationId(orgId)).thenReturn(5L)
+
+            val (result, count) = service.listByOrganization(orgId, 0, 20)
+
+            assertEquals(2, result.size)
+            assertEquals(5L, count)
+        }
+    }
+
+    @Nested
+    inner class ListUnread {
+        @Test
+        fun `returns unread alerts`() {
+            val alerts = listOf(createAlert(isRead = false))
+            whenever(productAlertRepository.findUnreadByOrganizationId(orgId)).thenReturn(alerts)
+
+            val result = service.listUnread(orgId)
+
+            assertEquals(1, result.size)
+        }
+    }
+
+    @Nested
+    inner class Create {
+        @Test
+        fun `creates alert`() {
+            val productId = UUID.randomUUID()
+
+            val result = service.create(orgId, productId, "TRENDING", "Sales up 50%")
+
+            assertNotNull(result)
+            assertEquals(orgId, result.organizationId)
+            assertEquals("TRENDING", result.alertType)
+            verify(productAlertRepository).persist(any<ProductAlertEntity>())
+        }
+    }
+
+    @Nested
+    inner class MarkAsRead {
+        @Test
+        fun `marks alert as read when owned by current tenant`() {
+            val alertId = UUID.randomUUID()
+            val alert = createAlert(id = alertId, alertOrgId = orgId)
+            whenever(productAlertRepository.findById(alertId)).thenReturn(alert)
+
+            val result = service.markAsRead(alertId)
+
+            assertNotNull(result)
+            assertTrue(result!!.isRead)
+        }
+
+        @Test
+        fun `returns null when alert not found`() {
+            val alertId = UUID.randomUUID()
+            whenever(productAlertRepository.findById(alertId)).thenReturn(null)
+
+            assertNull(service.markAsRead(alertId))
+        }
+
+        @Test
+        fun `returns null when alert belongs to different tenant`() {
+            val alertId = UUID.randomUUID()
+            val otherOrgId = UUID.randomUUID()
+            val alert = createAlert(id = alertId, alertOrgId = otherOrgId)
+            whenever(productAlertRepository.findById(alertId)).thenReturn(alert)
+
+            assertNull(service.markAsRead(alertId))
+        }
+    }
+
+    private fun createAlert(
+        id: UUID = UUID.randomUUID(),
+        isRead: Boolean = false,
+        alertOrgId: UUID = orgId,
+    ): ProductAlertEntity =
+        ProductAlertEntity().apply {
+            this.id = id
+            this.organizationId = alertOrgId
+            this.productId = UUID.randomUUID()
+            this.alertType = "TRENDING"
+            this.description = "Test alert"
+            this.isRead = isRead
+        }
+}

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/cache/RedisCacheServiceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/cache/RedisCacheServiceTest.kt
@@ -2,6 +2,7 @@ package com.openpos.gateway.cache
 
 import io.quarkus.redis.datasource.RedisDataSource
 import io.quarkus.redis.datasource.keys.KeyCommands
+import io.quarkus.redis.datasource.keys.KeyScanCursor
 import io.quarkus.redis.datasource.value.ValueCommands
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -98,16 +99,42 @@ class RedisCacheServiceTest {
             redisCacheService.invalidate()
             verify(keyCommands, never()).del(any<String>())
         }
+
+        @Test
+        fun `Redis例外時は例外をスローせずログ出力する`() {
+            whenever(keyCommands.del(any<String>())).thenThrow(RuntimeException("Connection refused"))
+            redisCacheService.invalidate("openpos:product:123")
+        }
     }
 
     @Nested
     inner class InvalidatePattern {
         @Test
-        fun `Redis例外時はスローせずログ出力する`() {
-            // Arrange: scan が例外を投げる場合
-            whenever(keyCommands.scan(any())).thenThrow(RuntimeException("Connection refused"))
+        fun `SCANでキーを取得して削除する`() {
+            val cursor: KeyScanCursor<String> = mock()
+            whenever(keyCommands.scan(any())).thenReturn(cursor)
+            whenever(cursor.hasNext()).thenReturn(true, false)
+            whenever(cursor.next()).thenReturn(setOf("key1", "key2"))
 
-            // Act (should not throw)
+            redisCacheService.invalidatePattern("openpos:product:*")
+
+            verify(keyCommands).del("key1", "key2")
+        }
+
+        @Test
+        fun `SCANでキーが空の場合はdelが呼ばれない`() {
+            val cursor: KeyScanCursor<String> = mock()
+            whenever(keyCommands.scan(any())).thenReturn(cursor)
+            whenever(cursor.hasNext()).thenReturn(false)
+
+            redisCacheService.invalidatePattern("openpos:product:*")
+
+            verify(keyCommands, never()).del(any<String>())
+        }
+
+        @Test
+        fun `Redis例外時はスローせずログ出力する`() {
+            whenever(keyCommands.scan(any())).thenThrow(RuntimeException("Connection refused"))
             redisCacheService.invalidatePattern("openpos:product:*")
         }
     }

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/webhook/WebhookDeliveryServiceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/webhook/WebhookDeliveryServiceTest.kt
@@ -1,11 +1,13 @@
 package com.openpos.gateway.webhook
 
+import com.sun.net.httpserver.HttpServer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
 import java.time.Instant
 import java.util.UUID
 
@@ -234,6 +236,55 @@ class WebhookDeliveryServiceTest {
             // Assert
             assertEquals(false, deleted)
         }
+
+        @Test
+        fun `update replaces registration in store`() {
+            // Arrange
+            val registration =
+                WebhookRegistration(
+                    organizationId = orgId,
+                    url = "https://example.com/old",
+                    events = listOf("sale.completed"),
+                    secret = "secret",
+                )
+            webhookStore.register(registration)
+
+            // Act
+            val updated = registration.copy(url = "https://example.com/new")
+            webhookStore.update(updated)
+
+            // Assert
+            val found = webhookStore.findById(registration.id)
+            assertNotNull(found)
+            assertEquals("https://example.com/new", found?.url)
+        }
+
+        @Test
+        fun `clear removes all data`() {
+            // Arrange
+            webhookStore.register(
+                WebhookRegistration(
+                    organizationId = orgId,
+                    url = "https://example.com",
+                    events = listOf("sale.completed"),
+                    secret = "secret",
+                ),
+            )
+            webhookStore.recordDelivery(
+                WebhookDelivery(
+                    webhookId = UUID.randomUUID(),
+                    eventType = "sale.completed",
+                    payload = "{}",
+                    status = DeliveryStatus.PENDING,
+                ),
+            )
+
+            // Act
+            webhookStore.clear()
+
+            // Assert
+            assertEquals(0, webhookStore.findByOrganization(orgId).size)
+        }
     }
 
     @Nested
@@ -321,6 +372,92 @@ class WebhookDeliveryServiceTest {
             // Assert
             assertEquals(1, pending.size)
             assertEquals(pastRetry.id, pending[0].id)
+        }
+    }
+
+    @Nested
+    inner class AttemptDeliveryHttpSuccess {
+        @Test
+        fun `marks delivery as SUCCESS when HTTP 200`() {
+            // Arrange: start a simple HTTP server that returns 200
+            val server = HttpServer.create(InetSocketAddress(0), 0)
+            val port = server.address.port
+            server.createContext("/webhook") { exchange ->
+                exchange.sendResponseHeaders(200, 0)
+                exchange.responseBody.close()
+            }
+            server.start()
+
+            try {
+                val webhook =
+                    WebhookRegistration(
+                        organizationId = orgId,
+                        url = "http://localhost:$port/webhook",
+                        events = listOf("sale.completed"),
+                        secret = "test-secret",
+                    )
+                webhookStore.register(webhook)
+
+                val delivery =
+                    WebhookDelivery(
+                        webhookId = webhook.id,
+                        eventType = "sale.completed",
+                        payload = """{"test":true}""",
+                        status = DeliveryStatus.PENDING,
+                    )
+                webhookStore.recordDelivery(delivery)
+
+                // Act
+                val result = deliveryService.attemptDelivery(webhook, delivery)
+
+                // Assert
+                assertEquals(DeliveryStatus.SUCCESS, result.status)
+                assertEquals(200, result.httpStatusCode)
+                assertEquals(1, result.attemptCount)
+                assertNotNull(result.completedAt)
+            } finally {
+                server.stop(0)
+            }
+        }
+
+        @Test
+        fun `marks delivery as RETRYING when HTTP 500`() {
+            val server = HttpServer.create(InetSocketAddress(0), 0)
+            val port = server.address.port
+            server.createContext("/webhook") { exchange ->
+                exchange.sendResponseHeaders(500, 0)
+                exchange.responseBody.close()
+            }
+            server.start()
+
+            try {
+                val webhook =
+                    WebhookRegistration(
+                        organizationId = orgId,
+                        url = "http://localhost:$port/webhook",
+                        events = listOf("sale.completed"),
+                        secret = "test-secret",
+                    )
+                webhookStore.register(webhook)
+
+                val delivery =
+                    WebhookDelivery(
+                        webhookId = webhook.id,
+                        eventType = "sale.completed",
+                        payload = """{"test":true}""",
+                        status = DeliveryStatus.PENDING,
+                        maxRetries = 5,
+                    )
+                webhookStore.recordDelivery(delivery)
+
+                val result = deliveryService.attemptDelivery(webhook, delivery)
+
+                assertEquals(DeliveryStatus.RETRYING, result.status)
+                assertEquals(500, result.httpStatusCode)
+                assertEquals(1, result.attemptCount)
+            } finally {
+                server.stop(0)
+            }
         }
     }
 

--- a/services/product-service/src/test/kotlin/com/openpos/product/cache/ProductCacheServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/cache/ProductCacheServiceTest.kt
@@ -2,6 +2,7 @@ package com.openpos.product.cache
 
 import io.quarkus.redis.datasource.RedisDataSource
 import io.quarkus.redis.datasource.keys.KeyCommands
+import io.quarkus.redis.datasource.keys.KeyScanCursor
 import io.quarkus.redis.datasource.value.ValueCommands
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -132,16 +133,42 @@ class ProductCacheServiceTest {
             // Assert
             verify(keyCommands, never()).del(any<String>())
         }
+
+        @Test
+        fun `Redis例外時は例外をスローせずログ出力する`() {
+            whenever(keyCommands.del(any<String>())).thenThrow(RuntimeException("Connection lost"))
+            cacheService.invalidate("openpos:product-service:product:123")
+        }
     }
 
     @Nested
     inner class InvalidatePattern {
         @Test
-        fun `Redis例外時はスローせずログ出力する`() {
-            // Arrange: scan が例外を投げる場合
-            whenever(keyCommands.scan(any())).thenThrow(RuntimeException("Connection lost"))
+        fun `SCANでキーを取得して削除する`() {
+            val cursor: KeyScanCursor<String> = mock()
+            whenever(keyCommands.scan(any())).thenReturn(cursor)
+            whenever(cursor.hasNext()).thenReturn(true, false)
+            whenever(cursor.next()).thenReturn(setOf("key1", "key2"))
 
-            // Act (should not throw)
+            cacheService.invalidatePattern("openpos:product-service:product:*")
+
+            verify(keyCommands).del("key1", "key2")
+        }
+
+        @Test
+        fun `SCANでキーが空の場合はdelが呼ばれない`() {
+            val cursor: KeyScanCursor<String> = mock()
+            whenever(keyCommands.scan(any())).thenReturn(cursor)
+            whenever(cursor.hasNext()).thenReturn(false)
+
+            cacheService.invalidatePattern("openpos:product-service:product:*")
+
+            verify(keyCommands, never()).del(any<String>())
+        }
+
+        @Test
+        fun `Redis例外時はスローせずログ出力する`() {
+            whenever(keyCommands.scan(any())).thenThrow(RuntimeException("Connection lost"))
             cacheService.invalidatePattern("openpos:product-service:product:*")
         }
     }

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/CategoryServiceUnitTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/CategoryServiceUnitTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -130,6 +131,30 @@ class CategoryServiceUnitTest {
             assertEquals("From DB", result[0].name)
             verify(cacheService).set(eq(cacheKey), any(), eq(3600L))
         }
+
+        @Test
+        fun `handles cache write failure gracefully for listByParentId`() {
+            val cacheKey = "openpos:product-service:$orgId:category:list:null"
+            whenever(cacheService.categoryListKey(eq(null))).thenReturn(cacheKey)
+            whenever(cacheService.get(cacheKey)).thenReturn(null)
+            doThrow(RuntimeException("Redis down")).whenever(cacheService).set(any(), any(), any())
+
+            val dbCategories =
+                listOf(
+                    CategoryEntity().apply {
+                        this.id = UUID.randomUUID()
+                        this.organizationId = orgId
+                        this.name = "Fallback"
+                        this.displayOrder = 1
+                    },
+                )
+            whenever(categoryRepository.findByParentId(null)).thenReturn(dbCategories)
+
+            val result = service.listByParentId(null)
+
+            assertEquals(1, result.size)
+            assertEquals("Fallback", result[0].name)
+        }
     }
 
     @Nested
@@ -205,6 +230,29 @@ class CategoryServiceUnitTest {
         }
 
         @Test
+        fun `handles cache write failure gracefully for findById`() {
+            val categoryId = UUID.randomUUID()
+            val cacheKey = "openpos:product-service:$orgId:category:$categoryId"
+            whenever(cacheService.categoryKey(eq(categoryId.toString()))).thenReturn(cacheKey)
+            whenever(cacheService.get(cacheKey)).thenReturn(null)
+            doThrow(RuntimeException("Redis down")).whenever(cacheService).set(any(), any(), any())
+
+            val entity =
+                CategoryEntity().apply {
+                    this.id = categoryId
+                    this.organizationId = orgId
+                    this.name = "Fallback Entity"
+                    this.displayOrder = 1
+                }
+            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+
+            val result = service.findById(categoryId)
+
+            assertNotNull(result)
+            assertEquals("Fallback Entity", result?.name)
+        }
+
+        @Test
         fun `returns null when not found in DB on cache miss`() {
             val categoryId = UUID.randomUUID()
             val cacheKey = "openpos:product-service:$orgId:category:$categoryId"
@@ -261,6 +309,19 @@ class CategoryServiceUnitTest {
     }
 
     @Nested
+    inner class UpdateNotFound {
+        @Test
+        fun `returns null when category not found`() {
+            val categoryId = UUID.randomUUID()
+            whenever(categoryRepository.findById(categoryId)).thenReturn(null)
+
+            val result = service.update(categoryId, "New", null, null, null, null)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
     inner class DeleteTest {
         @Test
         fun `deletes category and invalidates cache`() {
@@ -279,6 +340,16 @@ class CategoryServiceUnitTest {
 
             assertEquals(true, result)
             verify(cacheService).invalidateCategory(categoryId.toString())
+        }
+
+        @Test
+        fun `returns false when category not found`() {
+            val categoryId = UUID.randomUUID()
+            whenever(categoryRepository.findById(categoryId)).thenReturn(null)
+
+            val result = service.delete(categoryId)
+
+            assertEquals(false, result)
         }
     }
 }

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/DiscountServiceUnitTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/DiscountServiceUnitTest.kt
@@ -1,0 +1,289 @@
+package com.openpos.product.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openpos.product.cache.ProductCacheService
+import com.openpos.product.config.OrganizationIdHolder
+import com.openpos.product.config.TenantFilterService
+import com.openpos.product.entity.DiscountEntity
+import com.openpos.product.repository.DiscountRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.UUID
+
+class DiscountServiceUnitTest {
+    private lateinit var service: DiscountService
+    private lateinit var discountRepository: DiscountRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var cacheService: ProductCacheService
+    private val objectMapper = ObjectMapper().findAndRegisterModules()
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        discountRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+        cacheService = mock()
+
+        service = DiscountService()
+        service.discountRepository = discountRepository
+        service.tenantFilterService = tenantFilterService
+        service.organizationIdHolder = organizationIdHolder
+        service.cacheService = cacheService
+        service.objectMapper = objectMapper
+
+        organizationIdHolder.organizationId = orgId
+        doNothing().whenever(tenantFilterService).enableFilter()
+        doNothing().whenever(discountRepository).persist(any<DiscountEntity>())
+    }
+
+    @Nested
+    inner class FindByIdCache {
+        @Test
+        fun `returns from cache when cache hit`() {
+            val discountId = UUID.randomUUID()
+            // Jackson Kotlin module serializes isActive as "active", so build JSON manually
+            val cachedJson =
+                """
+                {"id":"$discountId","organizationId":"$orgId","name":"Cached Discount",
+                 "discountType":"PERCENTAGE","value":10,"appliesTo":"ALL",
+                 "validFrom":null,"validUntil":null,"isActive":true}
+                """.trimIndent()
+            whenever(cacheService.get(any())).thenReturn(cachedJson)
+
+            val result = service.findById(discountId)
+
+            assertNotNull(result)
+            assertEquals("Cached Discount", result?.name)
+            assertEquals(discountId, result?.id)
+        }
+
+        @Test
+        fun `falls back to DB when cache deserialization fails`() {
+            val discountId = UUID.randomUUID()
+            whenever(cacheService.get(any())).thenReturn("invalid json")
+
+            val entity =
+                DiscountEntity().apply {
+                    this.id = discountId
+                    this.organizationId = orgId
+                    this.name = "DB Discount"
+                    this.discountType = "PERCENTAGE"
+                    this.value = 10
+                    this.isActive = true
+                }
+            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+
+            val result = service.findById(discountId)
+
+            assertNotNull(result)
+            assertEquals("DB Discount", result?.name)
+        }
+
+        @Test
+        fun `caches entity after DB fetch on cache miss`() {
+            val discountId = UUID.randomUUID()
+            whenever(cacheService.get(any())).thenReturn(null)
+            doNothing().whenever(cacheService).set(any(), any(), any())
+
+            val entity =
+                DiscountEntity().apply {
+                    this.id = discountId
+                    this.organizationId = orgId
+                    this.name = "DB Fetched"
+                    this.discountType = "FIXED_AMOUNT"
+                    this.value = 50000
+                    this.isActive = true
+                }
+            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+
+            val result = service.findById(discountId)
+
+            assertNotNull(result)
+            verify(cacheService).set(any(), any(), eq(1800L))
+        }
+
+        @Test
+        fun `returns null when not in cache or DB`() {
+            val discountId = UUID.randomUUID()
+            whenever(cacheService.get(any())).thenReturn(null)
+            whenever(discountRepository.findById(discountId)).thenReturn(null)
+
+            val result = service.findById(discountId)
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `handles cache write failure gracefully`() {
+            val discountId = UUID.randomUUID()
+            whenever(cacheService.get(any())).thenReturn(null)
+            doThrow(RuntimeException("Redis down")).whenever(cacheService).set(any(), any(), any())
+
+            val entity =
+                DiscountEntity().apply {
+                    this.id = discountId
+                    this.organizationId = orgId
+                    this.name = "Fallback"
+                    this.discountType = "PERCENTAGE"
+                    this.value = 5
+                    this.isActive = true
+                }
+            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+
+            val result = service.findById(discountId)
+
+            assertNotNull(result)
+            assertEquals("Fallback", result?.name)
+        }
+    }
+
+    @Nested
+    inner class DiscountCacheDtoTest {
+        @Test
+        fun `toEntity converts DTO with validFrom and validUntil`() {
+            val now = Instant.now()
+            val dto =
+                DiscountCacheDto(
+                    id = UUID.randomUUID(),
+                    organizationId = orgId,
+                    name = "Test",
+                    discountType = "PERCENTAGE",
+                    value = 10,
+                    appliesTo = "ALL",
+                    validFrom = now.toString(),
+                    validUntil = now.plusSeconds(3600).toString(),
+                    isActive = true,
+                )
+
+            val entity = dto.toEntity()
+
+            assertEquals(dto.id, entity.id)
+            assertEquals(dto.name, entity.name)
+            assertNotNull(entity.validFrom)
+            assertNotNull(entity.validUntil)
+        }
+
+        @Test
+        fun `toEntity handles null validFrom and validUntil`() {
+            val dto =
+                DiscountCacheDto(
+                    id = UUID.randomUUID(),
+                    organizationId = orgId,
+                    name = "No Dates",
+                    discountType = "FIXED_AMOUNT",
+                    value = 1000,
+                    appliesTo = "ALL",
+                    validFrom = null,
+                    validUntil = null,
+                    isActive = false,
+                )
+
+            val entity = dto.toEntity()
+
+            assertNull(entity.validFrom)
+            assertNull(entity.validUntil)
+            assertEquals(false, entity.isActive)
+        }
+
+        @Test
+        fun `from creates DTO from entity with dates`() {
+            val now = Instant.now()
+            val entity =
+                DiscountEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    name = "Entity"
+                    discountType = "PERCENTAGE"
+                    value = 20
+                    appliesTo = "ALL"
+                    validFrom = now
+                    validUntil = now.plusSeconds(3600)
+                    isActive = true
+                }
+
+            val dto = DiscountCacheDto.from(entity)
+
+            assertEquals(entity.id, dto.id)
+            assertEquals(now.toString(), dto.validFrom)
+            assertEquals(now.plusSeconds(3600).toString(), dto.validUntil)
+        }
+
+        @Test
+        fun `from creates DTO from entity without dates`() {
+            val entity =
+                DiscountEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    name = "No Dates"
+                    discountType = "FIXED_AMOUNT"
+                    value = 500
+                    appliesTo = "ALL"
+                    validFrom = null
+                    validUntil = null
+                    isActive = true
+                }
+
+            val dto = DiscountCacheDto.from(entity)
+
+            assertNull(dto.validFrom)
+            assertNull(dto.validUntil)
+        }
+    }
+
+    @Nested
+    inner class UpdateCache {
+        @Test
+        fun `update invalidates cache after modifying entity`() {
+            val discountId = UUID.randomUUID()
+            val entity =
+                DiscountEntity().apply {
+                    id = discountId
+                    organizationId = orgId
+                    name = "Old"
+                    discountType = "PERCENTAGE"
+                    value = 10
+                    isActive = true
+                }
+            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            doNothing().whenever(cacheService).invalidate(any())
+            doNothing().whenever(cacheService).invalidatePattern(any())
+
+            val result = service.update(discountId, "New", "FIXED_AMOUNT", 5000L, null, null, false)
+
+            assertNotNull(result)
+            assertEquals("New", result?.name)
+            assertEquals("FIXED_AMOUNT", result?.discountType)
+            assertEquals(5000L, result?.value)
+            assertEquals(false, result?.isActive)
+            verify(cacheService).invalidate(any())
+        }
+    }
+
+    @Nested
+    inner class CreateCache {
+        @Test
+        fun `create invalidates list caches`() {
+            doNothing().whenever(cacheService).invalidatePattern(any())
+
+            val result = service.create("New Discount", "PERCENTAGE", 10, null, null)
+
+            assertNotNull(result)
+            verify(cacheService).invalidatePattern(any())
+        }
+    }
+}

--- a/services/store-service/src/test/kotlin/com/openpos/store/cache/StoreCacheServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/cache/StoreCacheServiceTest.kt
@@ -2,6 +2,7 @@ package com.openpos.store.cache
 
 import io.quarkus.redis.datasource.RedisDataSource
 import io.quarkus.redis.datasource.keys.KeyCommands
+import io.quarkus.redis.datasource.keys.KeyScanCursor
 import io.quarkus.redis.datasource.value.ValueCommands
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -98,6 +99,44 @@ class StoreCacheServiceTest {
         fun `空のキーではdelが呼ばれない`() {
             cacheService.invalidate()
             verify(keyCommands, never()).del(any<String>())
+        }
+
+        @Test
+        fun `Redis例外時は例外をスローせずログ出力する`() {
+            whenever(keyCommands.del(any<String>())).thenThrow(RuntimeException("Connection lost"))
+            cacheService.invalidate("openpos:store-service:store:123")
+        }
+    }
+
+    @Nested
+    inner class InvalidatePattern {
+        @Test
+        fun `SCANでキーを取得して削除する`() {
+            val cursor: KeyScanCursor<String> = mock()
+            whenever(keyCommands.scan(any())).thenReturn(cursor)
+            whenever(cursor.hasNext()).thenReturn(true, false)
+            whenever(cursor.next()).thenReturn(setOf("key1", "key2"))
+
+            cacheService.invalidatePattern("openpos:store-service:store:*")
+
+            verify(keyCommands).del("key1", "key2")
+        }
+
+        @Test
+        fun `SCANでキーが空の場合はdelが呼ばれない`() {
+            val cursor: KeyScanCursor<String> = mock()
+            whenever(keyCommands.scan(any())).thenReturn(cursor)
+            whenever(cursor.hasNext()).thenReturn(false)
+
+            cacheService.invalidatePattern("openpos:store-service:store:*")
+
+            verify(keyCommands, never()).del(any<String>())
+        }
+
+        @Test
+        fun `Redis例外時はスローせずログ出力する`() {
+            whenever(keyCommands.scan(any())).thenThrow(RuntimeException("Connection lost"))
+            cacheService.invalidatePattern("openpos:store-service:store:*")
         }
     }
 

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/AuditLogServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/AuditLogServiceUnitTest.kt
@@ -1,0 +1,110 @@
+package com.openpos.store.service
+
+import com.openpos.store.entity.AuditLogEntity
+import com.openpos.store.repository.AuditLogRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.util.UUID
+
+class AuditLogServiceUnitTest {
+    private val auditLogRepository: AuditLogRepository = mock()
+    private val service =
+        AuditLogService().also {
+            it.auditLogRepository = auditLogRepository
+        }
+
+    private val orgId = UUID.randomUUID()
+
+    @Nested
+    inner class MaskIpAddress {
+        @Test
+        fun `IPv4アドレスの最終オクテットがマスクされる`() {
+            val captor = argumentCaptor<AuditLogEntity>()
+
+            service.log(organizationId = orgId, action = "TEST", entityType = "T", ipAddress = "192.168.1.100")
+
+            verify(auditLogRepository).persist(captor.capture())
+            assertEquals("192.168.1.***", captor.firstValue.ipAddress)
+        }
+
+        @Test
+        fun `IPv6アドレスの最終セグメントがマスクされる`() {
+            val captor = argumentCaptor<AuditLogEntity>()
+
+            service.log(organizationId = orgId, action = "TEST", entityType = "T", ipAddress = "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+
+            verify(auditLogRepository).persist(captor.capture())
+            assertEquals("2001:0db8:85a3:0000:0000:8a2e:0370:***", captor.firstValue.ipAddress)
+        }
+
+        @Test
+        fun `nullのIPアドレスはnullのまま`() {
+            val captor = argumentCaptor<AuditLogEntity>()
+
+            service.log(organizationId = orgId, action = "TEST", entityType = "T", ipAddress = null)
+
+            verify(auditLogRepository).persist(captor.capture())
+            assertNull(captor.firstValue.ipAddress)
+        }
+
+        @Test
+        fun `コロンなしの非IPv4文字列はそのまま返される`() {
+            val captor = argumentCaptor<AuditLogEntity>()
+
+            service.log(organizationId = orgId, action = "TEST", entityType = "T", ipAddress = "unknown-format")
+
+            verify(auditLogRepository).persist(captor.capture())
+            assertEquals("unknown-format", captor.firstValue.ipAddress)
+        }
+    }
+
+    @Nested
+    inner class LogMethod {
+        @Test
+        fun `全フィールドが正しく設定される`() {
+            val staffId = UUID.randomUUID()
+            val captor = argumentCaptor<AuditLogEntity>()
+
+            service.log(
+                organizationId = orgId,
+                staffId = staffId,
+                action = "CREATE",
+                entityType = "STAFF",
+                entityId = "entity-123",
+                details = """{"name":"test"}""",
+                ipAddress = "10.0.0.1",
+            )
+
+            verify(auditLogRepository).persist(captor.capture())
+            val entity = captor.firstValue
+            assertEquals(orgId, entity.organizationId)
+            assertEquals(staffId, entity.staffId)
+            assertEquals("CREATE", entity.action)
+            assertEquals("STAFF", entity.entityType)
+            assertEquals("entity-123", entity.entityId)
+            assertEquals("""{"name":"test"}""", entity.details)
+            assertEquals("10.0.0.***", entity.ipAddress)
+            assertNotNull(entity.createdAt)
+        }
+
+        @Test
+        fun `デフォルト値で記録できる`() {
+            val captor = argumentCaptor<AuditLogEntity>()
+
+            service.log(organizationId = orgId, action = "SYSTEM", entityType = "STORE")
+
+            verify(auditLogRepository).persist(captor.capture())
+            val entity = captor.firstValue
+            assertNull(entity.staffId)
+            assertNull(entity.entityId)
+            assertEquals("{}", entity.details)
+            assertNull(entity.ipAddress)
+        }
+    }
+}

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/CustomerServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/CustomerServiceUnitTest.kt
@@ -1,0 +1,204 @@
+package com.openpos.store.service
+
+import com.openpos.store.config.OrganizationIdHolder
+import com.openpos.store.config.TenantFilterService
+import com.openpos.store.entity.CustomerEntity
+import com.openpos.store.entity.PointTransactionEntity
+import com.openpos.store.repository.CustomerRepository
+import com.openpos.store.repository.PointTransactionRepository
+import io.quarkus.panache.common.Page
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class CustomerServiceUnitTest {
+    private lateinit var service: CustomerService
+    private lateinit var customerRepository: CustomerRepository
+    private lateinit var pointTransactionRepository: PointTransactionRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        customerRepository = mock()
+        pointTransactionRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        service = CustomerService()
+        service.customerRepository = customerRepository
+        service.pointTransactionRepository = pointTransactionRepository
+        service.tenantFilterService = tenantFilterService
+        service.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = orgId
+        doNothing().whenever(tenantFilterService).enableFilter()
+        doNothing().whenever(customerRepository).persist(any<CustomerEntity>())
+        doNothing().whenever(pointTransactionRepository).persist(any<PointTransactionEntity>())
+    }
+
+    @Nested
+    inner class FindById {
+        @Test
+        fun `returns customer when found`() {
+            val customerId = UUID.randomUUID()
+            val entity =
+                CustomerEntity().apply {
+                    id = customerId
+                    organizationId = orgId
+                    name = "Test"
+                }
+            whenever(customerRepository.findById(customerId)).thenReturn(entity)
+
+            val result = service.findById(customerId)
+
+            assertNotNull(result)
+            assertEquals("Test", result?.name)
+            verify(tenantFilterService).enableFilter()
+        }
+
+        @Test
+        fun `returns null when not found`() {
+            val customerId = UUID.randomUUID()
+            whenever(customerRepository.findById(customerId)).thenReturn(null)
+
+            val result = service.findById(customerId)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class List {
+        @Test
+        fun `returns paginated list with total count`() {
+            val customers =
+                listOf(
+                    CustomerEntity().apply {
+                        id = UUID.randomUUID()
+                        organizationId = orgId
+                        name = "Customer A"
+                    },
+                )
+            whenever(customerRepository.listPaginated(any<Page>())).thenReturn(customers)
+            whenever(customerRepository.count()).thenReturn(10L)
+
+            val (result, total) = service.list(0, 20)
+
+            assertEquals(1, result.size)
+            assertEquals(10L, total)
+        }
+    }
+
+    @Nested
+    inner class Update {
+        @Test
+        fun `updates customer fields selectively`() {
+            val customerId = UUID.randomUUID()
+            val entity =
+                CustomerEntity().apply {
+                    id = customerId
+                    organizationId = orgId
+                    name = "Old Name"
+                    email = "old@test.com"
+                    phone = "090-0000-0000"
+                }
+            whenever(customerRepository.findById(customerId)).thenReturn(entity)
+
+            val result = service.update(customerId, "New Name", null, "090-1111-1111")
+
+            assertNotNull(result)
+            assertEquals("New Name", result?.name)
+            assertEquals("old@test.com", result?.email)
+            assertEquals("090-1111-1111", result?.phone)
+        }
+
+        @Test
+        fun `returns null when customer not found`() {
+            val customerId = UUID.randomUUID()
+            whenever(customerRepository.findById(customerId)).thenReturn(null)
+
+            val result = service.update(customerId, "New", null, null)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class EarnPoints {
+        @Test
+        fun `throws when customer not found`() {
+            val customerId = UUID.randomUUID()
+            whenever(customerRepository.findById(customerId)).thenReturn(null)
+
+            assertThrows(IllegalArgumentException::class.java) {
+                service.earnPoints(customerId, 50000, null)
+            }
+        }
+
+        @Test
+        fun `earns points with transactionId`() {
+            val customerId = UUID.randomUUID()
+            val txId = UUID.randomUUID()
+            val customer =
+                CustomerEntity().apply {
+                    id = customerId
+                    organizationId = orgId
+                    name = "Test"
+                    points = 0
+                }
+            whenever(customerRepository.findById(customerId)).thenReturn(customer)
+
+            val earned = service.earnPoints(customerId, 100000, txId)
+
+            assertEquals(10L, earned)
+            assertEquals(10, customer.points)
+            verify(pointTransactionRepository).persist(any<PointTransactionEntity>())
+        }
+    }
+
+    @Nested
+    inner class RedeemPoints {
+        @Test
+        fun `throws when customer not found`() {
+            val customerId = UUID.randomUUID()
+            whenever(customerRepository.findByIdForUpdate(customerId)).thenReturn(null)
+
+            assertThrows(IllegalArgumentException::class.java) {
+                service.redeemPoints(customerId, 10, null)
+            }
+        }
+
+        @Test
+        fun `redeems with transactionId`() {
+            val customerId = UUID.randomUUID()
+            val txId = UUID.randomUUID()
+            val customer =
+                CustomerEntity().apply {
+                    id = customerId
+                    organizationId = orgId
+                    name = "Test"
+                    points = 100
+                }
+            whenever(customerRepository.findByIdForUpdate(customerId)).thenReturn(customer)
+
+            val result = service.redeemPoints(customerId, 30, txId)
+
+            assertEquals(true, result)
+            assertEquals(70, customer.points)
+            verify(pointTransactionRepository).persist(any<PointTransactionEntity>())
+        }
+    }
+}

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/FavoriteProductServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/FavoriteProductServiceUnitTest.kt
@@ -1,0 +1,100 @@
+package com.openpos.store.service
+
+import com.openpos.store.config.OrganizationIdHolder
+import com.openpos.store.config.TenantFilterService
+import com.openpos.store.entity.FavoriteProductEntity
+import com.openpos.store.repository.FavoriteProductRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class FavoriteProductServiceUnitTest {
+    private lateinit var service: FavoriteProductService
+    private lateinit var favoriteProductRepository: FavoriteProductRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        favoriteProductRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        service = FavoriteProductService()
+        service.favoriteProductRepository = favoriteProductRepository
+        service.tenantFilterService = tenantFilterService
+        service.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = orgId
+        doNothing().whenever(tenantFilterService).enableFilter()
+        doNothing().whenever(favoriteProductRepository).persist(any<FavoriteProductEntity>())
+        doNothing().whenever(favoriteProductRepository).delete(any<FavoriteProductEntity>())
+    }
+
+    @Nested
+    inner class Toggle {
+        @Test
+        fun `adds favorite when not exists`() {
+            val staffId = UUID.randomUUID()
+            val productId = UUID.randomUUID()
+            whenever(favoriteProductRepository.findByStaffAndProduct(staffId, productId)).thenReturn(null)
+
+            val result = service.toggle(staffId, productId)
+
+            assertTrue(result)
+            verify(favoriteProductRepository).persist(any<FavoriteProductEntity>())
+        }
+
+        @Test
+        fun `removes favorite when exists`() {
+            val staffId = UUID.randomUUID()
+            val productId = UUID.randomUUID()
+            val existing =
+                FavoriteProductEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    this.staffId = staffId
+                    this.productId = productId
+                }
+            whenever(favoriteProductRepository.findByStaffAndProduct(staffId, productId)).thenReturn(existing)
+
+            val result = service.toggle(staffId, productId)
+
+            assertFalse(result)
+            verify(favoriteProductRepository).delete(existing)
+        }
+    }
+
+    @Nested
+    inner class ListByStaffId {
+        @Test
+        fun `returns favorites for staff`() {
+            val staffId = UUID.randomUUID()
+            val fav =
+                FavoriteProductEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    this.staffId = staffId
+                    productId = UUID.randomUUID()
+                    sortOrder = 0
+                }
+            whenever(favoriteProductRepository.findByStaffId(staffId)).thenReturn(listOf(fav))
+
+            val result = service.listByStaffId(staffId)
+
+            assertEquals(1, result.size)
+            verify(tenantFilterService).enableFilter()
+        }
+    }
+}

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/GiftCardServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/GiftCardServiceUnitTest.kt
@@ -1,0 +1,238 @@
+package com.openpos.store.service
+
+import com.openpos.store.config.OrganizationIdHolder
+import com.openpos.store.config.TenantFilterService
+import com.openpos.store.entity.GiftCardEntity
+import com.openpos.store.repository.GiftCardRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class GiftCardServiceUnitTest {
+    private lateinit var service: GiftCardService
+    private lateinit var giftCardRepository: GiftCardRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        giftCardRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        service = GiftCardService()
+        service.giftCardRepository = giftCardRepository
+        service.tenantFilterService = tenantFilterService
+        service.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = orgId
+        doNothing().whenever(tenantFilterService).enableFilter()
+        doNothing().whenever(giftCardRepository).persist(any<GiftCardEntity>())
+    }
+
+    @Nested
+    inner class Activate {
+        @Test
+        fun `creates gift card with ACTIVE status`() {
+            val result = service.activate("GIFT-001", 500000)
+
+            assertEquals("GIFT-001", result.code)
+            assertEquals(500000L, result.balance)
+            assertEquals(500000L, result.initialBalance)
+            assertEquals("ACTIVE", result.status)
+            assertEquals(orgId, result.organizationId)
+            verify(giftCardRepository).persist(any<GiftCardEntity>())
+        }
+    }
+
+    @Nested
+    inner class FindByCode {
+        @Test
+        fun `returns card when found`() {
+            val card =
+                GiftCardEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    code = "GIFT-001"
+                    balance = 10000
+                    initialBalance = 10000
+                    status = "ACTIVE"
+                }
+            whenever(giftCardRepository.findByCode("GIFT-001")).thenReturn(card)
+
+            val result = service.findByCode("GIFT-001")
+
+            assertNotNull(result)
+            assertEquals("GIFT-001", result?.code)
+        }
+
+        @Test
+        fun `returns null when not found`() {
+            whenever(giftCardRepository.findByCode("NONE")).thenReturn(null)
+
+            assertNull(service.findByCode("NONE"))
+        }
+    }
+
+    @Nested
+    inner class FindById {
+        @Test
+        fun `returns card when found`() {
+            val cardId = UUID.randomUUID()
+            val card =
+                GiftCardEntity().apply {
+                    id = cardId
+                    organizationId = orgId
+                    code = "GIFT-002"
+                    balance = 20000
+                    initialBalance = 20000
+                    status = "ACTIVE"
+                }
+            whenever(giftCardRepository.findById(cardId)).thenReturn(card)
+
+            val result = service.findById(cardId)
+
+            assertNotNull(result)
+        }
+    }
+
+    @Nested
+    inner class Charge {
+        @Test
+        fun `adds balance to active card`() {
+            val card =
+                GiftCardEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    code = "GIFT-001"
+                    balance = 10000
+                    initialBalance = 10000
+                    status = "ACTIVE"
+                }
+            whenever(giftCardRepository.findByCode("GIFT-001")).thenReturn(card)
+
+            val result = service.charge("GIFT-001", 50000)
+
+            assertNotNull(result)
+            assertEquals(60000L, result?.balance)
+        }
+
+        @Test
+        fun `returns null for non-ACTIVE card`() {
+            val card =
+                GiftCardEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    code = "GIFT-001"
+                    balance = 10000
+                    initialBalance = 10000
+                    status = "USED"
+                }
+            whenever(giftCardRepository.findByCode("GIFT-001")).thenReturn(card)
+
+            val result = service.charge("GIFT-001", 50000)
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `returns null when card not found`() {
+            whenever(giftCardRepository.findByCode("NONE")).thenReturn(null)
+
+            assertNull(service.charge("NONE", 50000))
+        }
+    }
+
+    @Nested
+    inner class Redeem {
+        @Test
+        fun `deducts balance and sets USED when zero`() {
+            val card =
+                GiftCardEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    code = "GIFT-001"
+                    balance = 10000
+                    initialBalance = 10000
+                    status = "ACTIVE"
+                }
+            whenever(giftCardRepository.findByCodeForUpdate("GIFT-001")).thenReturn(card)
+
+            val result = service.redeem("GIFT-001", 10000)
+
+            assertNotNull(result)
+            assertEquals(0L, result?.balance)
+            assertEquals("USED", result?.status)
+        }
+
+        @Test
+        fun `deducts balance partially`() {
+            val card =
+                GiftCardEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    code = "GIFT-001"
+                    balance = 50000
+                    initialBalance = 50000
+                    status = "ACTIVE"
+                }
+            whenever(giftCardRepository.findByCodeForUpdate("GIFT-001")).thenReturn(card)
+
+            val result = service.redeem("GIFT-001", 20000)
+
+            assertNotNull(result)
+            assertEquals(30000L, result?.balance)
+            assertEquals("ACTIVE", result?.status)
+        }
+
+        @Test
+        fun `returns null for insufficient balance`() {
+            val card =
+                GiftCardEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    code = "GIFT-001"
+                    balance = 1000
+                    initialBalance = 10000
+                    status = "ACTIVE"
+                }
+            whenever(giftCardRepository.findByCodeForUpdate("GIFT-001")).thenReturn(card)
+
+            assertNull(service.redeem("GIFT-001", 5000))
+        }
+
+        @Test
+        fun `returns null for non-ACTIVE card`() {
+            val card =
+                GiftCardEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    code = "GIFT-001"
+                    balance = 10000
+                    initialBalance = 10000
+                    status = "USED"
+                }
+            whenever(giftCardRepository.findByCodeForUpdate("GIFT-001")).thenReturn(card)
+
+            assertNull(service.redeem("GIFT-001", 5000))
+        }
+
+        @Test
+        fun `returns null when card not found`() {
+            whenever(giftCardRepository.findByCodeForUpdate("NONE")).thenReturn(null)
+
+            assertNull(service.redeem("NONE", 5000))
+        }
+    }
+}

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/PlanServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/PlanServiceUnitTest.kt
@@ -1,0 +1,174 @@
+package com.openpos.store.service
+
+import com.openpos.store.entity.PlanEntity
+import com.openpos.store.entity.SubscriptionEntity
+import com.openpos.store.repository.PlanRepository
+import com.openpos.store.repository.SubscriptionRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class PlanServiceUnitTest {
+    private lateinit var service: PlanService
+    private lateinit var planRepository: PlanRepository
+    private lateinit var subscriptionRepository: SubscriptionRepository
+
+    @BeforeEach
+    fun setUp() {
+        planRepository = mock()
+        subscriptionRepository = mock()
+
+        service = PlanService()
+        service.planRepository = planRepository
+        service.subscriptionRepository = subscriptionRepository
+
+        doNothing().whenever(planRepository).persist(any<PlanEntity>())
+        doNothing().whenever(subscriptionRepository).persist(any<SubscriptionEntity>())
+    }
+
+    @Nested
+    inner class ListPlans {
+        @Test
+        fun `returns active plans`() {
+            val plans =
+                listOf(
+                    PlanEntity().apply {
+                        id = UUID.randomUUID()
+                        name = "Free"
+                        maxStores = 1
+                        maxTerminals = 2
+                        maxProducts = 100
+                        monthlyPrice = 0
+                    },
+                )
+            whenever(planRepository.findActive()).thenReturn(plans)
+
+            val result = service.listPlans()
+
+            assertEquals(1, result.size)
+            assertEquals("Free", result[0].name)
+        }
+    }
+
+    @Nested
+    inner class FindPlanById {
+        @Test
+        fun `returns plan when found`() {
+            val planId = UUID.randomUUID()
+            val plan =
+                PlanEntity().apply {
+                    id = planId
+                    name = "Pro"
+                    maxStores = 10
+                    maxTerminals = 50
+                    maxProducts = 10000
+                    monthlyPrice = 500000
+                }
+            whenever(planRepository.findById(planId)).thenReturn(plan)
+
+            val result = service.findPlanById(planId)
+
+            assertNotNull(result)
+            assertEquals("Pro", result?.name)
+        }
+
+        @Test
+        fun `returns null when not found`() {
+            val planId = UUID.randomUUID()
+            whenever(planRepository.findById(planId)).thenReturn(null)
+
+            val result = service.findPlanById(planId)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class CreatePlan {
+        @Test
+        fun `creates plan with correct fields`() {
+            val result = service.createPlan("Starter", 3, 10, 1000, 298000)
+
+            assertEquals("Starter", result.name)
+            assertEquals(3, result.maxStores)
+            assertEquals(10, result.maxTerminals)
+            assertEquals(1000, result.maxProducts)
+            assertEquals(298000, result.monthlyPrice)
+        }
+    }
+
+    @Nested
+    inner class GetSubscription {
+        @Test
+        fun `returns subscription when found`() {
+            val orgId = UUID.randomUUID()
+            val sub =
+                SubscriptionEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    planId = UUID.randomUUID()
+                    status = "ACTIVE"
+                }
+            whenever(subscriptionRepository.findActiveByOrganizationId(orgId)).thenReturn(sub)
+
+            val result = service.getSubscription(orgId)
+
+            assertNotNull(result)
+            assertEquals("ACTIVE", result?.status)
+        }
+    }
+
+    @Nested
+    inner class Subscribe {
+        @Test
+        fun `creates active subscription`() {
+            val orgId = UUID.randomUUID()
+            val planId = UUID.randomUUID()
+
+            val result = service.subscribe(orgId, planId)
+
+            assertEquals(orgId, result.organizationId)
+            assertEquals(planId, result.planId)
+            assertEquals("ACTIVE", result.status)
+        }
+    }
+
+    @Nested
+    inner class CancelSubscription {
+        @Test
+        fun `cancels subscription`() {
+            val subId = UUID.randomUUID()
+            val entity =
+                SubscriptionEntity().apply {
+                    id = subId
+                    organizationId = UUID.randomUUID()
+                    planId = UUID.randomUUID()
+                    status = "ACTIVE"
+                }
+            whenever(subscriptionRepository.findById(subId)).thenReturn(entity)
+
+            val result = service.cancelSubscription(subId)
+
+            assertNotNull(result)
+            assertEquals("CANCELLED", result?.status)
+        }
+
+        @Test
+        fun `returns null when subscription not found`() {
+            val subId = UUID.randomUUID()
+            whenever(subscriptionRepository.findById(subId)).thenReturn(null)
+
+            val result = service.cancelSubscription(subId)
+
+            assertNull(result)
+        }
+    }
+}

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/WebhookServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/WebhookServiceUnitTest.kt
@@ -1,0 +1,178 @@
+package com.openpos.store.service
+
+import com.openpos.store.config.OrganizationIdHolder
+import com.openpos.store.config.TenantFilterService
+import com.openpos.store.entity.WebhookEntity
+import com.openpos.store.repository.WebhookRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class WebhookServiceUnitTest {
+    private lateinit var service: WebhookService
+    private lateinit var webhookRepository: WebhookRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        webhookRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        service = WebhookService()
+        service.webhookRepository = webhookRepository
+        service.tenantFilterService = tenantFilterService
+        service.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = orgId
+        doNothing().whenever(tenantFilterService).enableFilter()
+        doNothing().whenever(webhookRepository).persist(any<WebhookEntity>())
+        doNothing().whenever(webhookRepository).delete(any<WebhookEntity>())
+    }
+
+    @Nested
+    inner class Create {
+        @Test
+        fun `creates webhook with correct fields`() {
+            val result = service.create("https://example.com/hook", "sale.completed", "secret-key")
+
+            assertNotNull(result)
+            assertEquals("https://example.com/hook", result.url)
+            assertEquals("sale.completed", result.events)
+            assertEquals("secret-key", result.secret)
+            assertEquals(orgId, result.organizationId)
+        }
+    }
+
+    @Nested
+    inner class Update {
+        @Test
+        fun `updates webhook fields selectively`() {
+            val webhookId = UUID.randomUUID()
+            val entity =
+                WebhookEntity().apply {
+                    id = webhookId
+                    organizationId = orgId
+                    url = "https://old.com"
+                    events = "[]"
+                    secret = "old-secret"
+                    isActive = true
+                }
+            whenever(webhookRepository.findById(webhookId)).thenReturn(entity)
+
+            val result = service.update(webhookId, "https://new.com", null, false)
+
+            assertNotNull(result)
+            assertEquals("https://new.com", result?.url)
+            assertEquals("[]", result?.events)
+            assertFalse(result?.isActive ?: true)
+        }
+
+        @Test
+        fun `returns null when webhook not found`() {
+            val id = UUID.randomUUID()
+            whenever(webhookRepository.findById(id)).thenReturn(null)
+
+            val result = service.update(id, "url", null, null)
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class Delete {
+        @Test
+        fun `deletes webhook and returns true`() {
+            val webhookId = UUID.randomUUID()
+            val entity =
+                WebhookEntity().apply {
+                    id = webhookId
+                    organizationId = orgId
+                    url = "https://example.com"
+                    events = "[]"
+                    secret = "secret"
+                }
+            whenever(webhookRepository.findById(webhookId)).thenReturn(entity)
+
+            val result = service.delete(webhookId)
+
+            assertTrue(result)
+            verify(webhookRepository).delete(entity)
+        }
+
+        @Test
+        fun `returns false when webhook not found`() {
+            val id = UUID.randomUUID()
+            whenever(webhookRepository.findById(id)).thenReturn(null)
+
+            val result = service.delete(id)
+
+            assertFalse(result)
+        }
+    }
+
+    @Nested
+    inner class Trigger {
+        @Test
+        fun `triggers webhooks for active ones`() {
+            val webhook =
+                WebhookEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    url = "https://example.com/hook"
+                    events = """["sale.completed"]"""
+                    secret = "my-secret"
+                    isActive = true
+                }
+            whenever(webhookRepository.findActiveByOrganizationId(orgId)).thenReturn(listOf(webhook))
+
+            service.trigger(orgId, "sale.completed", """{"data":"test"}""")
+
+            verify(webhookRepository).findActiveByOrganizationId(orgId)
+        }
+
+        @Test
+        fun `handles empty webhook list`() {
+            whenever(webhookRepository.findActiveByOrganizationId(orgId)).thenReturn(emptyList())
+
+            service.trigger(orgId, "sale.completed", """{"data":"test"}""")
+        }
+    }
+
+    @Nested
+    inner class ListByOrganizationId {
+        @Test
+        fun `returns webhooks for organization`() {
+            val webhooks =
+                listOf(
+                    WebhookEntity().apply {
+                        id = UUID.randomUUID()
+                        organizationId = orgId
+                        url = "https://example.com"
+                        events = "[]"
+                        secret = "s"
+                    },
+                )
+            whenever(webhookRepository.findByOrganizationId(orgId)).thenReturn(webhooks)
+
+            val result = service.listByOrganizationId(orgId)
+
+            assertEquals(1, result.size)
+            verify(tenantFilterService).enableFilter()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- JaCoCo 行カバレッジ閾値を 80% → 95% に引き上げ
- JaCoCo 除外対象に `**/repository/**`, HealthCheck, ProcessedEvent 系クラスを追加（DB/Redis接続必須のため）
- 全6サービスで 95% 以上のカバレッジを達成するための純粋ユニットテストを追加

## 変更内容

### build.gradle.kts
- `minimum` を `"0.80"` → `"0.95"` に変更
- JacocoReport / JacocoCoverageVerification の除外リストに repository、HealthCheck、ProcessedEvent を追加

### 新規テストファイル (8ファイル)
- **store-service**: `WebhookServiceUnitTest`, `AuditLogServiceUnitTest` (IPv6マスキング), `PlanServiceUnitTest`, `FavoriteProductServiceUnitTest`, `GiftCardServiceUnitTest`, `CustomerServiceUnitTest`
- **product-service**: `DiscountServiceUnitTest` (キャッシュパス)
- **analytics-service**: `ProductAlertServiceUnitTest` (テナント所有権チェック)

### 既存テスト拡充 (6ファイル)
- **StoreCacheServiceTest** / **ProductCacheServiceTest** / **RedisCacheServiceTest**: SCAN カーソル反復 + invalidate エラーパス
- **CategoryServiceUnitTest**: キャッシュ書き込み失敗パス + update/delete not-found
- **WebhookDeliveryServiceTest**: HTTP 200/500 レスポンスパス + WebhookStore update/clear

## Test plan
- [x] `./gradlew --parallel build` 全パス
- [x] `jacocoTestCoverageVerification` 全6サービスで 95% 以上
- [ ] CI 全ジョブ pass