### PR TITLE
fix(infra): add securityContext to all K8s deployments

### DIFF
--- a/infra/k8s/analytics-service.yaml
+++ b/infra/k8s/analytics-service.yaml
@@ -85,6 +85,10 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/api-gateway.yaml
+++ b/infra/k8s/api-gateway.yaml
@@ -74,6 +74,10 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/inventory-service.yaml
+++ b/infra/k8s/inventory-service.yaml
@@ -85,6 +85,10 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/pos-service.yaml
+++ b/infra/k8s/pos-service.yaml
@@ -85,6 +85,10 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/product-service.yaml
+++ b/infra/k8s/product-service.yaml
@@ -85,6 +85,10 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/store-service.yaml
+++ b/infra/k8s/store-service.yaml
@@ -85,6 +85,10 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- 全6サービスの Deployment yaml に container-level securityContext を追加
- `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`
- 本番環境でのコンテナハードニング強化

## Test plan
- [ ] K8s manifest の構文検証（`kubectl apply --dry-run=client`）
- [ ] Pod が正常に起動することをステージング環境で確認

Closes #905