### PR TITLE
fix(ci): add clean + quarkusGenerateCode before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
           java-version: '21'
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       # TODO: detekt CI統合（Gradle plugin方式でConfiguration Cache競合のため保留 #638）
+      - name: Clean generated sources to avoid stale cache
+        run: ./gradlew --parallel clean quarkusGenerateCode
       - name: Build, Test & Coverage Verification
         run: >-
           ./gradlew --parallel


### PR DESCRIPTION
## Summary
- CIのbackendジョブにclean + quarkusGenerateCodeステップを追加
- Gradleキャッシュからのstaleな生成コードによるビルド失敗を防止

## Test plan
- [ ] CIのbackendジョブが正常にパスすることを確認
- [ ] proto変更時にもビルドが正しく動作することを確認

Closes #885