### PR TITLE
fix: set %prod CORS origins to require explicit configuration

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -15,12 +15,12 @@ quarkus.http.header."Permissions-Policy".value=camera=(), microphone=(), geoloca
 %prod.quarkus.http.header."Strict-Transport-Security".value=max-age=31536000; includeSubDomains
 
 # CORS
-# WARNING: 本番では CORS_ORIGINS に実際のドメインを設定すること（ワイルドカード * は禁止）
 quarkus.http.cors.enabled=true
-quarkus.http.cors.origins=${CORS_ORIGINS:http://localhost:5173,http://localhost:5174}
+quarkus.http.cors.origins=http://localhost:5173,http://localhost:5174
 quarkus.http.cors.methods=GET,POST,PUT,DELETE,PATCH,OPTIONS
 quarkus.http.cors.headers=accept,authorization,content-type,x-requested-with,x-organization-id
 quarkus.http.cors.exposed-headers=location
+%prod.quarkus.http.cors.origins=${CORS_ALLOWED_ORIGINS:https://pos.example.com}
 
 # JWT (ORY Hydra)
 mp.jwt.verify.publickey.location=${HYDRA_JWKS_URL:http://localhost:14444/.well-known/jwks.json}


### PR DESCRIPTION
## Summary
- `%prod.quarkus.http.cors.origins` を追加し、本番環境では `CORS_ALLOWED_ORIGINS` 環境変数から CORS origins を読み取るように変更
- デフォルト値を `localhost` から安全なプレースホルダー (`https://pos.example.com`) に変更し、本番で localhost origins が残ることを防止
- dev/test 用の CORS origins はハードコードの `localhost:5173,5174` に固定（環境変数の上書き不要）

## Test plan
- [ ] `%prod` プロファイルで `CORS_ALLOWED_ORIGINS` 未設定時に `https://pos.example.com` がデフォルトになることを確認
- [ ] `CORS_ALLOWED_ORIGINS=https://myapp.example.com` 設定時に正しく反映されることを確認
- [ ] dev/test プロファイルでは従来通り `localhost:5173,5174` が使われることを確認

Closes #907