### PR TITLE
fix(api-gateway): enforce tenant boundary JWT validation

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/AuthFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/AuthFilter.kt
@@ -88,6 +88,42 @@ class AuthFilter : ContainerRequestFilter {
             requestContext.headers.putSingle("X-Staff-Role", role)
             tenantContext.staffRole = role
         }
+
+        // テナント境界検証: JWT の organization_id クレームと X-Organization-Id ヘッダーを照合
+        val jwtOrgId = jwt.getClaim<String>("organization_id")
+        if (!jwtOrgId.isNullOrBlank() && tenantContext.organizationId != null) {
+            try {
+                val jwtOrgUuid = java.util.UUID.fromString(jwtOrgId)
+                if (jwtOrgUuid != tenantContext.organizationId) {
+                    logger.warnf(
+                        "Tenant boundary violation: JWT org=%s, request org=%s, staff=%s",
+                        jwtOrgId,
+                        tenantContext.organizationId,
+                        subject,
+                    )
+                    requestContext.abortWith(
+                        Response
+                            .status(Response.Status.FORBIDDEN)
+                            .entity(
+                                mapOf(
+                                    "error" to "Forbidden",
+                                    "message" to "Organization ID mismatch between token and request",
+                                ),
+                            ).build(),
+                    )
+                    return
+                }
+            } catch (_: IllegalArgumentException) {
+                logger.warnf("Invalid organization_id claim in JWT: %s", jwtOrgId)
+                requestContext.abortWith(
+                    Response
+                        .status(Response.Status.FORBIDDEN)
+                        .entity(mapOf("error" to "Forbidden", "message" to "Invalid organization_id in token"))
+                        .build(),
+                )
+                return
+            }
+        }
     }
 
     @Inject


### PR DESCRIPTION
## Summary
- AuthFilterでJWTの`organization_id`クレームを取得し、TenantRequestFilterで設定された`organizationId`と照合
- 不一致時は403 Forbiddenを返却し、クロステナントアクセスを防止
- 不正な`organization_id`クレームも403で拒否

## Test plan
- [ ] JWTのorg_idとヘッダーのorg_idが一致する場合、リクエストが通過することを確認
- [ ] JWTのorg_idとヘッダーのorg_idが不一致の場合、403が返却されることを確認
- [ ] JWTにorg_idクレームがない場合、既存動作に影響がないことを確認

Closes #879