### PR TITLE
fix(infra): fix prod deploy path and add part-of labels

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -184,7 +184,11 @@ jobs:
 
       - name: Apply production ConfigMaps
         run: |
-          kubectl apply -f infra/k8s/configmap-prod.yaml
+          if [ -f infra/k8s/configmap-prod.yaml ]; then
+            kubectl apply -f infra/k8s/configmap-prod.yaml
+          else
+            echo "::warning::configmap-prod.yaml not found — using per-service ConfigMaps from k8s manifests"
+          fi
 
       - name: Update image tags in manifests
         run: |

--- a/infra/k8s/analytics-service.yaml
+++ b/infra/k8s/analytics-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openpos
   labels:
     app: analytics-service
+    app.kubernetes.io/part-of: openpos
 spec:
   replicas: 2
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app: analytics-service
+        app.kubernetes.io/part-of: openpos
     spec:
       containers:
         - name: analytics-service

--- a/infra/k8s/api-gateway.yaml
+++ b/infra/k8s/api-gateway.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openpos
   labels:
     app: api-gateway
+    app.kubernetes.io/part-of: openpos
 spec:
   replicas: 2
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app: api-gateway
+        app.kubernetes.io/part-of: openpos
     spec:
       containers:
         - name: api-gateway

--- a/infra/k8s/inventory-service.yaml
+++ b/infra/k8s/inventory-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openpos
   labels:
     app: inventory-service
+    app.kubernetes.io/part-of: openpos
 spec:
   replicas: 2
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app: inventory-service
+        app.kubernetes.io/part-of: openpos
     spec:
       containers:
         - name: inventory-service

--- a/infra/k8s/pos-service.yaml
+++ b/infra/k8s/pos-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openpos
   labels:
     app: pos-service
+    app.kubernetes.io/part-of: openpos
 spec:
   replicas: 2
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app: pos-service
+        app.kubernetes.io/part-of: openpos
     spec:
       containers:
         - name: pos-service

--- a/infra/k8s/product-service.yaml
+++ b/infra/k8s/product-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openpos
   labels:
     app: product-service
+    app.kubernetes.io/part-of: openpos
 spec:
   replicas: 2
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app: product-service
+        app.kubernetes.io/part-of: openpos
     spec:
       containers:
         - name: product-service

--- a/infra/k8s/store-service.yaml
+++ b/infra/k8s/store-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openpos
   labels:
     app: store-service
+    app.kubernetes.io/part-of: openpos
 spec:
   replicas: 2
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app: store-service
+        app.kubernetes.io/part-of: openpos
     spec:
       containers:
         - name: store-service


### PR DESCRIPTION
## Summary
- cd.ymlのconfigmap-prod.yaml適用ステップにファイル存在チェックを追加（セキュリティ上gitignoreされるファイルのため）
- 全6バックエンドDeploymentに`app.kubernetes.io/part-of: openpos`ラベルを追加（metadata + pod template）

## Test plan
- [ ] configmap-prod.yamlが存在しない場合、warningログで続行されることを確認
- [ ] configmap-prod.yamlが存在する場合、正常にapplyされることを確認
- [ ] kubectl get deployments -n openpos --show-labels でpart-ofラベルが表示されることを確認

Closes #883