### PR TITLE
fix(test): add Web Storage mock to Vitest setup for both frontend apps

### DIFF
--- a/apps/admin-dashboard/src/test-setup.ts
+++ b/apps/admin-dashboard/src/test-setup.ts
@@ -1,5 +1,25 @@
 import '@testing-library/jest-dom/vitest'
 
+// Web Storage mock for jsdom environments where localStorage/sessionStorage may be incomplete
+function createStorageMock(): Storage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, String(value)),
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => store.clear(),
+    get length() {
+      return store.size
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  }
+}
+
+Object.defineProperty(window, 'localStorage', { value: createStorageMock() })
+Object.defineProperty(window, 'sessionStorage', { value: createStorageMock() })
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: (query: string) => ({

--- a/apps/pos-terminal/src/test-setup.ts
+++ b/apps/pos-terminal/src/test-setup.ts
@@ -1,1 +1,21 @@
 import '@testing-library/jest-dom/vitest'
+
+// Web Storage mock for jsdom environments where localStorage/sessionStorage may be incomplete
+function createStorageMock(): Storage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, String(value)),
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => store.clear(),
+    get length() {
+      return store.size
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  }
+}
+
+Object.defineProperty(window, 'localStorage', { value: createStorageMock() })
+Object.defineProperty(window, 'sessionStorage', { value: createStorageMock() })


### PR DESCRIPTION
## Summary
- admin-dashboard / pos-terminal のテストで `localStorage.getItem is not a function` / `storage.setItem is not a function` エラーが発生していた
- 両アプリの `test-setup.ts` に Map-backed Storage mock を追加

## Test plan
- [x] `pnpm --filter admin-dashboard test -- --run` — 23 files, 213 tests passed
- [x] `pnpm --filter pos-terminal test -- --run` — 45 files, 419 tests passed

Closes #838