### PR TITLE
fix(api-gateway): enforce authentication in production profile

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -62,6 +62,9 @@ quarkus.otel.propagators=tracecontext,baggage
 %prod.quarkus.otel.traces.sampler=traceidratio
 %prod.quarkus.otel.traces.sampler.arg=0.1
 
+# Production auth: always enforce authentication
+%prod.openpos.auth.enabled=true
+
 # Structured Logging
 quarkus.log.level=INFO
 


### PR DESCRIPTION
## Summary
- `%prod.openpos.auth.enabled=true` を追加し、本番環境で認証が常に有効化されるよう強制
- 環境変数によるオーバーライドで認証を無効化することを防止

## Test plan
- [ ] 本番プロファイルで `openpos.auth.enabled` が true であることを確認
- [ ] dev/test プロファイルでは既存の動作に影響がないことを確認

Closes #904