### PR TITLE
fix(ci): add analytics-service to coverage quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
           :services:store-service:jacocoTestCoverageVerification
           :services:pos-service:jacocoTestCoverageVerification
           :services:inventory-service:jacocoTestCoverageVerification
+          :services:analytics-service:jacocoTestCoverageVerification
       - name: Upload Coverage Reports
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
## Summary
- analytics-serviceをjacocoTestCoverageVerificationタスクリストに追加
- 全6サービスが同一の品質ゲートを通過することを保証

## Test plan
- [ ] CIのbackendジョブでanalytics-serviceのカバレッジ検証が実行されることを確認

Closes #886