### PR TITLE
fix: add RBAC requireRole to CUD endpoints in 6 resources

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CategoryResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CategoryResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -31,8 +32,12 @@ class CategoryResource {
     @Inject
     lateinit var grpc: GrpcClientHelper
 
+    @Inject
+    lateinit var tenantContext: TenantContext
+
     @POST
     fun create(body: CreateCategoryBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val request =
             CreateCategoryRequest
                 .newBuilder()
@@ -69,6 +74,7 @@ class CategoryResource {
         @PathParam("id") id: String,
         body: UpdateCategoryBody,
     ): Map<String, Any?> {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val request =
             UpdateCategoryRequest
                 .newBuilder()
@@ -92,6 +98,7 @@ class CategoryResource {
     fun delete(
         @PathParam("id") id: String,
     ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         grpc.withTenant(stub).deleteCategory(DeleteCategoryRequest.newBuilder().setId(id).build())
         return Response.noContent().build()
     }

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CouponResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CouponResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -26,6 +27,9 @@ class CouponResource {
     @Inject
     lateinit var grpc: GrpcClientHelper
 
+    @Inject
+    lateinit var tenantContext: TenantContext
+
     @GET
     fun list(): List<Map<String, Any?>> {
         // product-service に ListCoupons RPC はないため、
@@ -37,6 +41,7 @@ class CouponResource {
 
     @POST
     fun create(body: CreateCouponBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val request =
             CreateCouponRequest
                 .newBuilder()

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CurrentOrganizationResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/CurrentOrganizationResource.kt
@@ -51,6 +51,7 @@ class CurrentOrganizationResource {
 
     @PUT
     fun updateCurrent(body: UpdateOrganizationBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val orgId =
             tenantContext.organizationId
                 ?: return Response

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/DiscountResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/DiscountResource.kt
@@ -2,6 +2,7 @@ package com.openpos.gateway.resource
 
 import com.google.protobuf.BoolValue
 import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -32,8 +33,12 @@ class DiscountResource {
     @Inject
     lateinit var grpc: GrpcClientHelper
 
+    @Inject
+    lateinit var tenantContext: TenantContext
+
     @POST
     fun create(body: CreateDiscountBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val request =
             CreateDiscountRequest
                 .newBuilder()
@@ -62,6 +67,7 @@ class DiscountResource {
         @PathParam("id") id: String,
         body: UpdateDiscountBody,
     ): Map<String, Any?> {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val request =
             UpdateDiscountRequest
                 .newBuilder()
@@ -86,6 +92,7 @@ class DiscountResource {
     fun delete(
         @PathParam("id") id: String,
     ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         grpc.withTenant(stub).deleteDiscount(DeleteDiscountRequest.newBuilder().setId(id).build())
         return Response.noContent().build()
     }

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SystemSettingResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SystemSettingResource.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -29,6 +30,9 @@ class SystemSettingResource {
     @Inject
     lateinit var grpc: GrpcClientHelper
 
+    @Inject
+    lateinit var tenantContext: TenantContext
+
     @GET
     fun list(): List<Map<String, Any?>> {
         val response = grpc.withTenant(stub).listSystemSettings(ListSystemSettingsRequest.getDefaultInstance())
@@ -52,6 +56,7 @@ class SystemSettingResource {
         @PathParam("key") key: String,
         body: UpsertSettingBody,
     ): Map<String, Any?> {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val request =
             UpsertSystemSettingRequest
                 .newBuilder()
@@ -71,6 +76,7 @@ class SystemSettingResource {
     fun delete(
         @PathParam("key") key: String,
     ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         grpc.withTenant(stub).deleteSystemSetting(DeleteSystemSettingRequest.newBuilder().setKey(key).build())
         return Response.noContent().build()
     }

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TaxRateResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TaxRateResource.kt
@@ -2,6 +2,7 @@ package com.openpos.gateway.resource
 
 import com.google.protobuf.BoolValue
 import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -31,8 +32,12 @@ class TaxRateResource {
     @Inject
     lateinit var grpc: GrpcClientHelper
 
+    @Inject
+    lateinit var tenantContext: TenantContext
+
     @POST
     fun create(body: CreateTaxRateBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val request =
             CreateTaxRateRequest
                 .newBuilder()
@@ -59,6 +64,7 @@ class TaxRateResource {
         @PathParam("id") id: String,
         body: UpdateTaxRateBody,
     ): Map<String, Any?> {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val request =
             UpdateTaxRateRequest
                 .newBuilder()
@@ -81,6 +87,7 @@ class TaxRateResource {
     fun delete(
         @PathParam("id") id: String,
     ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         grpc.withTenant(stub).deleteTaxRate(DeleteTaxRateRequest.newBuilder().setId(id).build())
         return Response.noContent().build()
     }

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/CategoryResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/CategoryResourceTest.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import openpos.product.v1.Category
@@ -26,6 +27,7 @@ class CategoryResourceTest {
         CategoryResource().also { r ->
             ProductResourceTest.setField(r, "stub", stub)
             ProductResourceTest.setField(r, "grpc", grpc)
+            ProductResourceTest.setField(r, "tenantContext", TenantContext())
         }
 
     private val orgId = UUID.randomUUID().toString()

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/TaxRateResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/TaxRateResourceTest.kt
@@ -1,6 +1,7 @@
 package com.openpos.gateway.resource
 
 import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
 import openpos.product.v1.CreateTaxRateResponse
 import openpos.product.v1.ListTaxRatesResponse
 import openpos.product.v1.ProductServiceGrpc
@@ -22,6 +23,7 @@ class TaxRateResourceTest {
         TaxRateResource().also { r ->
             ProductResourceTest.setField(r, "stub", stub)
             ProductResourceTest.setField(r, "grpc", grpc)
+            ProductResourceTest.setField(r, "tenantContext", TenantContext())
         }
 
     private val orgId = UUID.randomUUID().toString()


### PR DESCRIPTION
## Summary

- SystemSettingResource / TaxRateResource / CategoryResource / CouponResource / DiscountResource / CurrentOrganizationResource の CUD エンドポイントに `tenantContext.requireRole("OWNER", "MANAGER")` を追加
- STAFF ロールによる不正な作成・更新・削除操作を防止
- 既存テスト（TaxRateResourceTest, CategoryResourceTest）に TenantContext のモック注入を追加

## Test plan

- [x] `./gradlew :services:api-gateway:test` — 141 tests passed, 0 failures
- [ ] CI で全テスト pass を確認

Closes #928