### PR TITLE
fix(otel): default OpenTelemetry to disabled, enable only in prod

### DIFF
--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -101,12 +101,12 @@ quarkus.smallrye-health.root-path=/q/health
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 
-# OpenTelemetry
-quarkus.otel.enabled=true
+# OpenTelemetry (disabled by default; enable via QUARKUS_OTEL_ENABLED=true when a collector is available)
+quarkus.otel.enabled=${QUARKUS_OTEL_ENABLED:false}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
-%dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.enabled=true
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -52,12 +52,12 @@ quarkus.smallrye-health.root-path=/q/health
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 
-# OpenTelemetry
-quarkus.otel.enabled=true
+# OpenTelemetry (disabled by default; enable via QUARKUS_OTEL_ENABLED=true when a collector is available)
+quarkus.otel.enabled=${QUARKUS_OTEL_ENABLED:false}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
-%dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.enabled=true
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -112,12 +112,12 @@ quarkus.smallrye-health.root-path=/q/health
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 
-# OpenTelemetry
-quarkus.otel.enabled=true
+# OpenTelemetry (disabled by default; enable via QUARKUS_OTEL_ENABLED=true when a collector is available)
+quarkus.otel.enabled=${QUARKUS_OTEL_ENABLED:false}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
-%dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.enabled=true
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -64,12 +64,12 @@ quarkus.smallrye-health.root-path=/q/health
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 
-# OpenTelemetry
-quarkus.otel.enabled=true
+# OpenTelemetry (disabled by default; enable via QUARKUS_OTEL_ENABLED=true when a collector is available)
+quarkus.otel.enabled=${QUARKUS_OTEL_ENABLED:false}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
-%dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.enabled=true
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 

--- a/services/product-service/src/main/resources/application.properties
+++ b/services/product-service/src/main/resources/application.properties
@@ -46,12 +46,12 @@ quarkus.smallrye-health.root-path=/q/health
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 
-# OpenTelemetry
-quarkus.otel.enabled=true
+# OpenTelemetry (disabled by default; enable via QUARKUS_OTEL_ENABLED=true when a collector is available)
+quarkus.otel.enabled=${QUARKUS_OTEL_ENABLED:false}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
-%dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.enabled=true
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 

--- a/services/store-service/src/main/resources/application.properties
+++ b/services/store-service/src/main/resources/application.properties
@@ -46,12 +46,12 @@ quarkus.smallrye-health.root-path=/q/health
 quarkus.micrometer.enabled=true
 quarkus.micrometer.export.prometheus.enabled=true
 
-# OpenTelemetry
-quarkus.otel.enabled=true
+# OpenTelemetry (disabled by default; enable via QUARKUS_OTEL_ENABLED=true when a collector is available)
+quarkus.otel.enabled=${QUARKUS_OTEL_ENABLED:false}
 quarkus.otel.exporter.otlp.endpoint=${OTEL_ENDPOINT:http://localhost:14317}
 quarkus.otel.resource.attributes=service.name=${quarkus.application.name}
 quarkus.otel.propagators=tracecontext,baggage
-%dev.quarkus.otel.enabled=false
+%prod.quarkus.otel.enabled=true
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 


### PR DESCRIPTION
## Summary
- 全6サービスで `quarkus.otel.enabled=true` がデフォルトだったため、OTel collector が存在しない local demo / dev 環境で OTLP 接続失敗が大量出力されていた
- デフォルトを `${QUARKUS_OTEL_ENABLED:false}` に変更し、`%prod` プロファイルのみ `true` に設定
- `local-stack-up.sh` の既存 `QUARKUS_OTEL_ENABLED=false` 設定と整合

## Test plan
- [ ] `local-stack-up.sh` で起動後、ログに OTLP 接続失敗が出ないことを確認
- [ ] `QUARKUS_OTEL_ENABLED=true OTEL_ENDPOINT=http://localhost:4317 ./gradlew :services:api-gateway:quarkusDev` で OTel が有効化されることを確認

Closes #831