### PR TITLE
perf: パフォーマンス負荷テスト（500+ RPS検証）

### DIFF
--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -1,0 +1,54 @@
+# k6 Load Tests
+
+## Prerequisites
+
+```bash
+# k6 のインストール
+brew install grafana/k6/k6  # macOS
+# or: https://grafana.com/docs/k6/latest/get-started/installation/
+```
+
+## Environment Variables
+
+```bash
+export K6_BASE_URL=http://localhost:8080
+export K6_ORG_ID=<organization-uuid>
+export K6_STORE_ID=<store-uuid>
+export K6_TERMINAL_ID=<terminal-uuid>
+export K6_STAFF_ID=<staff-uuid>
+```
+
+## Test Scripts
+
+| Script | Purpose | Load Profile |
+|--------|---------|-------------|
+| `product-listing.js` | Product/category API throughput | Standard (10 VU) |
+| `transaction-create.js` | Transaction creation pipeline | Standard (10 VU) |
+| `transaction-finalize.js` | Full payment finalization | Smoke (2 VU) |
+| `full-checkout-flow.js` | E2E checkout flow, SLO validation | High (500 VU) |
+| `stress-test.js` | Mixed workload, find breaking point | Stress (1000 VU) |
+
+## Running Tests
+
+```bash
+# Smoke test (quick validation)
+k6 run tests/k6/product-listing.js
+
+# Full checkout flow (500+ RPS target, SLO: P95 < 200ms)
+k6 run tests/k6/full-checkout-flow.js
+
+# Stress test (find breaking point)
+k6 run tests/k6/stress-test.js
+
+# With Grafana Cloud output
+k6 run --out cloud tests/k6/full-checkout-flow.js
+```
+
+## SLO Targets
+
+| Metric | Target |
+|--------|--------|
+| P95 Latency | < 200ms |
+| P99 Latency | < 500ms |
+| Error Rate | < 1% |
+| Checkout Success Rate | > 95% |

--- a/tests/k6/config.js
+++ b/tests/k6/config.js
@@ -34,7 +34,31 @@ export const smokeStages = [
   { duration: '5s', target: 0 },
 ]
 
+/** High-load profile: 500+ RPS target (adjust VUs based on API response time) */
+export const highLoadStages = [
+  { duration: '30s', target: 50 }, // Warm-up
+  { duration: '1m', target: 200 }, // Ramp to moderate load
+  { duration: '2m', target: 500 }, // Sustain peak load (500+ RPS)
+  { duration: '1m', target: 500 }, // Hold peak
+  { duration: '30s', target: 0 }, // Ramp down
+]
+
+/** Stress test profile: find breaking point */
+export const stressStages = [
+  { duration: '30s', target: 100 },
+  { duration: '1m', target: 300 },
+  { duration: '1m', target: 600 },
+  { duration: '1m', target: 1000 },
+  { duration: '30s', target: 0 },
+]
+
 export const defaultThresholds = {
   http_req_duration: ['p(95)<2000'],
   http_req_failed: ['rate<0.05'],
+}
+
+/** SLO thresholds: P95 < 200ms, error rate < 1% */
+export const sloThresholds = {
+  http_req_duration: ['p(95)<200', 'p(99)<500'],
+  http_req_failed: ['rate<0.01'],
 }

--- a/tests/k6/full-checkout-flow.js
+++ b/tests/k6/full-checkout-flow.js
@@ -1,0 +1,143 @@
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+import { Counter, Rate, Trend } from 'k6/metrics'
+import {
+  BASE_URL,
+  defaultHeaders,
+  STORE_ID,
+  TERMINAL_ID,
+  STAFF_ID,
+  highLoadStages,
+  sloThresholds,
+} from './config.js'
+
+// Custom metrics
+const checkoutSuccess = new Counter('checkout_success_total')
+const checkoutFailure = new Counter('checkout_failure_total')
+const checkoutRate = new Rate('checkout_success_rate')
+const checkoutDuration = new Trend('checkout_e2e_duration')
+
+export const options = {
+  stages: highLoadStages,
+  thresholds: {
+    ...sloThresholds,
+    checkout_success_rate: ['rate>0.95'],
+    checkout_e2e_duration: ['p(95)<1000'],
+  },
+}
+
+/**
+ * Full POS checkout flow load test (500+ RPS target)
+ *
+ * End-to-end scenario:
+ *   1. Fetch product list
+ *   2. Create a new transaction (DRAFT)
+ *   3. Add item to transaction
+ *   4. Finalize transaction (cash payment)
+ *   5. Verify completed status
+ */
+export default function () {
+  const start = Date.now()
+
+  // 1. Fetch products
+  const productsRes = http.get(`${BASE_URL}/api/products?page=1&pageSize=5`, {
+    headers: defaultHeaders,
+    tags: { name: 'GET /api/products' },
+  })
+
+  if (productsRes.status !== 200) {
+    checkoutFailure.add(1)
+    checkoutRate.add(false)
+    return
+  }
+
+  const products = productsRes.json()
+  if (!products || !products.data || products.data.length === 0) {
+    checkoutFailure.add(1)
+    checkoutRate.add(false)
+    return
+  }
+
+  const productId = products.data[0].id
+
+  sleep(0.1)
+
+  // 2. Create transaction
+  const createRes = http.post(
+    `${BASE_URL}/api/transactions`,
+    JSON.stringify({
+      storeId: STORE_ID,
+      terminalId: TERMINAL_ID,
+      staffId: STAFF_ID,
+      type: 'SALE',
+      clientId: `k6-flow-${Date.now()}-${__VU}-${__ITER}`,
+    }),
+    { headers: defaultHeaders, tags: { name: 'POST /api/transactions' } },
+  )
+
+  if (createRes.status >= 300) {
+    checkoutFailure.add(1)
+    checkoutRate.add(false)
+    return
+  }
+
+  const transactionId = createRes.json().id
+  check(createRes, {
+    'create: status DRAFT': (r) => r.json().status === 'DRAFT',
+  })
+
+  sleep(0.1)
+
+  // 3. Add item
+  const addItemRes = http.post(
+    `${BASE_URL}/api/transactions/${transactionId}/items`,
+    JSON.stringify({ productId: productId, quantity: 1 }),
+    { headers: defaultHeaders, tags: { name: 'POST /api/transactions/:id/items' } },
+  )
+
+  if (addItemRes.status >= 300) {
+    checkoutFailure.add(1)
+    checkoutRate.add(false)
+    return
+  }
+
+  const total = addItemRes.json().total
+  check(addItemRes, {
+    'add item: has items': (r) => {
+      const body = r.json()
+      return body && body.items && body.items.length > 0
+    },
+  })
+
+  sleep(0.1)
+
+  // 4. Finalize (cash payment)
+  const finalizeRes = http.post(
+    `${BASE_URL}/api/transactions/${transactionId}/finalize`,
+    JSON.stringify({
+      payments: [{ method: 'CASH', amount: total, received: total }],
+    }),
+    { headers: defaultHeaders, tags: { name: 'POST /api/transactions/:id/finalize' } },
+  )
+
+  check(finalizeRes, {
+    'finalize: status 2xx': (r) => r.status >= 200 && r.status < 300,
+    'finalize: COMPLETED': (r) => {
+      const body = r.json()
+      return body && body.transaction && body.transaction.status === 'COMPLETED'
+    },
+  })
+
+  if (finalizeRes.status < 300) {
+    checkoutSuccess.add(1)
+    checkoutRate.add(true)
+  } else {
+    checkoutFailure.add(1)
+    checkoutRate.add(false)
+  }
+
+  const duration = Date.now() - start
+  checkoutDuration.add(duration)
+
+  sleep(0.2)
+}

--- a/tests/k6/stress-test.js
+++ b/tests/k6/stress-test.js
@@ -1,0 +1,161 @@
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+import { Counter, Rate } from 'k6/metrics'
+import {
+  BASE_URL,
+  defaultHeaders,
+  STORE_ID,
+  TERMINAL_ID,
+  STAFF_ID,
+  stressStages,
+} from './config.js'
+
+const errorsByEndpoint = new Counter('errors_by_endpoint')
+const successRate = new Rate('overall_success_rate')
+
+export const options = {
+  stages: stressStages,
+  thresholds: {
+    // Stress test: observe degradation, don't enforce strict SLOs
+    http_req_duration: ['p(95)<5000'],
+    http_req_failed: ['rate<0.20'],
+  },
+}
+
+/**
+ * Stress test: find the breaking point
+ *
+ * Mixed workload simulating realistic traffic distribution:
+ *   - 50% read operations (product/category listing)
+ *   - 30% transaction creation (write-heavy)
+ *   - 20% full checkout flow
+ */
+export default function () {
+  const scenario = Math.random()
+
+  if (scenario < 0.5) {
+    readWorkload()
+  } else if (scenario < 0.8) {
+    createTransactionWorkload()
+  } else {
+    fullCheckoutWorkload()
+  }
+}
+
+function readWorkload() {
+  const res = http.get(`${BASE_URL}/api/products?page=1&pageSize=20`, {
+    headers: defaultHeaders,
+    tags: { name: 'GET /api/products' },
+  })
+
+  const ok = check(res, { 'products: status 200': (r) => r.status === 200 })
+  successRate.add(ok)
+  if (!ok) errorsByEndpoint.add(1, { endpoint: 'products' })
+
+  sleep(0.1)
+
+  const catRes = http.get(`${BASE_URL}/api/categories`, {
+    headers: defaultHeaders,
+    tags: { name: 'GET /api/categories' },
+  })
+
+  const catOk = check(catRes, { 'categories: status 200': (r) => r.status === 200 })
+  successRate.add(catOk)
+  if (!catOk) errorsByEndpoint.add(1, { endpoint: 'categories' })
+
+  sleep(0.1)
+}
+
+function createTransactionWorkload() {
+  const createRes = http.post(
+    `${BASE_URL}/api/transactions`,
+    JSON.stringify({
+      storeId: STORE_ID,
+      terminalId: TERMINAL_ID,
+      staffId: STAFF_ID,
+      type: 'SALE',
+      clientId: `k6-stress-${Date.now()}-${__VU}-${__ITER}`,
+    }),
+    { headers: defaultHeaders, tags: { name: 'POST /api/transactions' } },
+  )
+
+  const ok = check(createRes, {
+    'create tx: status 2xx': (r) => r.status >= 200 && r.status < 300,
+  })
+  successRate.add(ok)
+  if (!ok) errorsByEndpoint.add(1, { endpoint: 'transactions_create' })
+
+  sleep(0.1)
+}
+
+function fullCheckoutWorkload() {
+  // Fetch product
+  const productsRes = http.get(`${BASE_URL}/api/products?page=1&pageSize=5`, {
+    headers: defaultHeaders,
+    tags: { name: 'GET /api/products' },
+  })
+
+  if (productsRes.status !== 200) {
+    successRate.add(false)
+    errorsByEndpoint.add(1, { endpoint: 'products' })
+    return
+  }
+
+  const products = productsRes.json()
+  if (!products || !products.data || products.data.length === 0) return
+
+  const productId = products.data[0].id
+
+  // Create transaction
+  const createRes = http.post(
+    `${BASE_URL}/api/transactions`,
+    JSON.stringify({
+      storeId: STORE_ID,
+      terminalId: TERMINAL_ID,
+      staffId: STAFF_ID,
+      type: 'SALE',
+      clientId: `k6-stress-flow-${Date.now()}-${__VU}-${__ITER}`,
+    }),
+    { headers: defaultHeaders, tags: { name: 'POST /api/transactions' } },
+  )
+
+  if (createRes.status >= 300) {
+    successRate.add(false)
+    errorsByEndpoint.add(1, { endpoint: 'transactions_create' })
+    return
+  }
+
+  const transactionId = createRes.json().id
+
+  // Add item
+  const addRes = http.post(
+    `${BASE_URL}/api/transactions/${transactionId}/items`,
+    JSON.stringify({ productId, quantity: 1 }),
+    { headers: defaultHeaders, tags: { name: 'POST /api/transactions/:id/items' } },
+  )
+
+  if (addRes.status >= 300) {
+    successRate.add(false)
+    errorsByEndpoint.add(1, { endpoint: 'transactions_add_item' })
+    return
+  }
+
+  const total = addRes.json().total
+
+  // Finalize
+  const finalizeRes = http.post(
+    `${BASE_URL}/api/transactions/${transactionId}/finalize`,
+    JSON.stringify({
+      payments: [{ method: 'CASH', amount: total, received: total }],
+    }),
+    { headers: defaultHeaders, tags: { name: 'POST /api/transactions/:id/finalize' } },
+  )
+
+  const ok = check(finalizeRes, {
+    'finalize: status 2xx': (r) => r.status >= 200 && r.status < 300,
+  })
+  successRate.add(ok)
+  if (!ok) errorsByEndpoint.add(1, { endpoint: 'transactions_finalize' })
+
+  sleep(0.1)
+}


### PR DESCRIPTION
## Summary
- 500+ RPS フルチェックアウトフロー負荷テスト (`full-checkout-flow.js`) を追加
- ストレステスト（1000 VU、混合ワークロード、ブレイクポイント探索）を追加
- SLO 閾値（P95 < 200ms, P99 < 500ms, エラー率 < 1%）を config に追加
- カスタムメトリクス（checkout_success_rate, checkout_e2e_duration）を追加
- テスト実行ガイド README を追加

## Test plan
- [ ] CI パスを確認
- [ ] k6 スクリプトの構文エラーがないことを確認
- [ ] 負荷テストの閾値設定が SLO 要件を満たしていることを確認

Closes #801