### PR TITLE
fix(inventory-service): accept any payload type in RabbitMQ consumers

### DIFF
--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/EventConsumer.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/EventConsumer.kt
@@ -28,9 +28,9 @@ class EventConsumer {
     private val log = Logger.getLogger(EventConsumer::class.java)
 
     @Incoming("sale-completed")
-    fun onSaleCompleted(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
+    fun onSaleCompleted(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = message.payload
+            val body = message.payload.toString()
             val envelope = objectMapper.readValue(body, EventEnvelopeDto::class.java)
             val eventId = UUID.fromString(envelope.eventId)
 
@@ -48,9 +48,9 @@ class EventConsumer {
         }
 
     @Incoming("sale-voided")
-    fun onSaleVoided(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
+    fun onSaleVoided(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = message.payload
+            val body = message.payload.toString()
             val envelope = objectMapper.readValue(body, EventEnvelopeDto::class.java)
             val eventId = UUID.fromString(envelope.eventId)
 

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/event/EventConsumerTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/event/EventConsumerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.vertx.core.json.JsonObject
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -59,8 +60,8 @@ class EventConsumerTest {
     // --- ヘルパー ---
 
     @Suppress("UNCHECKED_CAST")
-    private fun mockMessage(body: String): IncomingRabbitMQMessage<String> {
-        val message = mock<IncomingRabbitMQMessage<String>>()
+    private fun mockMessage(body: Any): IncomingRabbitMQMessage<*> {
+        val message = mock<IncomingRabbitMQMessage<Any>>()
         whenever(message.payload).thenReturn(body)
         whenever(message.ack()).thenReturn(CompletableFuture.completedFuture(null))
         whenever(message.nack(any<Throwable>())).thenReturn(CompletableFuture.completedFuture(null))
@@ -172,6 +173,22 @@ class EventConsumerTest {
         }
 
         @Test
+        fun `JsonObjectペイロードでもprocessSaleCompletedが呼ばれる`() {
+            // Arrange
+            val json = buildSaleCompletedJson()
+            val jsonObject = JsonObject(json)
+            val message = mockMessage(jsonObject)
+
+            // Act
+            consumer.onSaleCompleted(message)
+
+            // Assert
+            verify(idempotentHandler).handleIdempotent(eq(eventId), eq("sale.completed"), any())
+            verify(stockEventProcessor).processSaleCompleted(eq(orgId), any())
+            verify(message).ack()
+        }
+
+        @Test
         fun `不正なJSONではnackが呼ばれる`() {
             // Arrange
             val invalidJson = "{ invalid json }"
@@ -195,6 +212,22 @@ class EventConsumerTest {
             assertNotNull(json)
             assertTrue(json.contains("sale.voided"))
             val message = mockMessage(json)
+
+            // Act
+            consumer.onSaleVoided(message)
+
+            // Assert
+            verify(idempotentHandler).handleIdempotent(eq(eventId), eq("sale.voided"), any())
+            verify(stockEventProcessor).processSaleVoided(eq(orgId), any())
+            verify(message).ack()
+        }
+
+        @Test
+        fun `JsonObjectペイロードでもprocessSaleVoidedが呼ばれる`() {
+            // Arrange
+            val json = buildSaleVoidedJson()
+            val jsonObject = JsonObject(json)
+            val message = mockMessage(jsonObject)
 
             // Act
             consumer.onSaleVoided(message)


### PR DESCRIPTION
## Summary
- `sale-completed` / `sale-voided` consumer が `IncomingRabbitMQMessage<String>` を期待していたが、SmallRye Reactive Messaging は `JsonObject` を渡すことがあり `ClassCastException` が発生していた
- 型パラメータを `*` (star-projection) に変更し、`payload.toString()` で文字列化することで `String` / `JsonObject` 両方に対応
- `JsonObject` ペイロードのテストケースを追加

## Test plan
- [x] `./gradlew :services:inventory-service:test` — BUILD SUCCESSFUL
- [ ] local demo で `sale.completed` イベント発行後、inventory-service ログに ClassCastException が出ないことを確認
- [ ] 在庫減算が正常に処理されることを確認

Closes #829