### PR TITLE
fix(api-gateway): fix TenantRequestFilter priority to run before AuthFilter

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/TenantRequestFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/TenantRequestFilter.kt
@@ -10,7 +10,7 @@ import jakarta.ws.rs.ext.Provider
 import java.util.UUID
 
 @Provider
-@Priority(Priorities.AUTHENTICATION + 10)
+@Priority(Priorities.AUTHENTICATION - 10)
 class TenantRequestFilter : ContainerRequestFilter {
     @Inject
     lateinit var tenantContext: TenantContext


### PR DESCRIPTION
## Summary
- TenantRequestFilter priority changed from `AUTHENTICATION+10` (1010) to `AUTHENTICATION-10` (990)
- This ensures tenant context is populated **before** AuthFilter runs its JWT org claim vs X-Organization-Id check
- Previously, the boundary check at AuthFilter:94 was dead code (tenantContext.organizationId was always null)

## Test plan
- [x] `./gradlew :services:api-gateway:test` passes (139 tests)
- [ ] E2E tests pass in CI

Closes #918