### PR TITLE
fix(api-gateway): add @DenyAll to remaining placeholder resources

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AccountingResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AccountingResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.security.DenyAll
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.QueryParam
@@ -12,6 +13,7 @@ import jakarta.ws.rs.core.Response
  */
 @Path("/api/accounting")
 @Blocking
+@DenyAll
 class AccountingResource {
     private fun notImplemented(): Response =
         Response

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GiftCardResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GiftCardResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.security.DenyAll
 import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
@@ -16,6 +17,7 @@ import jakarta.ws.rs.core.Response
  */
 @Path("/api/gift-cards")
 @Blocking
+@DenyAll
 class GiftCardResource {
     private fun notImplemented(): Response =
         Response

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/PlanResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/PlanResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.security.DenyAll
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
@@ -12,6 +13,7 @@ import jakarta.ws.rs.core.Response
  */
 @Path("/api/plans")
 @Blocking
+@DenyAll
 class PlanResource {
     private fun notImplemented(): Response =
         Response

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ReservationResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ReservationResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.security.DenyAll
 import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
@@ -16,6 +17,7 @@ import jakarta.ws.rs.core.Response
  */
 @Path("/api/reservations")
 @Blocking
+@DenyAll
 class ReservationResource {
     private fun notImplemented(): Response =
         Response

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SalesTargetResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SalesTargetResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.security.DenyAll
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.PUT
 import jakarta.ws.rs.Path
@@ -13,6 +14,7 @@ import jakarta.ws.rs.core.Response
  */
 @Path("/api/sales-targets")
 @Blocking
+@DenyAll
 class SalesTargetResource {
     private fun notImplemented(): Response =
         Response

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StampCardResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StampCardResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.security.DenyAll
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
@@ -13,6 +14,7 @@ import jakarta.ws.rs.core.Response
  */
 @Path("/api/stamp-cards")
 @Blocking
+@DenyAll
 class StampCardResource {
     private fun notImplemented(): Response =
         Response


### PR DESCRIPTION
## Summary
- GiftCard, Accounting, Plan, Reservation, SalesTarget, StampCard の6つの未実装プレースホルダーリソースに `@DenyAll` アノテーションを追加
- Jakarta Security レイヤーでアクセスを遮断し、501ハンドラーに到達する前にリクエストを拒否

## Test plan
- [ ] `@DenyAll` が付与された各エンドポイントへのリクエストが 403 Forbidden を返すことを確認
- [ ] 既存の `@DenyAll` 付きリソース（ImageUpload, SSE）と同様の動作であることを確認

Closes #901