### PR TITLE
fix(api-gateway): enforce auth in production profile

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -26,6 +26,9 @@ quarkus.http.cors.exposed-headers=location
 mp.jwt.verify.publickey.location=${HYDRA_JWKS_URL:http://localhost:14444/.well-known/jwks.json}
 mp.jwt.verify.issuer=${HYDRA_ISSUER:http://localhost:14444/}
 
+# Auth: always enforce in production (prevent bypass via env override)
+%prod.openpos.auth.enabled=true
+
 # Session JWT signing key (Base64-encoded HMAC-SHA256 secret, min 256 bits)
 # Production: inject via GCP Secret Manager → OPENPOS_SESSION_JWT_SECRET env var
 # Rotation: update secret + rolling restart. Old tokens expire naturally (8h TTL).


### PR DESCRIPTION
## Summary
- `%prod.openpos.auth.enabled=true` を `application.properties` に追加し、本番環境で認証が常に有効であることを保証
- 環境変数による `openpos.auth.enabled=false` 上書きを本番プロファイルで不可能にする
- これにより `AuthFilter` が必ず動作し、`TenantContext.requireRole()` で `staffRole=null` によるロールチェックスキップが発生しない

## Background
`TenantContext.requireRole()` は `staffRole` が null の場合にチェックをスキップする設計（dev/test用）。本番では `AuthFilter` が JWT から role を取得して設定するが、`openpos.auth.enabled` が環境変数で false に上書きされると認証バイパスが発生する。`%prod` プロファイルで true を強制することでこのリスクを排除する。

## Test plan
- [ ] テストプロファイルでは `openpos.auth.enabled=false` が維持されていることを確認
- [ ] `%prod` プロファイルで `openpos.auth.enabled=true` が適用されることを確認
- [ ] CI テスト通過を確認

Closes #904