### PR TITLE
fix(api-gateway): disable placeholder endpoints with @DenyAll

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GiftCardResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GiftCardResource.kt
@@ -11,7 +11,8 @@ import jakarta.ws.rs.core.Response
 
 /**
  * ギフトカード REST リソース (#142)。
- * 未実装: gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * 未実装: gRPC バックエンドが未整備のため全エンドポイントが 501 Not Implemented を返す。
+ * 本番では実装されるまで明示的に 501 でブロックする。
  */
 @Path("/api/gift-cards")
 @Blocking

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ImageUploadResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ImageUploadResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.security.DenyAll
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
@@ -9,10 +10,11 @@ import jakarta.ws.rs.core.Response
 
 /**
  * 画像アップロード REST リソース (#173)。
- * 未実装: オブジェクトストレージ連携が未整備のため 501 を返す。
+ * 未実装: オブジェクトストレージ連携が未整備のため全エンドポイントをブロック。
  */
 @Path("/api/images")
 @Blocking
+@DenyAll
 class ImageUploadResource {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)


### PR DESCRIPTION
## Summary
- ImageUploadResource: @DenyAllアノテーションを追加し、未実装エンドポイントへのアクセスを完全にブロック
- GiftCardResource: 既に全エンドポイントが501を返却済み。ドキュメント明確化

## Test plan
- [ ] ImageUploadResourceへのリクエストが403で拒否されることを確認
- [ ] GiftCardResourceへのリクエストが501で返却されることを確認

Closes #888