### PR TITLE
fix(entities): quote H2 reserved keyword column names

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/entity/HourlySalesEntity.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/entity/HourlySalesEntity.kt
@@ -20,7 +20,7 @@ class HourlySalesEntity : BaseEntity() {
     @Column(name = "sale_date", nullable = false)
     lateinit var saleDate: LocalDate
 
-    @Column(name = "hour", nullable = false)
+    @Column(name = "\"hour\"", nullable = false)
     var hour: Int = 0
 
     @Column(name = "total_sales", nullable = false)

--- a/services/product-service/src/main/kotlin/com/openpos/product/entity/DiscountEntity.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/entity/DiscountEntity.kt
@@ -20,7 +20,7 @@ class DiscountEntity : BaseEntity() {
     @Column(name = "discount_type", nullable = false, length = 20)
     lateinit var discountType: String
 
-    @Column(name = "value", nullable = false)
+    @Column(name = "\"value\"", nullable = false)
     var value: Long = 0
 
     @Column(name = "applies_to", nullable = false, length = 20)

--- a/services/store-service/src/main/kotlin/com/openpos/store/entity/SystemSettingEntity.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/entity/SystemSettingEntity.kt
@@ -11,10 +11,10 @@ import jakarta.persistence.Table
 @Entity
 @Table(name = "system_settings", schema = "store_schema")
 class SystemSettingEntity : BaseEntity() {
-    @Column(name = "key", nullable = false, length = 100)
+    @Column(name = "\"key\"", nullable = false, length = 100)
     lateinit var key: String
 
-    @Column(name = "value", nullable = false, columnDefinition = "text")
+    @Column(name = "\"value\"", nullable = false, columnDefinition = "text")
     var value: String = ""
 
     @Column(name = "description", length = 500)


### PR DESCRIPTION
## Summary
- H2 テスト DB で reserved keyword (`hour`, `key`, `value`) がカラム名として使用されており DDL エラーが発生
- `@Column(name)` にエスケープ引用符を追加し、PostgreSQL と H2 の両方で動作するように修正

## Test plan
- [x] `./gradlew --parallel build` — BUILD SUCCESSFUL
- [ ] `./gradlew --parallel test` で H2 DDL エラーが出ないことを確認

Closes #841