### PR TITLE
test: Testcontainers結合テスト強化（store-service + Flyway検証）

### DIFF
--- a/services/product-service/src/test/kotlin/com/openpos/product/integration/ProductRepositoryIntegrationTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/integration/ProductRepositoryIntegrationTest.kt
@@ -191,4 +191,21 @@ class ProductRepositoryIntegrationTest {
         // Assert
         assertEquals(5L, count)
     }
+
+    @Test
+    fun `Flyway migrations executed successfully`() {
+        // Verify that Flyway migrations ran by checking for expected tables
+        val tables =
+            entityManager
+                .createNativeQuery(
+                    """SELECT table_name FROM information_schema.tables
+               WHERE table_schema = 'product_schema'
+               ORDER BY table_name""",
+                ).resultList
+
+        // Assert core tables exist
+        val tableNames = tables.map { it.toString() }
+        assertTrue(tableNames.contains("products"), "products table should exist")
+        assertTrue(tableNames.contains("categories"), "categories table should exist")
+    }
 }

--- a/services/store-service/src/test/kotlin/com/openpos/store/integration/IntegrationTestProfile.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/integration/IntegrationTestProfile.kt
@@ -1,0 +1,41 @@
+package com.openpos.store.integration
+
+import io.quarkus.test.junit.QuarkusTestProfile
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Testcontainers で PostgreSQL を起動する結合テストプロファイル。
+ * Flyway の create-schemas=true でスキーマを自動作成し、マイグレーションで実テーブルを構築する。
+ */
+class IntegrationTestProfile : QuarkusTestProfile {
+    companion object {
+        val postgres: PostgreSQLContainer<*> =
+            PostgreSQLContainer("postgres:17-alpine")
+                .withDatabaseName("openpos_test")
+                .withUsername("test")
+                .withPassword("test")
+                .apply { start() }
+    }
+
+    override fun getConfigOverrides(): Map<String, String> =
+        mapOf(
+            "quarkus.datasource.db-kind" to "postgresql",
+            "quarkus.datasource.jdbc.url" to postgres.jdbcUrl,
+            "quarkus.datasource.username" to postgres.username,
+            "quarkus.datasource.password" to postgres.password,
+            "quarkus.hibernate-orm.database.generation" to "none",
+            "quarkus.hibernate-orm.database.default-schema" to "store_schema",
+            "quarkus.flyway.migrate-at-start" to "true",
+            "quarkus.flyway.schemas" to "store_schema",
+            "quarkus.flyway.create-schemas" to "true",
+            "quarkus.datasource.health.enabled" to "false",
+            "quarkus.redis.devservices.enabled" to "false",
+            "quarkus.rabbitmq.devservices.enabled" to "false",
+            "quarkus.grpc.server.port" to "0",
+            "quarkus.grpc.server.test-port" to "0",
+            "quarkus.http.port" to "0",
+            "quarkus.http.test-port" to "0",
+        )
+
+    override fun getConfigProfile(): String = "integration"
+}

--- a/services/store-service/src/test/kotlin/com/openpos/store/integration/StoreRepositoryIntegrationTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/integration/StoreRepositoryIntegrationTest.kt
@@ -1,0 +1,197 @@
+package com.openpos.store.integration
+
+import com.openpos.store.config.OrganizationIdHolder
+import com.openpos.store.config.TenantFilterService
+import com.openpos.store.entity.StoreEntity
+import com.openpos.store.repository.StoreRepository
+import io.quarkus.panache.common.Page
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import jakarta.persistence.EntityManager
+import jakarta.transaction.Transactional
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * StoreRepository の Testcontainers 結合テスト。
+ * PostgreSQL 17 + Flyway マイグレーションで実スキーマを使用する。
+ */
+@QuarkusTest
+@TestProfile(IntegrationTestProfile::class)
+class StoreRepositoryIntegrationTest {
+    @Inject
+    lateinit var storeRepository: StoreRepository
+
+    @Inject
+    lateinit var organizationIdHolder: OrganizationIdHolder
+
+    @Inject
+    lateinit var tenantFilterService: TenantFilterService
+
+    @Inject
+    lateinit var entityManager: EntityManager
+
+    private val testOrgId: UUID = UUID.randomUUID()
+
+    @BeforeEach
+    @Transactional
+    fun setUp() {
+        // FK制約を考慮した順序でクリーンアップ（子テーブルから先に削除）
+        entityManager.createNativeQuery("DELETE FROM store_schema.staff").executeUpdate()
+        entityManager.createNativeQuery("DELETE FROM store_schema.terminals").executeUpdate()
+        entityManager.createNativeQuery("DELETE FROM store_schema.stores").executeUpdate()
+        entityManager.createNativeQuery("DELETE FROM store_schema.organizations").executeUpdate()
+        // テスト用 organization を挿入（stores.organization_id FK のため）
+        entityManager
+            .createNativeQuery(
+                """INSERT INTO store_schema.organizations (id, name, business_type, plan, created_at, updated_at)
+                   VALUES (:id, 'Test Organization', 'RETAIL', 'FREE', NOW(), NOW())""",
+            ).setParameter("id", testOrgId)
+            .executeUpdate()
+        organizationIdHolder.organizationId = testOrgId
+        tenantFilterService.enableFilter()
+    }
+
+    @Test
+    @Transactional
+    fun `persist and find store by id`() {
+        // Arrange
+        val store =
+            StoreEntity().apply {
+                organizationId = testOrgId
+                name = "テスト渋谷店"
+                code = "SHIBUYA-001"
+                address = "東京都渋谷区道玄坂1-1-1"
+                phone = "03-1234-5678"
+                timezone = "Asia/Tokyo"
+                isActive = true
+            }
+
+        // Act
+        storeRepository.persist(store)
+        val found = storeRepository.findById(store.id)
+
+        // Assert
+        assertNotNull(found)
+        requireNotNull(found)
+        assertEquals("テスト渋谷店", found.name)
+        assertEquals("SHIBUYA-001", found.code)
+        assertEquals("東京都渋谷区道玄坂1-1-1", found.address)
+        assertEquals("03-1234-5678", found.phone)
+        assertEquals(testOrgId, found.organizationId)
+    }
+
+    @Test
+    @Transactional
+    fun `listPaginated returns stores sorted by name`() {
+        // Arrange
+        listOf("C店舗", "A店舗", "B店舗").forEach { name ->
+            storeRepository.persist(
+                StoreEntity().apply {
+                    organizationId = testOrgId
+                    this.name = name
+                    timezone = "Asia/Tokyo"
+                    isActive = true
+                },
+            )
+        }
+
+        // Act
+        val results = storeRepository.listPaginated(Page.ofSize(10))
+
+        // Assert
+        assertEquals(3, results.size)
+        assertEquals("A店舗", results[0].name)
+        assertEquals("B店舗", results[1].name)
+        assertEquals("C店舗", results[2].name)
+    }
+
+    @Test
+    @Transactional
+    fun `tenant isolation prevents cross-organization access`() {
+        // Arrange: create store under testOrgId
+        storeRepository.persist(
+            StoreEntity().apply {
+                organizationId = testOrgId
+                name = "テナント分離テスト店舗"
+                timezone = "Asia/Tokyo"
+                isActive = true
+            },
+        )
+        entityManager.flush()
+
+        // Act: switch to different org
+        val differentOrgId = UUID.randomUUID()
+        organizationIdHolder.organizationId = differentOrgId
+        tenantFilterService.enableFilter()
+
+        val results = storeRepository.listPaginated(Page.ofSize(10))
+
+        // Assert: should not find store from different org
+        assertEquals(0, results.size)
+    }
+
+    @Test
+    @Transactional
+    fun `findAllByOrganizationId returns correct stores`() {
+        // Arrange
+        val otherOrgId = UUID.randomUUID()
+        storeRepository.persist(
+            StoreEntity().apply {
+                organizationId = testOrgId
+                name = "自組織の店舗"
+                timezone = "Asia/Tokyo"
+                isActive = true
+            },
+        )
+        // 他組織の organization を先に挿入（FK制約のため）
+        entityManager
+            .createNativeQuery(
+                """INSERT INTO store_schema.organizations (id, name, business_type, plan, created_at, updated_at)
+                   VALUES (:id, 'Other Organization', 'RETAIL', 'FREE', NOW(), NOW())""",
+            ).setParameter("id", otherOrgId)
+            .executeUpdate()
+        // Note: we need to bypass the filter for inserting another org's store
+        entityManager
+            .createNativeQuery(
+                """INSERT INTO store_schema.stores
+               (id, organization_id, name, timezone, is_active, settings, created_at, updated_at)
+               VALUES (:id, :orgId, :name, 'Asia/Tokyo', true, '{}', NOW(), NOW())""",
+            ).setParameter("id", UUID.randomUUID())
+            .setParameter("orgId", otherOrgId)
+            .setParameter("name", "他組織の店舗")
+            .executeUpdate()
+
+        entityManager.flush()
+
+        // Act
+        val results = storeRepository.findAllByOrganizationId(testOrgId)
+
+        // Assert
+        assertEquals(1, results.size)
+        assertEquals("自組織の店舗", results.first().name)
+    }
+
+    @Test
+    fun `Flyway migrations executed successfully`() {
+        // Verify that Flyway migrations ran by checking for expected tables
+        val tables =
+            entityManager
+                .createNativeQuery(
+                    """SELECT table_name FROM information_schema.tables
+               WHERE table_schema = 'store_schema'
+               ORDER BY table_name""",
+                ).resultList
+
+        // Assert core tables exist
+        val tableNames = tables.map { it.toString() }
+        assertTrue(tableNames.contains("stores"), "stores table should exist")
+        assertTrue(tableNames.contains("staff"), "staff table should exist")
+        assertTrue(tableNames.contains("terminals"), "terminals table should exist")
+    }
+}


### PR DESCRIPTION
## Summary
- store-service に Testcontainers（PostgreSQL 17）結合テストを追加（5テスト）
  - CRUD操作、ページネーションソート、テナント分離、組織間クエリ、Flyway マイグレーション検証
- product-service に Flyway マイグレーション検証テストを追加
- FK制約（stores → organizations）を考慮したテストデータセットアップ

## Test plan
- [x] `./gradlew :services:store-service:test` 全テスト pass
- [x] `./gradlew :services:product-service:test` 全テスト pass
- [x] `./gradlew --parallel build` 全体ビルド pass

Closes #802