### PR TITLE
fix: enhance gitleaks history scan with artifact upload and manual trigger

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: '0 9 * * 1' # Every Monday at 9:00 UTC
+  workflow_dispatch: # Allow manual full-history scan
 
 permissions:
   contents: read
@@ -66,14 +67,28 @@ jobs:
             log_opts="--all"
           fi
 
+          verbose_flag=""
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            verbose_flag="--verbose"
+          fi
+
           gitleaks git \
             --no-banner \
             --redact \
+            ${verbose_flag} \
             --exit-code=2 \
             --report-format=sarif \
             --report-path=results.sarif \
             --log-opts="${log_opts}" \
             .
+      - name: Upload SARIF report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: gitleaks-sarif
+          path: results.sarif
+          retention-days: 90
+          if-no-files-found: ignore
 
   dependency-audit:
     name: Dependency Vulnerability Scan


### PR DESCRIPTION
## Summary
- `workflow_dispatch` トリガー追加で手動フルスキャン実行可能に
- schedule/manual 実行時に `--verbose` で進捗追跡
- SARIF レポートを artifact としてアップロード（90日保持）
- 既存設定の確認: `fetch-depth: 0`, `--redact`, schedule 時 `--all` で全履歴スキャン済み

## Test plan
- [ ] CI green
- [ ] workflow_dispatch から手動実行可能なことを確認

Closes #795