### PR TITLE
fix(infra): wire session JWT secret to api-gateway deployment

### DIFF
--- a/infra/k8s/api-gateway.yaml
+++ b/infra/k8s/api-gateway.yaml
@@ -41,6 +41,11 @@ spec:
                 secretKeyRef:
                   name: openpos-secrets
                   key: HYDRA_ISSUER
+            - name: OPENPOS_SESSION_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: openpos-secrets
+                  key: OPENPOS_SESSION_JWT_SECRET
           startupProbe:
             httpGet:
               path: /q/health/live

--- a/infra/k8s/secrets.yaml
+++ b/infra/k8s/secrets.yaml
@@ -28,3 +28,6 @@ stringData:
   # --- ORY Hydra (JWT / OIDC) ---
   HYDRA_JWKS_URL: 'CHANGE_ME'
   HYDRA_ISSUER: 'CHANGE_ME'
+
+  # --- Session JWT ---
+  OPENPOS_SESSION_JWT_SECRET: 'CHANGE_ME'


### PR DESCRIPTION
## Summary
- api-gateway.yamlにOPENPOS_SESSION_JWT_SECRET環境変数を追加（secretRefで注入）
- secrets.yamlテンプレートにも対応するキーを追加
- external-secret.yamlは既にopenpos-session-jwt-secretを参照済み

## Test plan
- [ ] api-gatewayデプロイ時にOPENPOS_SESSION_JWT_SECRETが注入されることを確認
- [ ] セッションJWTの生成・検証が正常に動作することを確認

Closes #882