### PR TITLE
fix(analytics-service): accept any payload type in RabbitMQ consumers

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventConsumer.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventConsumer.kt
@@ -28,9 +28,9 @@ class EventConsumer {
     private val log = Logger.getLogger(EventConsumer::class.java)
 
     @Incoming("sale-completed-events")
-    fun onSaleCompleted(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
+    fun onSaleCompleted(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = message.payload
+            val body = message.payload.toString()
             val envelope = objectMapper.readValue(body, EventEnvelopeDto::class.java)
             val eventId = UUID.fromString(envelope.eventId)
 
@@ -48,9 +48,9 @@ class EventConsumer {
         }
 
     @Incoming("sale-voided-events")
-    fun onSaleVoided(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
+    fun onSaleVoided(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = message.payload
+            val body = message.payload.toString()
             val envelope = objectMapper.readValue(body, EventEnvelopeDto::class.java)
             val eventId = UUID.fromString(envelope.eventId)
 

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/EventConsumerTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/EventConsumerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.vertx.core.json.JsonObject
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -57,8 +58,8 @@ class EventConsumerTest {
     // --- ヘルパー ---
 
     @Suppress("UNCHECKED_CAST")
-    private fun mockMessage(body: String): IncomingRabbitMQMessage<String> {
-        val message = mock<IncomingRabbitMQMessage<String>>()
+    private fun mockMessage(body: Any): IncomingRabbitMQMessage<*> {
+        val message = mock<IncomingRabbitMQMessage<Any>>()
         whenever(message.payload).thenReturn(body)
         whenever(message.ack()).thenReturn(CompletableFuture.completedFuture(null))
         whenever(message.nack(any<Throwable>())).thenReturn(CompletableFuture.completedFuture(null))
@@ -169,6 +170,22 @@ class EventConsumerTest {
         }
 
         @Test
+        fun `JsonObjectペイロードでもprocessSaleCompletedが呼ばれる`() {
+            // Arrange
+            val json = buildSaleCompletedJson()
+            val jsonObject = JsonObject(json)
+            val message = mockMessage(jsonObject)
+
+            // Act
+            consumer.onSaleCompleted(message)
+
+            // Assert
+            verify(idempotentHandler).handleIdempotent(eq(eventId), eq("sale.completed"), any())
+            verify(salesEventProcessor).processSaleCompleted(eq(orgId), any())
+            verify(message).ack()
+        }
+
+        @Test
         fun `不正なJSONではnackが呼ばれる`() {
             // Arrange
             val invalidJson = "{ invalid json }"
@@ -189,6 +206,22 @@ class EventConsumerTest {
             // Arrange
             val json = buildSaleVoidedJson()
             val message = mockMessage(json)
+
+            // Act
+            consumer.onSaleVoided(message)
+
+            // Assert
+            verify(idempotentHandler).handleIdempotent(eq(eventId), eq("sale.voided"), any())
+            verify(salesEventProcessor).processSaleVoided(eq(orgId), any())
+            verify(message).ack()
+        }
+
+        @Test
+        fun `JsonObjectペイロードでもprocessSaleVoidedが呼ばれる`() {
+            // Arrange
+            val json = buildSaleVoidedJson()
+            val jsonObject = JsonObject(json)
+            val message = mockMessage(jsonObject)
 
             // Act
             consumer.onSaleVoided(message)


### PR DESCRIPTION
## Summary
- #829 と同系統の修正。analytics-service の consumer も `IncomingRabbitMQMessage<String>` が `JsonObject` ペイロードで `ClassCastException` を起こしていた
- 型パラメータを `*` に変更し `payload.toString()` で文字列化
- `JsonObject` ペイロードのテストケースを追加

## Test plan
- [x] `./gradlew :services:analytics-service:test` — BUILD SUCCESSFUL

Closes #842