### PR TITLE
fix(admin): add missing routes, sidebar nav, and API endpoints

### DIFF
--- a/apps/admin-dashboard/src/App.tsx
+++ b/apps/admin-dashboard/src/App.tsx
@@ -28,6 +28,29 @@ const ActivityLogsPage = lazy(() =>
 const OnboardingPage = lazy(() =>
   import('@/routes/onboarding').then((m) => ({ default: m.OnboardingPage })),
 )
+const CustomersPage = lazy(() =>
+  import('@/routes/customers').then((m) => ({ default: m.CustomersPage })),
+)
+const NotificationsPage = lazy(() =>
+  import('@/routes/notifications').then((m) => ({ default: m.NotificationsPage })),
+)
+const TaxRatesPage = lazy(() =>
+  import('@/routes/tax-rates').then((m) => ({ default: m.TaxRatesPage })),
+)
+const OrganizationPage = lazy(() =>
+  import('@/routes/organization').then((m) => ({ default: m.OrganizationPage })),
+)
+const DiscountsPage = lazy(() =>
+  import('@/routes/discounts').then((m) => ({ default: m.DiscountsPage })),
+)
+const ReportsPage = lazy(() => import('@/routes/reports').then((m) => ({ default: m.ReportsPage })))
+const ExportPage = lazy(() => import('@/routes/export').then((m) => ({ default: m.ExportPage })))
+const TerminalsPage = lazy(() =>
+  import('@/routes/terminals').then((m) => ({ default: m.TerminalsPage })),
+)
+const NotFoundPage = lazy(() =>
+  import('@/routes/not-found').then((m) => ({ default: m.NotFoundPage })),
+)
 
 function RouteLoading() {
   return (
@@ -42,81 +65,153 @@ export function App() {
     <ErrorBoundary>
       <BrowserRouter>
         <Routes>
-        <Route element={<Layout />}>
-          <Route index element={<DashboardPage />} />
-          <Route
-            path="products"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <ProductsPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="categories"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <CategoriesPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="stores"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <StoresPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="staff"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <StaffPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="settings"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <SettingsPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="inventory"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <InventoryPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="purchase-orders"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <PurchaseOrdersPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="activity-logs"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <ActivityLogsPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="onboarding"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <OnboardingPage />
-              </Suspense>
-            }
-          />
-        </Route>
+          <Route element={<Layout />}>
+            <Route index element={<DashboardPage />} />
+            <Route
+              path="products"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <ProductsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="categories"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <CategoriesPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="stores"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <StoresPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="staff"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <StaffPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="settings"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <SettingsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="inventory"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <InventoryPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="purchase-orders"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <PurchaseOrdersPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="activity-logs"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <ActivityLogsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="onboarding"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <OnboardingPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="customers"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <CustomersPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="notifications"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <NotificationsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="tax-rates"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <TaxRatesPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="organization"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <OrganizationPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="discounts"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <DiscountsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="reports"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <ReportsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="export"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <ExportPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="terminals"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <TerminalsPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="*"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <NotFoundPage />
+                </Suspense>
+              }
+            />
+          </Route>
         </Routes>
       </BrowserRouter>
     </ErrorBoundary>

--- a/apps/admin-dashboard/src/components/app-sidebar.tsx
+++ b/apps/admin-dashboard/src/components/app-sidebar.tsx
@@ -9,6 +9,9 @@ import {
   Warehouse,
   ClipboardList,
   ScrollText,
+  UserRound,
+  Bell,
+  Receipt,
 } from 'lucide-react'
 
 import {
@@ -32,7 +35,10 @@ const navItems = [
   { title: '発注管理', url: '/purchase-orders', icon: ClipboardList },
   { title: '店舗管理', url: '/stores', icon: Store },
   { title: 'スタッフ管理', url: '/staff', icon: Users },
+  { title: '顧客管理', url: '/customers', icon: UserRound },
+  { title: '税率管理', url: '/tax-rates', icon: Receipt },
   { title: '操作履歴', url: '/activity-logs', icon: ScrollText },
+  { title: '通知', url: '/notifications', icon: Bell },
   { title: '設定', url: '/settings', icon: Settings },
 ]
 

--- a/apps/pos-terminal/src/App.tsx
+++ b/apps/pos-terminal/src/App.tsx
@@ -21,25 +21,34 @@ export function App() {
     <ErrorBoundary>
       <BrowserRouter>
         <Routes>
-        <Route element={<Layout />}>
-          <Route index element={<ProductsPage />} />
-          <Route
-            path="cart"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <CartPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="history"
-            element={
-              <Suspense fallback={<RouteLoading />}>
-                <HistoryPage />
-              </Suspense>
-            }
-          />
-        </Route>
+          <Route element={<Layout />}>
+            <Route index element={<ProductsPage />} />
+            <Route
+              path="cart"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <CartPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="history"
+              element={
+                <Suspense fallback={<RouteLoading />}>
+                  <HistoryPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="*"
+              element={
+                <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8">
+                  <h1 className="text-2xl font-bold">ページが見つかりません</h1>
+                  <p className="text-muted-foreground">指定されたURLは存在しません。</p>
+                </div>
+              }
+            />
+          </Route>
         </Routes>
       </BrowserRouter>
     </ErrorBoundary>

--- a/proto/openpos/product/v1/product.proto
+++ b/proto/openpos/product/v1/product.proto
@@ -41,6 +41,8 @@ service ProductService {
   rpc ListTaxRates(ListTaxRatesRequest) returns (ListTaxRatesResponse);
   // 税率を更新する
   rpc UpdateTaxRate(UpdateTaxRateRequest) returns (UpdateTaxRateResponse);
+  // 税率を削除する
+  rpc DeleteTaxRate(DeleteTaxRateRequest) returns (DeleteTaxRateResponse);
 
   // 割引を作成する（パーセント割引・定額割引）
   rpc CreateDiscount(CreateDiscountRequest) returns (CreateDiscountResponse);
@@ -451,6 +453,15 @@ message UpdateTaxRateRequest {
   // デフォルト税率フラグ（presence 付き更新用）
   google.protobuf.BoolValue is_default_value = 7;
 }
+
+// 税率削除リクエスト
+message DeleteTaxRateRequest {
+  // 税率ID（UUID）
+  string id = 1;
+}
+
+// 税率削除レスポンス（空レスポンス）
+message DeleteTaxRateResponse {}
 
 // 割引作成リクエスト
 message CreateDiscountRequest {

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CurrentOrganizationResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CurrentOrganizationResource.kt
@@ -1,0 +1,72 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
+import com.openpos.gateway.config.toMap
+import io.quarkus.grpc.GrpcClient
+import io.smallrye.common.annotation.Blocking
+import jakarta.inject.Inject
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PUT
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+import openpos.store.v1.GetOrganizationRequest
+import openpos.store.v1.StoreServiceGrpc
+import openpos.store.v1.UpdateOrganizationRequest
+import org.eclipse.microprofile.faulttolerance.Timeout
+
+/**
+ * X-Organization-Id ヘッダーで特定される「現在の組織」を操作する補助エンドポイント。
+ * Admin ダッシュボードの組織設定画面は /api/organization (単数形) を呼び出すため、
+ * 組織 ID をパスに含めずに自分の組織を取得・更新できるようにする。
+ */
+@Path("/api/organization")
+@Blocking
+@Timeout(30000)
+class CurrentOrganizationResource {
+    @Inject
+    @GrpcClient("store-service")
+    lateinit var stub: StoreServiceGrpc.StoreServiceBlockingStub
+
+    @Inject
+    lateinit var grpc: GrpcClientHelper
+
+    @Inject
+    lateinit var tenantContext: TenantContext
+
+    @GET
+    fun getCurrent(): Response {
+        val orgId =
+            tenantContext.organizationId
+                ?: return Response
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity(mapOf("error" to "MISSING_ORGANIZATION_ID", "message" to "X-Organization-Id header is required"))
+                    .build()
+        val response =
+            grpc
+                .withTenant(stub)
+                .getOrganization(GetOrganizationRequest.newBuilder().setId(orgId.toString()).build())
+        return Response.ok(response.organization.toMap()).build()
+    }
+
+    @PUT
+    fun updateCurrent(body: UpdateOrganizationBody): Response {
+        val orgId =
+            tenantContext.organizationId
+                ?: return Response
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity(mapOf("error" to "MISSING_ORGANIZATION_ID", "message" to "X-Organization-Id header is required"))
+                    .build()
+        val request =
+            UpdateOrganizationRequest
+                .newBuilder()
+                .setId(orgId.toString())
+                .apply {
+                    body.name?.let { setName(it) }
+                    body.businessType?.let { setBusinessType(it) }
+                    body.invoiceNumber?.let { setInvoiceNumber(it) }
+                }.build()
+        val response = grpc.withTenant(stub).updateOrganization(request)
+        return Response.ok(response.organization.toMap()).build()
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TaxRateResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TaxRateResource.kt
@@ -6,6 +6,7 @@ import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
 import jakarta.inject.Inject
+import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.PUT
@@ -13,6 +14,7 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.core.Response
 import openpos.product.v1.CreateTaxRateRequest
+import openpos.product.v1.DeleteTaxRateRequest
 import openpos.product.v1.ListTaxRatesRequest
 import openpos.product.v1.ProductServiceGrpc
 import openpos.product.v1.UpdateTaxRateRequest
@@ -72,6 +74,15 @@ class TaxRateResource {
             .updateTaxRate(request)
             .taxRate
             .toMap()
+    }
+
+    @DELETE
+    @Path("/{id}")
+    fun delete(
+        @PathParam("id") id: String,
+    ): Response {
+        grpc.withTenant(stub).deleteTaxRate(DeleteTaxRateRequest.newBuilder().setId(id).build())
+        return Response.noContent().build()
     }
 }
 

--- a/services/product-service/src/main/kotlin/com/openpos/product/grpc/ProductGrpcService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/grpc/ProductGrpcService.kt
@@ -34,6 +34,8 @@ import openpos.product.v1.DeleteCategoryRequest
 import openpos.product.v1.DeleteCategoryResponse
 import openpos.product.v1.DeleteProductRequest
 import openpos.product.v1.DeleteProductResponse
+import openpos.product.v1.DeleteTaxRateRequest
+import openpos.product.v1.DeleteTaxRateResponse
 import openpos.product.v1.Discount
 import openpos.product.v1.DiscountType
 import openpos.product.v1.GetProductByBarcodeRequest
@@ -347,6 +349,19 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
         responseObserver.onNext(
             UpdateTaxRateResponse.newBuilder().setTaxRate(entity.toProto()).build(),
         )
+        responseObserver.onCompleted()
+    }
+
+    override fun deleteTaxRate(
+        request: DeleteTaxRateRequest,
+        responseObserver: io.grpc.stub.StreamObserver<DeleteTaxRateResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val deleted = taxRateService.delete(request.id.toUUID())
+        if (!deleted) {
+            throw Status.NOT_FOUND.withDescription("TaxRate not found: ${request.id}").asRuntimeException()
+        }
+        responseObserver.onNext(DeleteTaxRateResponse.getDefaultInstance())
         responseObserver.onCompleted()
     }
 

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateService.kt
@@ -74,6 +74,18 @@ class TaxRateService {
     }
 
     /**
+     * 税率を削除する（論理削除: isActive = false）。
+     */
+    @Transactional
+    fun delete(id: UUID): Boolean {
+        tenantFilterService.enableFilter()
+        val entity = taxRateRepository.findById(id) ?: return false
+        entity.isActive = false
+        taxRateRepository.persist(entity)
+        return true
+    }
+
+    /**
      * 税率を更新する。
      */
     @Transactional


### PR DESCRIPTION
## Summary

- Admin ダッシュボードに未マウントだった9つのルート（customers, notifications, tax-rates, organization, discounts, reports, export, terminals, 404 catch-all）を lazy-loaded Route として追加
- POS ターミナルにインライン 404 catch-all route を追加
- サイドバーに顧客管理・税率管理・通知のナビゲーションリンクを追加
- `/api/organization`（単数形）エンドポイントを新設し、OrganizationPage が X-Organization-Id ヘッダーのテナント情報で自身の組織を GET/PUT できるように修正
- `DELETE /api/tax-rates/{id}` を proto → product-service → api-gateway の全層で実装し、税率管理画面の削除操作を機能させた

## Changes

| File | Change |
|------|--------|
| `apps/admin-dashboard/src/App.tsx` | 9 lazy imports + 9 Route + catch-all 追加 |
| `apps/admin-dashboard/src/components/app-sidebar.tsx` | 顧客・税率・通知のナビリンク追加 |
| `apps/pos-terminal/src/App.tsx` | インライン 404 catch-all route 追加 |
| `proto/openpos/product/v1/product.proto` | DeleteTaxRate RPC + message 定義追加 |
| `services/api-gateway/.../CurrentOrganizationResource.kt` | `/api/organization` GET/PUT 新設 |
| `services/api-gateway/.../TaxRateResource.kt` | DELETE endpoint 追加 |
| `services/product-service/.../ProductGrpcService.kt` | deleteTaxRate handler 追加 |
| `services/product-service/.../TaxRateService.kt` | delete() メソッド追加（論理削除） |

## Test plan

- [x] `pnpm --filter admin-dashboard typecheck` pass
- [x] `pnpm --filter pos-terminal typecheck` pass
- [x] `pnpm --filter admin-dashboard lint` pass
- [x] `pnpm --filter pos-terminal lint` pass
- [x] `pnpm --filter admin-dashboard test` — 213 tests pass
- [x] `pnpm --filter pos-terminal test` — 419 tests pass
- [x] `./gradlew :services:product-service:build` pass
- [x] `./gradlew :services:api-gateway:build` pass
- [x] `buf lint` pass

Closes #823, Closes #824, Closes #832, Closes #834, Closes #835, Closes #837