### PR TITLE
chore(config): remove unrecognized and deprecated Quarkus settings

### DIFF
--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -18,7 +18,7 @@ quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
 quarkus.datasource.jdbc.max-size=10
 quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=analytics_schema
-quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.schema-management.strategy=none
 
 # Flyway
 quarkus.flyway.migrate-at-start=true
@@ -34,10 +34,8 @@ rabbitmq-port=${RABBITMQ_PORT:15672}
 rabbitmq-username=${RABBITMQ_USER:openpos}
 rabbitmq-password=${RABBITMQ_PASS:openpos_dev}
 
-# Structured Logging (JSON in prod)
-quarkus.log.console.json=false
-quarkus.log.console.json.additional-field.service.value=${quarkus.application.name}
-%prod.quarkus.log.console.json=true
+# Structured Logging
+quarkus.log.level=INFO
 
 # RabbitMQ Incoming (Event Consumer)
 mp.messaging.incoming.sale-completed-events.connector=smallrye-rabbitmq
@@ -110,9 +108,7 @@ quarkus.otel.propagators=tracecontext,baggage
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 
-# GCP Secret Manager
-%prod.quarkus.gcp.secret-manager.enabled=true
-%docker.quarkus.gcp.secret-manager.enabled=false
+# Docker profile
 %docker.quarkus.datasource.username=${DB_USER:openpos}
 %docker.quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -61,10 +61,8 @@ quarkus.otel.propagators=tracecontext,baggage
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 
-# Structured Logging (JSON in prod)
-quarkus.log.console.json=false
-%prod.quarkus.log.console.json=true
-quarkus.log.console.json.additional-field.service.value=${quarkus.application.name}
+# Structured Logging
+quarkus.log.level=INFO
 
 # Dev profile (quarkusDev with local infra via Docker Compose)
 %dev.quarkus.redis.hosts=redis://:openpos_dev@localhost:16379

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -18,7 +18,7 @@ quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
 quarkus.datasource.jdbc.max-size=10
 quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=inventory_schema
-quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.schema-management.strategy=none
 
 # Flyway
 quarkus.flyway.migrate-at-start=true
@@ -57,10 +57,8 @@ mp.messaging.incoming.sale-voided.failure-strategy=reject
 mp.messaging.incoming.sale-voided.reconnect-attempts=10
 mp.messaging.incoming.sale-voided.reconnect-interval=5
 
-# Structured Logging (JSON in prod)
-quarkus.log.console.json=false
-quarkus.log.console.json.additional-field.service.value=${quarkus.application.name}
-%prod.quarkus.log.console.json=true
+# Structured Logging
+quarkus.log.level=INFO
 
 # RabbitMQ Outgoing (StockLowEvent Publisher)
 mp.messaging.outgoing.stock-low-events.connector=smallrye-rabbitmq
@@ -121,9 +119,7 @@ quarkus.otel.propagators=tracecontext,baggage
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 
-# GCP Secret Manager
-%prod.quarkus.gcp.secret-manager.enabled=true
-%docker.quarkus.gcp.secret-manager.enabled=false
+# Docker profile
 %docker.quarkus.datasource.username=${DB_USER:openpos}
 %docker.quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -18,7 +18,7 @@ quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
 quarkus.datasource.jdbc.max-size=10
 quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=pos_schema
-quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.schema-management.strategy=none
 
 # Flyway
 quarkus.flyway.migrate-at-start=true
@@ -52,10 +52,8 @@ quarkus.grpc.clients.store-service.host=${STORE_SERVICE_HOST:localhost}
 quarkus.grpc.clients.store-service.port=${STORE_SERVICE_PORT:9000}
 quarkus.grpc.clients.store-service.deadline=5000
 
-# Structured Logging (JSON in prod)
-quarkus.log.console.json=false
-quarkus.log.console.json.additional-field.service.value=${quarkus.application.name}
-%prod.quarkus.log.console.json=true
+# Structured Logging
+quarkus.log.level=INFO
 
 # Health (Quarkus standard: /q/health/live, /q/health/ready)
 quarkus.smallrye-health.root-path=/q/health
@@ -76,9 +74,7 @@ quarkus.otel.propagators=tracecontext,baggage
 # MicroProfile Fault Tolerance
 # 全環境で有効化。@Timeout はデフォルト 30s で CI でも十分なマージンを確保。
 
-# GCP Secret Manager
-%prod.quarkus.gcp.secret-manager.enabled=true
-%docker.quarkus.gcp.secret-manager.enabled=false
+# Docker profile
 %docker.quarkus.datasource.username=${DB_USER:openpos}
 %docker.quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 

--- a/services/product-service/src/main/resources/application.properties
+++ b/services/product-service/src/main/resources/application.properties
@@ -18,7 +18,7 @@ quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
 quarkus.datasource.jdbc.max-size=10
 quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=product_schema
-quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.schema-management.strategy=none
 
 # Flyway
 quarkus.flyway.migrate-at-start=true
@@ -34,10 +34,8 @@ rabbitmq-port=${RABBITMQ_PORT:15672}
 rabbitmq-username=${RABBITMQ_USER:openpos}
 rabbitmq-password=${RABBITMQ_PASS:openpos_dev}
 
-# Structured Logging (JSON in prod)
-quarkus.log.console.json=false
-quarkus.log.console.json.additional-field.service.value=${quarkus.application.name}
-%prod.quarkus.log.console.json=true
+# Structured Logging
+quarkus.log.level=INFO
 
 # Health (Quarkus standard: /q/health/live, /q/health/ready)
 quarkus.smallrye-health.root-path=/q/health
@@ -55,9 +53,7 @@ quarkus.otel.propagators=tracecontext,baggage
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 
-# GCP Secret Manager
-%prod.quarkus.gcp.secret-manager.enabled=true
-%docker.quarkus.gcp.secret-manager.enabled=false
+# Docker profile
 %docker.quarkus.datasource.username=${DB_USER:openpos}
 %docker.quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 

--- a/services/store-service/src/main/resources/application.properties
+++ b/services/store-service/src/main/resources/application.properties
@@ -18,7 +18,7 @@ quarkus.datasource.jdbc.additional-jdbc-properties.prepareThreshold=0
 quarkus.datasource.jdbc.max-size=10
 quarkus.datasource.jdbc.min-size=2
 quarkus.hibernate-orm.database.default-schema=store_schema
-quarkus.hibernate-orm.database.generation=none
+quarkus.hibernate-orm.schema-management.strategy=none
 
 # Flyway
 quarkus.flyway.migrate-at-start=true
@@ -34,10 +34,8 @@ rabbitmq-port=${RABBITMQ_PORT:15672}
 rabbitmq-username=${RABBITMQ_USER:openpos}
 rabbitmq-password=${RABBITMQ_PASS:openpos_dev}
 
-# Structured Logging (JSON in prod)
-quarkus.log.console.json=false
-quarkus.log.console.json.additional-field.service.value=${quarkus.application.name}
-%prod.quarkus.log.console.json=true
+# Structured Logging
+quarkus.log.level=INFO
 
 # Health (Quarkus standard: /q/health/live, /q/health/ready)
 quarkus.smallrye-health.root-path=/q/health
@@ -55,9 +53,7 @@ quarkus.otel.propagators=tracecontext,baggage
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 
-# GCP Secret Manager
-%prod.quarkus.gcp.secret-manager.enabled=true
-%docker.quarkus.gcp.secret-manager.enabled=false
+# Docker profile
 %docker.quarkus.datasource.username=${DB_USER:openpos}
 %docker.quarkus.datasource.password=${DB_PASSWORD:openpos_dev}
 


### PR DESCRIPTION
## Summary
- `quarkus.log.console.json*` 設定を削除（logging-json extension が未導入のため unrecognized）
- `quarkus.gcp.secret-manager.enabled` 設定を削除（GCP extension が未導入のため unrecognized）
- `quarkus.hibernate-orm.database.generation=none` を `quarkus.hibernate-orm.schema-management.strategy=none` に置換（deprecated 対応）
- 全6サービスに適用

## Test plan
- [x] `./gradlew --parallel build` — BUILD SUCCESSFUL
- [ ] 起動時に unrecognized / deprecated warning が出ないことを確認

Closes #833
Closes #843
Closes #845