### PR TITLE
infra: 本番デプロイ準備（GCP Secret Manager + CDパイプライン）

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -152,3 +152,72 @@ jobs:
           echo "Commit SHA: ${{ github.sha }}"
           kubectl get deployments -n openpos
           kubectl get pods -n openpos
+
+  deploy-prod:
+    needs: [version, build-and-push, deploy-staging]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production # Requires manual approval via GitHub Environments
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG_PRODUCTION }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Pre-deploy health check
+        run: |
+          echo "Running pre-deploy health checks..."
+          kubectl get nodes -o wide
+          kubectl get ns openpos || kubectl create ns openpos
+
+      - name: Apply ExternalSecret for GCP Secret Manager
+        run: |
+          kubectl apply -f infra/k8s/external-secret.yaml
+          echo "Waiting for ExternalSecret to sync..."
+          kubectl wait --for=condition=Ready externalsecret/openpos-secrets -n openpos --timeout=120s || true
+
+      - name: Apply production ConfigMaps
+        run: |
+          kubectl apply -f infra/k8s/configmap-prod.yaml
+
+      - name: Update image tags in manifests
+        run: |
+          IMAGE_TAG="${{ needs.version.outputs.semver }}"
+          SERVICES=(api-gateway product-service store-service pos-service inventory-service analytics-service)
+          for SERVICE in "${SERVICES[@]}"; do
+            sed -i "s|image: ${{ env.IMAGE_PREFIX }}/${SERVICE}:.*|image: ${{ env.IMAGE_PREFIX }}/${SERVICE}:${IMAGE_TAG}|" \
+              "infra/k8s/${SERVICE}.yaml"
+          done
+
+      - name: Apply Kubernetes manifests
+        run: |
+          kubectl apply -f infra/k8s/namespace.yaml
+          kubectl apply -f infra/k8s/network-policy.yaml
+          kubectl apply -f infra/k8s/ingress.yaml
+          kubectl apply -f infra/k8s/
+
+      - name: Wait for rollout completion
+        run: |
+          SERVICES=(api-gateway product-service store-service pos-service inventory-service analytics-service)
+          for SERVICE in "${SERVICES[@]}"; do
+            echo "Waiting for ${SERVICE} rollout..."
+            kubectl rollout status deployment/"${SERVICE}" -n openpos --timeout=600s
+          done
+
+      - name: Post-deploy verification
+        run: |
+          echo "=== Production Deploy Complete ==="
+          echo "Version: ${{ needs.version.outputs.semver }}"
+          echo "Commit:  ${{ github.sha }}"
+          echo ""
+          kubectl get deployments -n openpos
+          kubectl get pods -n openpos
+          echo ""
+          echo "Checking pod health..."
+          kubectl get pods -n openpos -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}'

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -1,0 +1,185 @@
+# Production Deployment Guide
+
+## Overview
+
+OpenPOS の本番デプロイは GitHub Actions CD パイプラインを通じて実行される。
+staging 環境への自動デプロイ後、GitHub Environments の承認ゲートを経て本番環境にデプロイされる。
+
+## Architecture
+
+```
+Git Tag (v*) → CD Pipeline
+  ├── version: セマンティックバージョン生成
+  ├── build-and-push: Docker イメージビルド & GHCR push
+  ├── deploy-staging: ステージング自動デプロイ
+  └── deploy-prod: 本番デプロイ（承認必要）
+```
+
+## Prerequisites
+
+### GCP Resources
+
+| リソース | 用途 |
+|---------|------|
+| GKE クラスタ | Kubernetes 実行環境 |
+| Cloud SQL (PostgreSQL 17) | データベース |
+| Memorystore (Redis 7) | キャッシュ |
+| Cloud Pub/Sub or RabbitMQ on GKE | メッセージキュー |
+| GCP Secret Manager | シークレット管理 |
+
+### External Secrets Operator
+
+```bash
+# ESO インストール（Helm）
+helm repo add external-secrets https://charts.external-secrets.io
+helm install external-secrets external-secrets/external-secrets \
+  -n external-secrets --create-namespace
+```
+
+### GitHub Environments
+
+1. Repository Settings > Environments に `production` 環境を作成
+2. Required reviewers に承認者を追加
+3. 以下の Secrets を設定:
+   - `KUBE_CONFIG_PRODUCTION`: base64 エンコードされた kubeconfig
+
+## Deployment Steps
+
+### 1. シークレット設定
+
+GCP Secret Manager にシークレットを登録:
+
+```bash
+# Database credentials
+gcloud secrets create openpos-db-user --data-file=- <<< "dbuser"
+gcloud secrets create openpos-db-password --data-file=- <<< "secure-password"
+gcloud secrets create openpos-db-url --data-file=- <<< "jdbc:postgresql://10.x.x.x:5432/openpos"
+
+# Redis
+gcloud secrets create openpos-redis-url --data-file=- <<< "redis://10.x.x.x:6379"
+
+# RabbitMQ
+gcloud secrets create openpos-rabbitmq-user --data-file=- <<< "rmquser"
+gcloud secrets create openpos-rabbitmq-pass --data-file=- <<< "secure-password"
+
+# Hydra (OIDC)
+gcloud secrets create openpos-hydra-jwks-url --data-file=- <<< "https://hydra.example.com/.well-known/jwks.json"
+gcloud secrets create openpos-hydra-issuer --data-file=- <<< "https://hydra.example.com/"
+
+# Session JWT
+gcloud secrets create openpos-session-jwt-secret --data-file=- <<< "base64-encoded-256bit-key"
+```
+
+### 2. ConfigMap 作成
+
+```bash
+cp infra/k8s/configmap-prod.yaml.example infra/k8s/configmap-prod.yaml
+# 環境に合わせて値を編集
+kubectl apply -f infra/k8s/configmap-prod.yaml
+```
+
+### 3. ExternalSecret 適用
+
+```bash
+# SecretStore の projectID を GCP プロジェクトに変更
+vi infra/k8s/external-secret.yaml
+kubectl apply -f infra/k8s/external-secret.yaml
+
+# 同期確認
+kubectl get externalsecret -n openpos
+kubectl get secret openpos-secrets -n openpos
+```
+
+### 4. デプロイ実行
+
+```bash
+# タグを作成して push（CD パイプラインが自動起動）
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+パイプライン実行フロー:
+1. バージョン生成
+2. 6サービスの Docker イメージビルド & push
+3. ステージング環境にデプロイ & rollout 待機
+4. **GitHub で承認を要求** (production environment)
+5. 承認後、本番環境にデプロイ
+
+### 5. デプロイ後の確認
+
+```bash
+# Pod 状態確認
+kubectl get pods -n openpos
+
+# ログ確認
+kubectl logs -n openpos -l app=api-gateway --tail=50
+
+# ヘルスチェック
+kubectl exec -n openpos deployment/api-gateway -- curl -s localhost:8080/q/health
+```
+
+## Rollback
+
+```bash
+# 直前のバージョンに戻す
+kubectl rollout undo deployment/api-gateway -n openpos
+kubectl rollout undo deployment/product-service -n openpos
+kubectl rollout undo deployment/store-service -n openpos
+kubectl rollout undo deployment/pos-service -n openpos
+kubectl rollout undo deployment/inventory-service -n openpos
+kubectl rollout undo deployment/analytics-service -n openpos
+
+# 特定リビジョンに戻す
+kubectl rollout undo deployment/api-gateway -n openpos --to-revision=2
+```
+
+## Environment Variables
+
+### Secret（GCP Secret Manager 経由）
+
+| Key | 説明 |
+|-----|------|
+| `DB_USER` | PostgreSQL ユーザー名 |
+| `DB_PASSWORD` | PostgreSQL パスワード |
+| `DB_URL` | JDBC 接続 URL |
+| `REDIS_URL` | Redis 接続 URL |
+| `RABBITMQ_USER` | RabbitMQ ユーザー名 |
+| `RABBITMQ_PASS` | RabbitMQ パスワード |
+| `HYDRA_JWKS_URL` | ORY Hydra JWKS エンドポイント |
+| `HYDRA_ISSUER` | ORY Hydra Issuer URL |
+| `OPENPOS_SESSION_JWT_SECRET` | セッション JWT 署名鍵（Base64） |
+
+### ConfigMap（非機密設定）
+
+`infra/k8s/configmap-prod.yaml.example` を参照。
+
+## Monitoring
+
+デプロイ後に以下を確認:
+- Prometheus メトリクス: `/q/metrics`
+- Liveness probe: `/q/health/live`
+- Readiness probe: `/q/health/ready`
+- Grafana ダッシュボード（設定済みの場合）
+
+## Troubleshooting
+
+### Pod が起動しない
+
+```bash
+kubectl describe pod -n openpos <pod-name>
+kubectl logs -n openpos <pod-name> --previous
+```
+
+### ExternalSecret が同期しない
+
+```bash
+kubectl describe externalsecret openpos-secrets -n openpos
+# Workload Identity の権限を確認
+```
+
+### Flyway マイグレーション失敗
+
+```bash
+# マイグレーションログを確認
+kubectl logs -n openpos -l app=<service> | grep -i flyway
+```

--- a/infra/k8s/configmap-prod.yaml.example
+++ b/infra/k8s/configmap-prod.yaml.example
@@ -1,0 +1,139 @@
+# ============================================================================
+# OpenPOS Production ConfigMaps — Example Template
+# ============================================================================
+# 使い方:
+#   1. このファイルをコピーして configmap-prod.yaml を作成
+#   2. CHANGE_ME の値を本番環境に合わせて設定
+#   3. kubectl apply -f infra/k8s/configmap-prod.yaml
+#
+# WARNING: 実際の本番値を Git にコミットしないこと
+# ============================================================================
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-gateway-config
+  namespace: openpos
+  labels:
+    app.kubernetes.io/part-of: openpos
+    app.kubernetes.io/component: api-gateway
+    environment: production
+data:
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_LOG_LEVEL: 'INFO'
+  QUARKUS_LOG_CONSOLE_JSON: 'true'
+  # gRPC service endpoints
+  PRODUCT_SERVICE_HOST: 'product-service'
+  PRODUCT_SERVICE_PORT: '9000'
+  STORE_SERVICE_HOST: 'store-service'
+  STORE_SERVICE_PORT: '9000'
+  POS_SERVICE_HOST: 'pos-service'
+  POS_SERVICE_PORT: '9000'
+  INVENTORY_SERVICE_HOST: 'inventory-service'
+  INVENTORY_SERVICE_PORT: '9000'
+  ANALYTICS_SERVICE_HOST: 'analytics-service'
+  ANALYTICS_SERVICE_PORT: '9000'
+  # Session JWT
+  OPENPOS_SESSION_JWT_ISSUER: 'CHANGE_ME'  # e.g., https://pos.example.com
+  OPENPOS_SESSION_JWT_DURATION: '3600'
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-service-config
+  namespace: openpos
+  labels:
+    app.kubernetes.io/part-of: openpos
+    app.kubernetes.io/component: product-service
+    environment: production
+data:
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'
+  QUARKUS_LOG_LEVEL: 'INFO'
+  QUARKUS_LOG_CONSOLE_JSON: 'true'
+  QUARKUS_DATASOURCE_DB_KIND: 'postgresql'
+  QUARKUS_HIBERNATE_ORM_DATABASE_DEFAULT_SCHEMA: 'product_schema'
+  QUARKUS_FLYWAY_DEFAULT_SCHEMA: 'product_schema'
+  QUARKUS_FLYWAY_SCHEMAS: 'product_schema'
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: store-service-config
+  namespace: openpos
+  labels:
+    app.kubernetes.io/part-of: openpos
+    app.kubernetes.io/component: store-service
+    environment: production
+data:
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'
+  QUARKUS_LOG_LEVEL: 'INFO'
+  QUARKUS_LOG_CONSOLE_JSON: 'true'
+  QUARKUS_DATASOURCE_DB_KIND: 'postgresql'
+  QUARKUS_HIBERNATE_ORM_DATABASE_DEFAULT_SCHEMA: 'store_schema'
+  QUARKUS_FLYWAY_DEFAULT_SCHEMA: 'store_schema'
+  QUARKUS_FLYWAY_SCHEMAS: 'store_schema'
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pos-service-config
+  namespace: openpos
+  labels:
+    app.kubernetes.io/part-of: openpos
+    app.kubernetes.io/component: pos-service
+    environment: production
+data:
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'
+  QUARKUS_LOG_LEVEL: 'INFO'
+  QUARKUS_LOG_CONSOLE_JSON: 'true'
+  QUARKUS_DATASOURCE_DB_KIND: 'postgresql'
+  QUARKUS_HIBERNATE_ORM_DATABASE_DEFAULT_SCHEMA: 'pos_schema'
+  QUARKUS_FLYWAY_DEFAULT_SCHEMA: 'pos_schema'
+  QUARKUS_FLYWAY_SCHEMAS: 'pos_schema'
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inventory-service-config
+  namespace: openpos
+  labels:
+    app.kubernetes.io/part-of: openpos
+    app.kubernetes.io/component: inventory-service
+    environment: production
+data:
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'
+  QUARKUS_LOG_LEVEL: 'INFO'
+  QUARKUS_LOG_CONSOLE_JSON: 'true'
+  QUARKUS_DATASOURCE_DB_KIND: 'postgresql'
+  QUARKUS_HIBERNATE_ORM_DATABASE_DEFAULT_SCHEMA: 'inventory_schema'
+  QUARKUS_FLYWAY_DEFAULT_SCHEMA: 'inventory_schema'
+  QUARKUS_FLYWAY_SCHEMAS: 'inventory_schema'
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analytics-service-config
+  namespace: openpos
+  labels:
+    app.kubernetes.io/part-of: openpos
+    app.kubernetes.io/component: analytics-service
+    environment: production
+data:
+  QUARKUS_HTTP_PORT: '8080'
+  QUARKUS_GRPC_SERVER_PORT: '9000'
+  QUARKUS_LOG_LEVEL: 'INFO'
+  QUARKUS_LOG_CONSOLE_JSON: 'true'
+  QUARKUS_DATASOURCE_DB_KIND: 'postgresql'
+  QUARKUS_HIBERNATE_ORM_DATABASE_DEFAULT_SCHEMA: 'analytics_schema'
+  QUARKUS_FLYWAY_DEFAULT_SCHEMA: 'analytics_schema'
+  QUARKUS_FLYWAY_SCHEMAS: 'analytics_schema'

--- a/infra/k8s/external-secret.yaml
+++ b/infra/k8s/external-secret.yaml
@@ -1,0 +1,73 @@
+# ============================================================================
+# ExternalSecret — GCP Secret Manager Integration
+# ============================================================================
+# 前提:
+#   - External Secrets Operator がクラスタにインストール済み
+#   - GCP Workload Identity で ESO の ServiceAccount に権限付与済み
+#   - SecretStore 'gcp-secret-store' が namespace に作成済み
+#
+# 参考: https://external-secrets.io/latest/provider/google-secrets-manager/
+# ============================================================================
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: gcp-secret-store
+  namespace: openpos
+spec:
+  provider:
+    gcpsm:
+      projectID: CHANGE_ME # GCP Project ID
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: openpos-secrets
+  namespace: openpos
+  labels:
+    app.kubernetes.io/part-of: openpos
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: SecretStore
+  target:
+    name: openpos-secrets
+    creationPolicy: Owner
+  data:
+    # --- Database ---
+    - secretKey: DB_USER
+      remoteRef:
+        key: openpos-db-user
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: openpos-db-password
+    - secretKey: DB_URL
+      remoteRef:
+        key: openpos-db-url
+
+    # --- Redis ---
+    - secretKey: REDIS_URL
+      remoteRef:
+        key: openpos-redis-url
+
+    # --- RabbitMQ ---
+    - secretKey: RABBITMQ_USER
+      remoteRef:
+        key: openpos-rabbitmq-user
+    - secretKey: RABBITMQ_PASS
+      remoteRef:
+        key: openpos-rabbitmq-pass
+
+    # --- ORY Hydra (JWT / OIDC) ---
+    - secretKey: HYDRA_JWKS_URL
+      remoteRef:
+        key: openpos-hydra-jwks-url
+    - secretKey: HYDRA_ISSUER
+      remoteRef:
+        key: openpos-hydra-issuer
+
+    # --- Session JWT ---
+    - secretKey: OPENPOS_SESSION_JWT_SECRET
+      remoteRef:
+        key: openpos-session-jwt-secret


### PR DESCRIPTION
## Summary
- CD パイプラインに `deploy-prod` ジョブ追加（staging 成功後、GitHub Environments 承認ゲート経由）
- GCP Secret Manager + External Secrets Operator の ExternalSecret リソース追加
- 本番用 ConfigMap テンプレート (`configmap-prod.yaml.example`) 追加
- 本番デプロイガイド (`docs/guides/production-deployment.md`) 追加

## Test plan
- [ ] `actionlint` で cd.yml の構文検証通過を確認
- [ ] CI パスを確認
- [ ] `deploy-prod` ジョブが `deploy-staging` 成功後にのみ実行されることを確認
- [ ] ExternalSecret / ConfigMap の YAML 構文が正しいことを確認

Closes #800