### PR TITLE
fix(flyway): use direct PostgreSQL connection for Flyway migrations

### DIFF
--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -20,7 +20,9 @@ quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=analytics_schema
 quarkus.hibernate-orm.database.generation=none
 
-# Flyway
+# Flyway (bypass PgBouncer — advisory locks require a direct connection)
+quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://localhost:15432/openpos}
+%docker.quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://postgres:5432/openpos}
 quarkus.flyway.migrate-at-start=true
 %prod.quarkus.flyway.migrate-at-start=false
 quarkus.flyway.schemas=analytics_schema

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -20,7 +20,9 @@ quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=inventory_schema
 quarkus.hibernate-orm.database.generation=none
 
-# Flyway
+# Flyway (bypass PgBouncer — advisory locks require a direct connection)
+quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://localhost:15432/openpos}
+%docker.quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://postgres:5432/openpos}
 quarkus.flyway.migrate-at-start=true
 %prod.quarkus.flyway.migrate-at-start=false
 quarkus.flyway.schemas=inventory_schema

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -20,7 +20,9 @@ quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=pos_schema
 quarkus.hibernate-orm.database.generation=none
 
-# Flyway
+# Flyway (bypass PgBouncer — advisory locks require a direct connection)
+quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://localhost:15432/openpos}
+%docker.quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://postgres:5432/openpos}
 quarkus.flyway.migrate-at-start=true
 %prod.quarkus.flyway.migrate-at-start=false
 quarkus.flyway.schemas=pos_schema

--- a/services/product-service/src/main/resources/application.properties
+++ b/services/product-service/src/main/resources/application.properties
@@ -20,7 +20,9 @@ quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=product_schema
 quarkus.hibernate-orm.database.generation=none
 
-# Flyway
+# Flyway (bypass PgBouncer — advisory locks require a direct connection)
+quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://localhost:15432/openpos}
+%docker.quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://postgres:5432/openpos}
 quarkus.flyway.migrate-at-start=true
 %prod.quarkus.flyway.migrate-at-start=false
 quarkus.flyway.schemas=product_schema

--- a/services/store-service/src/main/resources/application.properties
+++ b/services/store-service/src/main/resources/application.properties
@@ -20,7 +20,9 @@ quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=store_schema
 quarkus.hibernate-orm.database.generation=none
 
-# Flyway
+# Flyway (bypass PgBouncer — advisory locks require a direct connection)
+quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://localhost:15432/openpos}
+%docker.quarkus.flyway.jdbc-url=${FLYWAY_DB_URL:jdbc:postgresql://postgres:5432/openpos}
 quarkus.flyway.migrate-at-start=true
 %prod.quarkus.flyway.migrate-at-start=false
 quarkus.flyway.schemas=store_schema


### PR DESCRIPTION
## Summary
- PgBouncer の transaction pool mode が Flyway の advisory lock と干渉し、再利用したローカルDB volume で migration が失敗していた
- `pos_schema.outbox_events` 等 V6 以降の migration が適用されず `SQLGrammarException` が継続
- 全5サービスに `quarkus.flyway.jdbc-url` を追加し、Flyway が PgBouncer を迂回して直接 PostgreSQL に接続するよう設定

## Test plan
- [ ] `docker volume rm openpos_openpos-pgdata` 後に `make up` + `local-stack-up.sh` で起動
- [ ] pos-service ログに `outbox_events` 関連のエラーが出ないことを確認
- [ ] `flyway_schema_history` テーブルで全 migration が適用済みであることを確認

Closes #830