### PR TITLE
test: Property-Based Testing拡大（jqwik + fast-check）

### DIFF
--- a/apps/pos-terminal/src/lib/cart-totals.property.test.ts
+++ b/apps/pos-terminal/src/lib/cart-totals.property.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+import {
+  getCartEstimatedTax,
+  getCartEstimatedTotal,
+  getCartTaxBreakdown,
+  getCartItemTax,
+} from './cart-totals'
+import type { CartItem } from '@/stores/cart-store'
+import type { TaxRate } from '@shared-types/openpos'
+
+const now = '2026-01-01T00:00:00Z'
+
+const moneyAmount = fc.integer({ min: 0, max: 100_000_000 })
+const quantity = fc.integer({ min: 1, max: 999 })
+const taxRateValue = fc.integer({ min: 0, max: 10000 }).map((v) => (v / 10000).toString())
+
+function makeCartItem(price: number, qty: number, taxRateId?: string): CartItem {
+  return {
+    product: {
+      id: 'prod-1',
+      organizationId: 'org-1',
+      name: 'Test',
+      price,
+      taxRateId: taxRateId ?? null,
+      categoryId: null,
+      barcode: null,
+      isActive: true,
+      displayOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+    },
+    quantity: qty,
+  }
+}
+
+function makeTaxRate(id: string, rate: string): TaxRate {
+  return {
+    id,
+    organizationId: 'org-1',
+    name: 'Standard',
+    rate,
+    isReduced: false,
+    isDefault: false,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+describe('Cart totals property-based tests', () => {
+  it('税ブレイクダウンの課税対象額合計は商品小計合計と一致する', () => {
+    fc.assert(
+      fc.property(
+        moneyAmount,
+        moneyAmount,
+        quantity,
+        quantity,
+        taxRateValue,
+        (p1, p2, q1, q2, rate) => {
+          const item1 = makeCartItem(p1, q1, 'tax-1')
+          const item2: CartItem = {
+            product: { ...makeCartItem(p2, q2, 'tax-1').product, id: 'prod-2' },
+            quantity: q2,
+          }
+          const taxRates = [makeTaxRate('tax-1', rate)]
+          const breakdown = getCartTaxBreakdown([item1, item2], taxRates)
+          const totalTaxable = breakdown.reduce((sum, entry) => sum + entry.taxableAmount, 0)
+          expect(totalTaxable).toBe(p1 * q1 + p2 * q2)
+        },
+      ),
+    )
+  })
+
+  it('税ブレイクダウンの税額は全て非負である', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, taxRateValue, (price, qty, rate) => {
+        const item = makeCartItem(price, qty, 'tax-1')
+        const taxRates = [makeTaxRate('tax-1', rate)]
+        const breakdown = getCartTaxBreakdown([item], taxRates)
+        for (const entry of breakdown) {
+          expect(entry.taxAmount).toBeGreaterThanOrEqual(0)
+        }
+      }),
+    )
+  })
+
+  it('税ブレイクダウンの税額は全て整数である', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, taxRateValue, (price, qty, rate) => {
+        const item = makeCartItem(price, qty, 'tax-1')
+        const taxRates = [makeTaxRate('tax-1', rate)]
+        const breakdown = getCartTaxBreakdown([item], taxRates)
+        for (const entry of breakdown) {
+          expect(Number.isInteger(entry.taxAmount)).toBe(true)
+        }
+      }),
+    )
+  })
+
+  it('異なる税率は別グループに分かれる', () => {
+    fc.assert(
+      fc.property(moneyAmount, moneyAmount, quantity, quantity, (p1, p2, q1, q2) => {
+        const item1 = makeCartItem(p1, q1, 'tax-standard')
+        const item2: CartItem = {
+          product: { ...makeCartItem(p2, q2, 'tax-reduced').product, id: 'prod-2' },
+          quantity: q2,
+        }
+        const taxRates = [
+          makeTaxRate('tax-standard', '0.10'),
+          { ...makeTaxRate('tax-reduced', '0.08'), isReduced: true },
+        ]
+        const breakdown = getCartTaxBreakdown([item1, item2], taxRates)
+        expect(breakdown.length).toBe(2)
+      }),
+    )
+  })
+
+  it('推定合計 = 小計 + 推定税額', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, taxRateValue, (price, qty, rate) => {
+        const item = makeCartItem(price, qty, 'tax-1')
+        const taxRates = [makeTaxRate('tax-1', rate)]
+        const items = [item]
+        const subtotal = price * qty
+        const tax = getCartEstimatedTax(items, taxRates)
+        const total = getCartEstimatedTotal(items, taxRates)
+        expect(total).toBe(subtotal + tax)
+      }),
+    )
+  })
+
+  it('個別商品の税額は常に非負である', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, taxRateValue, (price, qty, rate) => {
+        const item = makeCartItem(price, qty, 'tax-1')
+        const taxRates = [makeTaxRate('tax-1', rate)]
+        expect(getCartItemTax(item, taxRates)).toBeGreaterThanOrEqual(0)
+      }),
+    )
+  })
+
+  it('税率なしの商品は税額0', () => {
+    fc.assert(
+      fc.property(moneyAmount, quantity, (price, qty) => {
+        const item = makeCartItem(price, qty) // no taxRateId
+        const taxRates = [makeTaxRate('tax-1', '0.10')]
+        expect(getCartItemTax(item, taxRates)).toBe(0)
+      }),
+    )
+  })
+})

--- a/apps/pos-terminal/src/stores/discount-store.property.test.ts
+++ b/apps/pos-terminal/src/stores/discount-store.property.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as fc from 'fast-check'
+import { useDiscountStore } from './discount-store'
+import type { Discount } from '@shared-types/openpos'
+
+const now = '2026-01-01T00:00:00Z'
+
+function makePercentageDiscount(rate: number): Discount {
+  return {
+    id: `discount-pct-${rate}`,
+    organizationId: 'org-1',
+    name: `${rate * 100}%割引`,
+    discountType: 'PERCENTAGE',
+    value: rate.toString(),
+    startDate: null,
+    endDate: null,
+    isActive: true,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function makeFixedDiscount(amount: number): Discount {
+  return {
+    id: `discount-fix-${amount}`,
+    organizationId: 'org-1',
+    name: `${amount}銭引き`,
+    discountType: 'FIXED_AMOUNT',
+    value: amount.toString(),
+    startDate: null,
+    endDate: null,
+    isActive: true,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+// 割引率: 0.01〜1.00
+const percentageRate = fc.integer({ min: 1, max: 100 }).map((v) => v / 100)
+const moneyAmount = fc.integer({ min: 0, max: 100_000_000 })
+const positiveAmount = fc.integer({ min: 1, max: 100_000_000 })
+
+describe('Discount property-based tests', () => {
+  beforeEach(() => {
+    useDiscountStore.getState().clearDiscounts()
+  })
+
+  it('パーセンテージ割引額は常に非負である', () => {
+    fc.assert(
+      fc.property(moneyAmount, percentageRate, (subtotal, rate) => {
+        useDiscountStore.getState().clearDiscounts()
+        useDiscountStore
+          .getState()
+          .addDiscount(`coupon-${subtotal}-${rate}`, makePercentageDiscount(rate), subtotal)
+        const discounts = useDiscountStore.getState().appliedDiscounts
+        if (discounts.length > 0) {
+          expect(discounts[0]!.amount).toBeGreaterThanOrEqual(0)
+        }
+      }),
+    )
+  })
+
+  it('パーセンテージ割引額は小計を超えない', () => {
+    fc.assert(
+      fc.property(moneyAmount, percentageRate, (subtotal, rate) => {
+        useDiscountStore.getState().clearDiscounts()
+        useDiscountStore
+          .getState()
+          .addDiscount(`coupon-${subtotal}-${rate}`, makePercentageDiscount(rate), subtotal)
+        const discounts = useDiscountStore.getState().appliedDiscounts
+        if (discounts.length > 0) {
+          expect(discounts[0]!.amount).toBeLessThanOrEqual(subtotal)
+        }
+      }),
+    )
+  })
+
+  it('パーセンテージ割引額は整数である（端数切り捨て）', () => {
+    fc.assert(
+      fc.property(moneyAmount, percentageRate, (subtotal, rate) => {
+        useDiscountStore.getState().clearDiscounts()
+        useDiscountStore
+          .getState()
+          .addDiscount(`coupon-${subtotal}-${rate}`, makePercentageDiscount(rate), subtotal)
+        const discounts = useDiscountStore.getState().appliedDiscounts
+        if (discounts.length > 0) {
+          expect(Number.isInteger(discounts[0]!.amount)).toBe(true)
+        }
+      }),
+    )
+  })
+
+  it('固定額割引は小計で上限が設けられる', () => {
+    fc.assert(
+      fc.property(positiveAmount, positiveAmount, (fixedValue, subtotal) => {
+        useDiscountStore.getState().clearDiscounts()
+        useDiscountStore
+          .getState()
+          .addDiscount(`coupon-${fixedValue}-${subtotal}`, makeFixedDiscount(fixedValue), subtotal)
+        const discounts = useDiscountStore.getState().appliedDiscounts
+        if (discounts.length > 0) {
+          expect(discounts[0]!.amount).toBeLessThanOrEqual(subtotal)
+          expect(discounts[0]!.amount).toBeLessThanOrEqual(fixedValue)
+        }
+      }),
+    )
+  })
+
+  it('固定額割引は min(value, subtotal) と一致する', () => {
+    fc.assert(
+      fc.property(positiveAmount, positiveAmount, (fixedValue, subtotal) => {
+        useDiscountStore.getState().clearDiscounts()
+        useDiscountStore
+          .getState()
+          .addDiscount(`coupon-${fixedValue}-${subtotal}`, makeFixedDiscount(fixedValue), subtotal)
+        const discounts = useDiscountStore.getState().appliedDiscounts
+        if (discounts.length > 0) {
+          expect(discounts[0]!.amount).toBe(Math.min(fixedValue, subtotal))
+        }
+      }),
+    )
+  })
+
+  it('合計割引額は個別割引額の和である', () => {
+    fc.assert(
+      fc.property(positiveAmount, percentageRate, positiveAmount, (subtotal, rate, fixedValue) => {
+        useDiscountStore.getState().clearDiscounts()
+        useDiscountStore
+          .getState()
+          .addDiscount('coupon-pct', makePercentageDiscount(rate), subtotal)
+        useDiscountStore
+          .getState()
+          .addDiscount('coupon-fix', makeFixedDiscount(fixedValue), subtotal)
+        const discounts = useDiscountStore.getState().appliedDiscounts
+        const expectedTotal = discounts.reduce((sum, d) => sum + d.amount, 0)
+        expect(useDiscountStore.getState().getTotalDiscount()).toBe(expectedTotal)
+      }),
+    )
+  })
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ bcrypt = "0.10.2"
 jacoco = "0.8.12"
 pitest = "1.17.4"
 pitest-junit5 = "1.2.1"
+jqwik = "1.9.3"
 
 [libraries]
 # Quarkus BOM
@@ -56,6 +57,8 @@ testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers" }
 pitest-junit5-plugin = { module = "org.pitest:pitest-junit5-plugin", version.ref = "pitest-junit5" }
+jqwik = { module = "net.jqwik:jqwik", version.ref = "jqwik" }
+jqwik-kotlin = { module = "net.jqwik:jqwik-kotlin", version.ref = "jqwik" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/services/pos-service/build.gradle.kts
+++ b/services/pos-service/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     testImplementation(libs.quarkus.jdbc.h2)
     testImplementation(libs.rest.assured)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.jqwik)
+    testImplementation(libs.jqwik.kotlin)
 }
 
 allOpen {

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/TaxCalculationPropertyTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/TaxCalculationPropertyTest.kt
@@ -1,0 +1,162 @@
+package com.openpos.pos.service
+
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ForAll
+import net.jqwik.api.Property
+import net.jqwik.api.Provide
+import net.jqwik.api.constraints.IntRange
+import net.jqwik.api.constraints.LongRange
+
+/**
+ * TaxCalculationService の Property-Based テスト。
+ * 金額計算の代数的不変条件をランダム入力で検証する。
+ */
+class TaxCalculationPropertyTest {
+    private val sut = TaxCalculationService()
+
+    // === Arbitraries ===
+
+    @Provide
+    fun validTaxRate(): Arbitrary<String> =
+        Arbitraries
+            .integers()
+            .between(0, 10000)
+            .map { (it.toDouble() / 10000).toBigDecimal().toPlainString() }
+
+    // === calculateTax properties ===
+
+    @Property
+    fun `税額は常に非負である`(
+        @ForAll @LongRange(min = 0, max = 100_000_000) subtotal: Long,
+        @ForAll("validTaxRate") taxRate: String,
+    ) {
+        val tax = sut.calculateTax(subtotal, taxRate)
+        assert(tax >= 0) { "税額が負: subtotal=$subtotal, rate=$taxRate, tax=$tax" }
+    }
+
+    @Property
+    fun `税額は小計を超えない（税率100%以下）`(
+        @ForAll @LongRange(min = 0, max = 100_000_000) subtotal: Long,
+        @ForAll("validTaxRate") taxRate: String,
+    ) {
+        val tax = sut.calculateTax(subtotal, taxRate)
+        assert(tax <= subtotal) { "税額が小計超過: subtotal=$subtotal, rate=$taxRate, tax=$tax" }
+    }
+
+    @Property
+    fun `税額は floor(subtotal * rate) と一致する（subtotal が正の場合）`(
+        @ForAll @LongRange(min = 1, max = 100_000_000) subtotal: Long,
+        @ForAll("validTaxRate") taxRate: String,
+    ) {
+        val tax = sut.calculateTax(subtotal, taxRate)
+        val expected =
+            java.math
+                .BigDecimal(subtotal)
+                .multiply(java.math.BigDecimal(taxRate))
+                .setScale(0, java.math.RoundingMode.FLOOR)
+                .toLong()
+        assert(tax == expected) { "税額不一致: tax=$tax, expected=$expected" }
+    }
+
+    @Property
+    fun `小計0以下なら税額は0`(
+        @ForAll @LongRange(min = -1_000_000, max = 0) subtotal: Long,
+        @ForAll("validTaxRate") taxRate: String,
+    ) {
+        val tax = sut.calculateTax(subtotal, taxRate)
+        assert(tax == 0L) { "小計≤0なのに税額非0: subtotal=$subtotal, tax=$tax" }
+    }
+
+    @Property
+    fun `税率0なら税額は0`(
+        @ForAll @LongRange(min = 0, max = 100_000_000) subtotal: Long,
+    ) {
+        val tax = sut.calculateTax(subtotal, "0.0")
+        assert(tax == 0L) { "税率0なのに税額非0: subtotal=$subtotal, tax=$tax" }
+    }
+
+    // === calculateTotal properties ===
+
+    @Property
+    fun `合計は小計と税額の和である`(
+        @ForAll @LongRange(min = 0, max = 100_000_000) subtotal: Long,
+        @ForAll @LongRange(min = 0, max = 10_000_000) taxAmount: Long,
+    ) {
+        val total = sut.calculateTotal(subtotal, taxAmount)
+        assert(total == subtotal + taxAmount) { "合計 != 小計 + 税額" }
+    }
+
+    // === calculateItemTax properties ===
+
+    @Property
+    fun `明細小計は単価と数量の積である`(
+        @ForAll @LongRange(min = 0, max = 1_000_000) unitPrice: Long,
+        @ForAll @IntRange(min = 1, max = 999) quantity: Int,
+        @ForAll("validTaxRate") taxRate: String,
+    ) {
+        val result = sut.calculateItemTax(unitPrice, quantity, taxRate)
+        assert(result.subtotal == unitPrice * quantity) {
+            "小計 != 単価*数量: ${result.subtotal} != ${unitPrice * quantity}"
+        }
+    }
+
+    @Property
+    fun `明細合計は小計と税額の和である`(
+        @ForAll @LongRange(min = 0, max = 1_000_000) unitPrice: Long,
+        @ForAll @IntRange(min = 1, max = 999) quantity: Int,
+        @ForAll("validTaxRate") taxRate: String,
+    ) {
+        val result = sut.calculateItemTax(unitPrice, quantity, taxRate)
+        assert(result.total == result.subtotal + result.taxAmount) {
+            "合計 != 小計+税額: ${result.total} != ${result.subtotal} + ${result.taxAmount}"
+        }
+    }
+
+    @Property
+    fun `明細合計は常に小計以上（税率非負）`(
+        @ForAll @LongRange(min = 0, max = 1_000_000) unitPrice: Long,
+        @ForAll @IntRange(min = 1, max = 999) quantity: Int,
+        @ForAll("validTaxRate") taxRate: String,
+    ) {
+        val result = sut.calculateItemTax(unitPrice, quantity, taxRate)
+        assert(result.total >= result.subtotal) {
+            "合計 < 小計: total=${result.total}, subtotal=${result.subtotal}"
+        }
+    }
+
+    // === aggregateTaxSummaries properties ===
+
+    @Property
+    fun `集計の税額合計は個別税額合計と一致する`(
+        @ForAll @LongRange(min = 1, max = 1_000_000) subtotal1: Long,
+        @ForAll @LongRange(min = 1, max = 1_000_000) subtotal2: Long,
+        @ForAll("validTaxRate") taxRate: String,
+    ) {
+        val items =
+            listOf(
+                TaxableItem("標準税率", taxRate, false, subtotal1),
+                TaxableItem("標準税率", taxRate, false, subtotal2),
+            )
+        val summaries = sut.aggregateTaxSummaries(items)
+        val expectedTax = sut.calculateTax(subtotal1 + subtotal2, taxRate)
+        assert(summaries.size == 1) { "同一税率で集約されるべき" }
+        assert(summaries[0].taxAmount == expectedTax) {
+            "集計税額が不一致: ${summaries[0].taxAmount} != $expectedTax"
+        }
+    }
+
+    @Property
+    fun `異なる税率は別グループに集約される`(
+        @ForAll @LongRange(min = 1, max = 1_000_000) subtotal1: Long,
+        @ForAll @LongRange(min = 1, max = 1_000_000) subtotal2: Long,
+    ) {
+        val items =
+            listOf(
+                TaxableItem("標準税率10%", "0.10", false, subtotal1),
+                TaxableItem("軽減税率8%", "0.08", true, subtotal2),
+            )
+        val summaries = sut.aggregateTaxSummaries(items)
+        assert(summaries.size == 2) { "異なる税率は別グループであるべき: size=${summaries.size}" }
+    }
+}


### PR DESCRIPTION
## Summary
- Backend: jqwik による TaxCalculationService の PBT（10 properties）
  - 税額の非負性、上限、floor 丸め、計算式一致、明細/集計の整合性
- Frontend: fast-check による割引計算・税ブレイクダウンの PBT（13 properties）
  - 割引額の非負性・上限、固定額 min(value, subtotal)、合計加法性
  - 税ブレイクダウンの課税対象額整合性、税額非負性・整数性、グループ分離

## Test plan
- [x] `./gradlew --parallel build` 全体ビルド pass
- [x] `pnpm --filter pos-terminal test` 419 tests pass
- [x] `pnpm --filter pos-terminal typecheck` pass

Closes #803