### PR TITLE
fix(metrics): deny redis.pool.* gauges to prevent duplicate registration warning

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/config/MicrometerConfig.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/config/MicrometerConfig.kt
@@ -1,0 +1,11 @@
+package com.openpos.analytics.config
+
+import io.micrometer.core.instrument.config.MeterFilter
+import jakarta.inject.Singleton
+
+@Singleton
+class MicrometerConfig {
+    @jakarta.enterprise.inject.Produces
+    @Singleton
+    fun denyRedisPoolMetrics(): MeterFilter = MeterFilter.deny { it.name.startsWith("redis.pool.") }
+}

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/MicrometerConfig.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/MicrometerConfig.kt
@@ -1,0 +1,11 @@
+package com.openpos.gateway.config
+
+import io.micrometer.core.instrument.config.MeterFilter
+import jakarta.inject.Singleton
+
+@Singleton
+class MicrometerConfig {
+    @jakarta.enterprise.inject.Produces
+    @Singleton
+    fun denyRedisPoolMetrics(): MeterFilter = MeterFilter.deny { it.name.startsWith("redis.pool.") }
+}

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/config/MicrometerConfig.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/config/MicrometerConfig.kt
@@ -1,0 +1,11 @@
+package com.openpos.inventory.config
+
+import io.micrometer.core.instrument.config.MeterFilter
+import jakarta.inject.Singleton
+
+@Singleton
+class MicrometerConfig {
+    @jakarta.enterprise.inject.Produces
+    @Singleton
+    fun denyRedisPoolMetrics(): MeterFilter = MeterFilter.deny { it.name.startsWith("redis.pool.") }
+}

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/config/MicrometerConfig.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/config/MicrometerConfig.kt
@@ -1,0 +1,11 @@
+package com.openpos.pos.config
+
+import io.micrometer.core.instrument.config.MeterFilter
+import jakarta.inject.Singleton
+
+@Singleton
+class MicrometerConfig {
+    @jakarta.enterprise.inject.Produces
+    @Singleton
+    fun denyRedisPoolMetrics(): MeterFilter = MeterFilter.deny { it.name.startsWith("redis.pool.") }
+}

--- a/services/product-service/src/main/kotlin/com/openpos/product/config/MicrometerConfig.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/config/MicrometerConfig.kt
@@ -1,0 +1,11 @@
+package com.openpos.product.config
+
+import io.micrometer.core.instrument.config.MeterFilter
+import jakarta.inject.Singleton
+
+@Singleton
+class MicrometerConfig {
+    @jakarta.enterprise.inject.Produces
+    @Singleton
+    fun denyRedisPoolMetrics(): MeterFilter = MeterFilter.deny { it.name.startsWith("redis.pool.") }
+}

--- a/services/store-service/src/main/kotlin/com/openpos/store/config/MicrometerConfig.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/config/MicrometerConfig.kt
@@ -1,0 +1,11 @@
+package com.openpos.store.config
+
+import io.micrometer.core.instrument.config.MeterFilter
+import jakarta.inject.Singleton
+
+@Singleton
+class MicrometerConfig {
+    @jakarta.enterprise.inject.Produces
+    @Singleton
+    fun denyRedisPoolMetrics(): MeterFilter = MeterFilter.deny { it.name.startsWith("redis.pool.") }
+}


### PR DESCRIPTION
## Summary
- Quarkus Redis client が接続プール初期化時に `redis.pool.*` gauge を複数回登録し、起動時に重複登録 warning が出ていた
- 全6サービスに `MeterFilter` CDI Bean を追加し、`redis.pool.*` メトリクスを deny することで warning を解消

## Test plan
- [x] `./gradlew --parallel build` — BUILD SUCCESSFUL
- [ ] local demo 起動時に `This Gauge has been already registered` warning が出ないことを確認

Closes #836