### PR TITLE
docs(infra): improve ExternalSecret projectID guidance

### DIFF
--- a/infra/k8s/external-secret.yaml
+++ b/infra/k8s/external-secret.yaml
@@ -16,7 +16,10 @@ metadata:
 spec:
   provider:
     gcpsm:
-      projectID: CHANGE_ME # GCP Project ID
+      # TODO(deploy): Replace with your GCP project ID before deploying.
+      # Find it via: gcloud config get-value project
+      # Example: projectID: my-company-prod-12345
+      projectID: CHANGE_ME
 
 ---
 apiVersion: external-secrets.io/v1beta1


### PR DESCRIPTION
## Summary
- ExternalSecret の `projectID: CHANGE_ME` にデプロイ前に設定が必要である旨のコメントを追加
- GCP project ID の確認コマンドとフォーマット例を記載

## Test plan
- [ ] YAML 構文が正しいことを確認

Closes #906