### PR TITLE
fix(api-gateway): change RateLimitFilter to fail-closed

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/RateLimitFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/RateLimitFilter.kt
@@ -20,7 +20,7 @@ import java.time.Instant
  * 1分あたりの最大リクエスト数を制限する。
  * organization_id が未設定のリクエストは "anonymous" としてカウント。
  * Redis INCR + EXPIRE による分散レートリミット。
- * Redis 障害時はリクエストを許可する（fail-open）。
+ * Redis 障害時は 429 を返す（fail-closed）。
  */
 @Provider
 @Priority(Priorities.AUTHENTICATION + 5)
@@ -62,8 +62,19 @@ class RateLimitFilter :
 
         val currentCount = tryIncrement(redisKey)
 
-        // Redis 障害時は -1 が返る → fail-open でリクエスト許可
+        // Redis 障害時は -1 が返る → fail-closed で 429 を返す
         if (currentCount < 0) {
+            requestContext.abortWith(
+                Response
+                    .status(429)
+                    .header("Retry-After", 60)
+                    .entity(
+                        mapOf(
+                            "error" to "Too Many Requests",
+                            "message" to "Rate limiting unavailable. Please retry later.",
+                        ),
+                    ).build(),
+            )
             return
         }
 
@@ -105,7 +116,7 @@ class RateLimitFilter :
 
     /**
      * Redis INCR + EXPIRE でリクエスト数をカウントする。
-     * Redis 障害時は -1 を返す（fail-open）。
+     * Redis 障害時は -1 を返す（呼び出し元で fail-closed 処理）。
      */
     internal fun tryIncrement(key: String): Long =
         try {


### PR DESCRIPTION
## Summary
- RateLimitFilterのRedis障害時の動作をfail-openからfail-closedに変更
- Redis例外発生時は429 Too Many Requestsを返却（Retry-After: 60秒）
- Redis障害中のレートリミットバイパスを防止

## Test plan
- [ ] Redis正常時のレートリミットが従来通り動作することを確認
- [ ] Redis障害時に429が返却されることを確認
- [ ] Retry-Afterヘッダーが60秒で設定されることを確認

Closes #887