### PR TITLE
fix: ExternalSecret projectID を CD パイプラインで自動置換 (#906)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -176,6 +176,10 @@ jobs:
           kubectl get nodes -o wide
           kubectl get ns openpos || kubectl create ns openpos
 
+      - name: Inject GCP Project ID into ExternalSecret manifest
+        run: |
+          sed -i "s/__GCP_PROJECT_ID__/${{ secrets.GCP_PROJECT_ID }}/" infra/k8s/external-secret.yaml
+
       - name: Apply ExternalSecret for GCP Secret Manager
         run: |
           kubectl apply -f infra/k8s/external-secret.yaml

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -42,6 +42,7 @@ helm install external-secrets external-secrets/external-secrets \
 2. Required reviewers に承認者を追加
 3. 以下の Secrets を設定:
    - `KUBE_CONFIG_PRODUCTION`: base64 エンコードされた kubeconfig
+   - `GCP_PROJECT_ID`: GCP プロジェクト ID（Terraform の `var.project_id` と同じ値）
 
 ## Deployment Steps
 
@@ -80,9 +81,20 @@ kubectl apply -f infra/k8s/configmap-prod.yaml
 
 ### 3. ExternalSecret 適用
 
+CD パイプライン経由のデプロイでは、GitHub Secrets の `GCP_PROJECT_ID` が
+`infra/k8s/external-secret.yaml` 内の `__GCP_PROJECT_ID__` プレースホルダーに
+自動で注入される。
+
+**GitHub Secrets に追加が必要:**
+- Repository Settings > Secrets and variables > Actions > Environment secrets (`production`)
+- Name: `GCP_PROJECT_ID`, Value: Terraform の `project_id` と同じ値
+
+手動デプロイの場合:
+
 ```bash
-# SecretStore の projectID を GCP プロジェクトに変更
-vi infra/k8s/external-secret.yaml
+# Terraform output から取得して置換
+GCP_PROJECT_ID=$(terraform -chdir=infra/terraform output -raw project_id)
+sed -i "s/__GCP_PROJECT_ID__/${GCP_PROJECT_ID}/" infra/k8s/external-secret.yaml
 kubectl apply -f infra/k8s/external-secret.yaml
 
 # 同期確認

--- a/infra/k8s/external-secret.yaml
+++ b/infra/k8s/external-secret.yaml
@@ -6,6 +6,12 @@
 #   - GCP Workload Identity で ESO の ServiceAccount に権限付与済み
 #   - SecretStore 'gcp-secret-store' が namespace に作成済み
 #
+# projectID の設定:
+#   CD パイプライン (cd.yml) が GitHub Secrets の GCP_PROJECT_ID を使って
+#   __GCP_PROJECT_ID__ プレースホルダーを自動置換する。
+#   手動デプロイ時は sed で置換するか、Terraform output を参照:
+#     terraform -chdir=infra/terraform output -raw project_id
+#
 # 参考: https://external-secrets.io/latest/provider/google-secrets-manager/
 # ============================================================================
 apiVersion: external-secrets.io/v1beta1
@@ -16,7 +22,7 @@ metadata:
 spec:
   provider:
     gcpsm:
-      projectID: CHANGE_ME # GCP Project ID
+      projectID: __GCP_PROJECT_ID__
 
 ---
 apiVersion: external-secrets.io/v1beta1


### PR DESCRIPTION
## Summary

- `infra/k8s/external-secret.yaml` の `CHANGE_ME` プレースホルダーを `__GCP_PROJECT_ID__` に変更
- CD パイプライン (`cd.yml`) の `deploy-prod` ジョブに `sed` 置換ステップを追加し、GitHub Secrets `GCP_PROJECT_ID` から自動注入
- `docs/guides/production-deployment.md` に `GCP_PROJECT_ID` シークレットの設定手順と手動デプロイ時の Terraform output 参照手順を追記

## Required Setup

production 環境の GitHub Secrets に `GCP_PROJECT_ID` を追加する必要があります（Terraform の `var.project_id` と同じ値）。

## Test plan

- [x] `actionlint` で `cd.yml` の構文検証済み
- [x] `__GCP_PROJECT_ID__` が `external-secret.yaml` 内に正しく設定されていることを確認
- [ ] CD パイプラインで `sed` 置換が正しく動作することを確認（staging/production デプロイ時）

Closes #906