### PR TITLE
fix(terraform): pass db_password to cloud_sql module

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -80,6 +80,7 @@ module "cloud_sql" {
   secondary_region = var.secondary_region
   environment      = var.environment
   db_tier          = var.db_tier
+  db_password      = var.db_password
   network_id       = module.networking.vpc_id
 
   depends_on = [module.networking]

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -44,3 +44,9 @@ variable "redis_tier" {
   type        = string
   default     = "STANDARD_HA"
 }
+
+variable "db_password" {
+  description = "Cloud SQL database password"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- root variables.tfに`db_password`変数を追加（sensitive）
- main.tfのcloud_sqlモジュール呼び出しに`db_password = var.db_password`を追加
- これにより、cloud-sql/main.tfの`google_sql_user`リソースに正しくパスワードが設定される

## Test plan
- [ ] `terraform plan`で変数の追加が反映されることを確認
- [ ] `terraform apply`でCloud SQLユーザーにパスワードが設定されることを確認

Closes #884