### PR TITLE
feat: add PIT mutation testing for local execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,57 @@ subprojects {
             tasks.matching { it.name == "check" }.configureEach {
                 dependsOn(tasks.withType<JacocoCoverageVerification>())
             }
+
+            // Mutation Testing (PIT) — local use only, not in CI
+            // Gradle 9 is not supported by the pitest Gradle plugin, so we use a JavaExec task instead.
+            val catalog = rootProject.extensions.getByType<VersionCatalogsExtension>().named("libs")
+            val pitestVersion = catalog.findVersion("pitest").orElseThrow().requiredVersion
+            val pitestJunit5Version = catalog.findVersion("pitest-junit5").orElseThrow().requiredVersion
+            val pitestConf = configurations.create("pitest")
+            dependencies {
+                pitestConf("org.pitest:pitest-command-line:$pitestVersion")
+                pitestConf("org.pitest:pitest-junit5-plugin:$pitestJunit5Version")
+            }
+
+            tasks.register<JavaExec>("pitest") {
+                group = "verification"
+                description = "Run PIT mutation testing (local use only)"
+                dependsOn(tasks.named("testClasses"))
+                mainClass.set("org.pitest.mutationtest.commandline.MutationCoverageReport")
+                classpath = pitestConf
+
+                val mainOutput = project.layout.buildDirectory.dir("classes/kotlin/main")
+                val testOutput = project.layout.buildDirectory.dir("classes/kotlin/test")
+                val reportDir = project.layout.buildDirectory.dir("reports/pitest")
+                val runtimeCp = configurations.getByName("testRuntimeClasspath")
+
+                doFirst {
+                    val cpEntries =
+                        (runtimeCp.files + mainOutput.get().asFile + testOutput.get().asFile)
+                            .joinToString(File.pathSeparator) { it.absolutePath }
+
+                    args =
+                        listOf(
+                            "--targetClasses",
+                            "com.openpos.*",
+                            "--targetTests",
+                            "com.openpos.*",
+                            "--sourceDirs",
+                            "src/main/kotlin",
+                            "--reportDir",
+                            reportDir.get().asFile.absolutePath,
+                            "--classPath",
+                            cpEntries,
+                            "--threads",
+                            Runtime.getRuntime().availableProcessors().toString(),
+                            "--outputFormats",
+                            "HTML,XML",
+                            "--timestampedReports=false",
+                            "--mutators",
+                            "DEFAULTS",
+                        )
+                }
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ testcontainers = "2.0.3"
 owasp-depcheck = "12.2.0"
 bcrypt = "0.10.2"
 jacoco = "0.8.12"
+pitest = "1.17.4"
+pitest-junit5 = "1.2.1"
 
 [libraries]
 # Quarkus BOM
@@ -53,6 +55,7 @@ mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers" }
+pitest-junit5-plugin = { module = "org.pitest:pitest-junit5-plugin", version.ref = "pitest-junit5" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- `libs.versions.toml` に pitest 1.17.4 / pitest-junit5 1.2.1 追加
- 全サービスサブプロジェクトに `pitest` JavaExec タスクを登録
- Gradle 9 と pitest Gradle プラグインの非互換を回避するため `pitest-command-line` を直接使用
- `./gradlew :services:{name}:pitest` で実行可能（CI には入れない）

## Test plan
- [x] `./gradlew --parallel build -x test` 成功
- [x] `./gradlew tasks --group=verification` で pitest タスク確認
- [ ] CI green

Closes #797