### PR TITLE
chore(grpc): suppress unused gRPC client interceptor warning

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -5,6 +5,7 @@ quarkus.shutdown.timeout=30s
 # gRPC code generation
 quarkus.generate-code.grpc.kotlin.generate=false
 quarkus.http.port=${QUARKUS_HTTP_PORT:8080}
+quarkus.log.category."io.quarkus.grpc.runtime.supports".level=ERROR
 
 # Security Headers
 quarkus.http.header."X-Content-Type-Options".value=nosniff

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -8,6 +8,7 @@ quarkus.generate-code.grpc.kotlin.generate=false
 # gRPC Server
 quarkus.grpc.server.port=${QUARKUS_GRPC_SERVER_PORT:9003}
 quarkus.http.port=${QUARKUS_HTTP_PORT:0}
+quarkus.log.category."io.quarkus.grpc.runtime.supports".level=ERROR
 
 # Database (via PgBouncer in transaction mode)
 quarkus.datasource.db-kind=postgresql


### PR DESCRIPTION
## Summary
- pos-service と api-gateway で inner-class gRPC interceptor が Quarkus の CDI interceptor スキャンで false positive として warning を出していた
- `io.quarkus.grpc.runtime.supports` のログレベルを ERROR に設定して warning を抑制

## Test plan
- [ ] `./gradlew --parallel test` で unused interceptor warning が出ないことを確認

Closes #844