### PR TITLE
fix: separate session JWT signing key for rotation support

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/SessionTokenService.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/SessionTokenService.kt
@@ -4,20 +4,42 @@ import io.smallrye.jwt.build.Jwt
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import java.time.Duration
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
 
 /**
  * PIN 認証成功後のセッショントークンを生成するサービス。
  * ORY Hydra の OIDC トークンとは別の、内部セッション用 JWT。
+ *
+ * 署名鍵は `openpos.session.jwt.secret` で設定し、
+ * ローテーション時は環境変数を更新してローリングリスタートする。
  */
 @ApplicationScoped
 class SessionTokenService {
     @ConfigProperty(name = "mp.jwt.verify.issuer", defaultValue = "http://localhost:14444/")
     lateinit var issuer: String
 
+    /**
+     * セッション JWT 署名用の HMAC 秘密鍵（Base64 エンコード）。
+     * SmallRye JWT 共有鍵から分離した専用鍵。
+     * 本番では GCP Secret Manager 経由で注入すること。
+     */
+    @ConfigProperty(name = "openpos.session.jwt.secret")
+    lateinit var jwtSecret: String
+
     companion object {
         /** セッショントークンの有効期限: 8時間（1シフト分） */
         private val TOKEN_DURATION: Duration = Duration.ofHours(8)
+        private const val HMAC_ALGORITHM = "HmacSHA256"
     }
+
+    private fun signingKey(): SecretKey =
+        SecretKeySpec(
+            java.util.Base64
+                .getDecoder()
+                .decode(jwtSecret),
+            HMAC_ALGORITHM,
+        )
 
     /**
      * スタッフ用セッショントークンを生成する。
@@ -26,7 +48,7 @@ class SessionTokenService {
      * @param staffRole ロール（OWNER, MANAGER, CASHIER）
      * @param storeId 店舗 UUID
      * @param organizationId テナント UUID
-     * @return JWT 文字列
+     * @return JWT 文字列（HS256 署名）
      */
     fun generateToken(
         staffId: String,
@@ -42,5 +64,5 @@ class SessionTokenService {
             .claim("organization_id", organizationId)
             .claim("token_type", "session")
             .expiresIn(TOKEN_DURATION)
-            .sign()
+            .sign(signingKey())
 }

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -25,6 +25,11 @@ quarkus.http.cors.exposed-headers=location
 mp.jwt.verify.publickey.location=${HYDRA_JWKS_URL:http://localhost:14444/.well-known/jwks.json}
 mp.jwt.verify.issuer=${HYDRA_ISSUER:http://localhost:14444/}
 
+# Session JWT signing key (Base64-encoded HMAC-SHA256 secret, min 256 bits)
+# Production: inject via GCP Secret Manager → OPENPOS_SESSION_JWT_SECRET env var
+# Rotation: update secret + rolling restart. Old tokens expire naturally (8h TTL).
+openpos.session.jwt.secret=${OPENPOS_SESSION_JWT_SECRET:Y2hhbmdlLW1lLWluLXByb2R1Y3Rpb24tMjU2Yml0cw==}
+
 # Redis
 quarkus.redis.hosts=${REDIS_URL:redis://:openpos_dev@localhost:16379}
 


### PR DESCRIPTION
## Summary
- SessionTokenService の JWT 署名鍵を SmallRye JWT 共有鍵から専用 HMAC-SHA256 鍵に分離
- `openpos.session.jwt.secret` 設定プロパティを追加（Base64 エンコード）
- 本番環境では GCP Secret Manager 経由で `OPENPOS_SESSION_JWT_SECRET` 環境変数として注入
- ローテーション戦略: 秘密鍵更新 + ローリングリスタート（旧トークンは 8h TTL で自然失効）

## Test plan
- [x] `./gradlew :services:api-gateway:test` 全テスト通過
- [ ] CI green

Closes #794