### PR TITLE
fix: PurchaseOrderにoptimistic lockを追加し二重処理を防止

### DIFF
--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/entity/PurchaseOrderEntity.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/entity/PurchaseOrderEntity.kt
@@ -3,6 +3,7 @@ package com.openpos.inventory.entity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import jakarta.persistence.Version
 import java.time.Instant
 import java.util.UUID
 
@@ -31,4 +32,11 @@ class PurchaseOrderEntity : BaseEntity() {
 
     @Column(name = "received_at")
     var receivedAt: Instant? = null
+
+    /**
+     * 楽観的ロック用バージョン番号。
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long = 0
 }

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/PurchaseOrderService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/PurchaseOrderService.kt
@@ -6,9 +6,12 @@ import com.openpos.inventory.entity.PurchaseOrderEntity
 import com.openpos.inventory.entity.PurchaseOrderItemEntity
 import com.openpos.inventory.repository.PurchaseOrderItemRepository
 import com.openpos.inventory.repository.PurchaseOrderRepository
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
 import io.quarkus.panache.common.Page
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import jakarta.persistence.OptimisticLockException
 import jakarta.transaction.Transactional
 import java.time.Instant
 import java.util.UUID
@@ -139,7 +142,14 @@ class PurchaseOrderService {
             }
         }
 
-        purchaseOrderRepository.persist(order)
+        try {
+            purchaseOrderRepository.persist(order)
+            purchaseOrderRepository.flush()
+        } catch (e: OptimisticLockException) {
+            throw StatusRuntimeException(
+                Status.ABORTED.withDescription("Concurrent modification detected for PurchaseOrder: $id"),
+            )
+        }
         return order
     }
 

--- a/services/inventory-service/src/main/resources/db/migration/V9__add_purchase_orders_version.sql
+++ b/services/inventory-service/src/main/resources/db/migration/V9__add_purchase_orders_version.sql
@@ -1,0 +1,2 @@
+-- Add optimistic lock version column to purchase_orders
+ALTER TABLE inventory_schema.purchase_orders ADD COLUMN version BIGINT NOT NULL DEFAULT 0;

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/PurchaseOrderServiceTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/PurchaseOrderServiceTest.kt
@@ -6,10 +6,12 @@ import com.openpos.inventory.entity.PurchaseOrderEntity
 import com.openpos.inventory.entity.PurchaseOrderItemEntity
 import com.openpos.inventory.repository.PurchaseOrderItemRepository
 import com.openpos.inventory.repository.PurchaseOrderRepository
+import io.grpc.StatusRuntimeException
 import io.quarkus.panache.common.Page
 import io.quarkus.test.InjectMock
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
+import jakarta.persistence.OptimisticLockException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -329,6 +332,32 @@ class PurchaseOrderServiceTest {
             assertThrows(IllegalArgumentException::class.java) {
                 purchaseOrderService.updateStatus(orderId, "ORDERED", emptyList())
             }
+        }
+
+        @Test
+        fun `楽観的ロック競合時はStatusRuntimeExceptionを投げる`() {
+            // Arrange
+            val orderId = UUID.randomUUID()
+            val entity =
+                PurchaseOrderEntity().apply {
+                    this.id = orderId
+                    this.organizationId = orgId
+                    this.storeId = this@PurchaseOrderServiceTest.storeId
+                    this.supplierName = "テスト仕入先"
+                    this.status = "DRAFT"
+                }
+            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(entity)
+            doNothing().whenever(purchaseOrderRepository).persist(any<PurchaseOrderEntity>())
+            doThrow(OptimisticLockException("concurrent modification"))
+                .whenever(purchaseOrderRepository)
+                .flush()
+
+            // Act & Assert
+            val exception =
+                assertThrows(StatusRuntimeException::class.java) {
+                    purchaseOrderService.updateStatus(orderId, "ORDERED", emptyList())
+                }
+            assertEquals(io.grpc.Status.Code.ABORTED, exception.status.code)
         }
     }
 }


### PR DESCRIPTION
## Summary
- PurchaseOrderEntityに`@Version`フィールドを追加し、JPA楽観的ロックを有効化
- `updateStatus()`でOptimisticLockExceptionをキャッチし、gRPC `ABORTED`ステータスを返却
- Flyway V9マイグレーションで`purchase_orders`テーブルに`version`カラムを追加
- 楽観的ロック競合時のテストケースを追加

## Test plan
- [x] `楽観的ロック競合時はStatusRuntimeExceptionを投げる` テストがパスすることを確認
- [x] 既存のPurchaseOrderServiceTestが全てパスすることを確認
- [x] `./gradlew :services:inventory-service:test` BUILD SUCCESSFUL

Closes #923