### PR TITLE
fix(api-gateway): server-side unitPrice validation for offline sync

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SyncResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SyncResource.kt
@@ -4,6 +4,7 @@ import com.openpos.gateway.config.GrpcClientHelper
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
 import jakarta.inject.Inject
+import jakarta.ws.rs.BadRequestException
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import openpos.pos.v1.OfflineTransaction
@@ -12,15 +13,19 @@ import openpos.pos.v1.PaymentInput
 import openpos.pos.v1.PaymentMethod
 import openpos.pos.v1.PosServiceGrpc
 import openpos.pos.v1.SyncOfflineTransactionsRequest
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.faulttolerance.Timeout
 import org.jboss.logging.Logger
 
 /**
  * オフライン取引同期エンドポイント。
  *
- * WARNING: クライアント送信の unitPrice/taxRate はオフライン時のスナップショットであり、
- * サーバー側で商品マスタの最新価格と突き合わせ検証すべき。
- * 現在は価格差異をログ出力するのみ。v1.1 でサーバー側価格検証を実装予定。
+ * unitPrice のバリデーション:
+ * - unitPrice <= 0 は即座に拒否（BadRequest）
+ * - unitPrice > maxUnitPrice は WARNING ログ出力後に拒否（BadRequest）
+ *
+ * NOTE: クライアント送信の unitPrice/taxRate はオフライン時のスナップショットであり、
+ * 商品マスタの最新価格との突き合わせ検証は v1.1 で実装予定。
  */
 @Path("/api/sync")
 @Blocking
@@ -36,6 +41,9 @@ class SyncResource {
 
     @Inject
     lateinit var grpc: GrpcClientHelper
+
+    @ConfigProperty(name = "openpos.sync.max-unit-price", defaultValue = "10000000")
+    var maxUnitPrice: Long = 10_000_000
 
     @POST
     @Path("/transactions")
@@ -54,16 +62,7 @@ class SyncResource {
                             .apply { t.createdAt?.let { setCreatedAt(it) } }
                             .addAllItems(
                                 t.items.map { item ->
-                                    // WARNING: クライアント提供の unitPrice はオフラインスナップショット
-                                    // サーバー側で商品マスタ価格との突き合わせ検証が必要（v1.1実装予定）
-                                    if (item.unitPrice <= 0) {
-                                        log.warnf(
-                                            "Suspicious offline item price: productId=%s, unitPrice=%d, clientId=%s",
-                                            item.productId,
-                                            item.unitPrice,
-                                            t.clientId,
-                                        )
-                                    }
+                                    validateUnitPrice(item, t.clientId)
                                     OfflineTransactionItem
                                         .newBuilder()
                                         .setProductId(item.productId)
@@ -107,6 +106,35 @@ class SyncResource {
                     )
                 },
         )
+    }
+
+    private fun validateUnitPrice(
+        item: OfflineItemBody,
+        clientId: String,
+    ) {
+        if (item.unitPrice <= 0) {
+            log.warnf(
+                "Invalid offline item price: productId=%s, unitPrice=%d, clientId=%s",
+                item.productId,
+                item.unitPrice,
+                clientId,
+            )
+            throw BadRequestException(
+                "Invalid unitPrice for product ${item.productId}: must be greater than 0",
+            )
+        }
+        if (item.unitPrice > maxUnitPrice) {
+            log.warnf(
+                "Offline item price exceeds maximum: productId=%s, unitPrice=%d, maxUnitPrice=%d, clientId=%s",
+                item.productId,
+                item.unitPrice,
+                maxUnitPrice,
+                clientId,
+            )
+            throw BadRequestException(
+                "unitPrice for product ${item.productId} exceeds maximum allowed price",
+            )
+        }
     }
 }
 

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -93,6 +93,9 @@ quarkus.grpc.clients.inventory-service.keep-alive-timeout=5s
 quarkus.grpc.clients.analytics-service.keep-alive-time=30s
 quarkus.grpc.clients.analytics-service.keep-alive-timeout=5s
 
+# Offline sync price validation (sen units: 10000000 = 100万円)
+openpos.sync.max-unit-price=${OPENPOS_SYNC_MAX_UNIT_PRICE:10000000}
+
 # MicroProfile Fault Tolerance
 # 全環境で有効化。@Timeout(30000) で CI でも十分なマージンを確保。
 # 本番はより短いタイムアウトを設定可能。

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/SyncResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/SyncResourceTest.kt
@@ -1,0 +1,264 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.GrpcClientHelper
+import jakarta.ws.rs.BadRequestException
+import openpos.pos.v1.PosServiceGrpc
+import openpos.pos.v1.SyncOfflineTransactionsResponse
+import openpos.pos.v1.SyncResult
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class SyncResourceTest {
+    private val stub: PosServiceGrpc.PosServiceBlockingStub = mock()
+    private val grpc: GrpcClientHelper = mock()
+    private val resource =
+        SyncResource().also { r ->
+            ProductResourceTest.setField(r, "stub", stub)
+            ProductResourceTest.setField(r, "grpc", grpc)
+            ProductResourceTest.setField(r, "maxUnitPrice", 10_000_000L)
+        }
+
+    private val clientId = UUID.randomUUID().toString()
+    private val storeId = UUID.randomUUID().toString()
+    private val terminalId = UUID.randomUUID().toString()
+    private val staffId = UUID.randomUUID().toString()
+
+    private fun buildItem(
+        unitPrice: Long = 10000,
+        productId: String = UUID.randomUUID().toString(),
+    ) = OfflineItemBody(
+        productId = productId,
+        productName = "テスト商品",
+        unitPrice = unitPrice,
+        quantity = 1,
+        taxRateName = "標準税率",
+        taxRate = "0.10",
+        isReducedTax = false,
+    )
+
+    private fun buildPayment(amount: Long = 10000) = PaymentInputBody(method = "CASH", amount = amount, received = amount)
+
+    private fun buildTransaction(items: List<OfflineItemBody> = listOf(buildItem())) =
+        OfflineTransactionBody(
+            clientId = clientId,
+            storeId = storeId,
+            terminalId = terminalId,
+            staffId = staffId,
+            items = items,
+            payments = listOf(buildPayment()),
+        )
+
+    private fun buildBody(transactions: List<OfflineTransactionBody> = listOf(buildTransaction())) =
+        SyncTransactionsBody(transactions = transactions)
+
+    @BeforeEach
+    fun setUp() {
+        whenever(grpc.withTenant(stub)).thenReturn(stub)
+    }
+
+    @Nested
+    inner class ValidPrice {
+        @Test
+        fun `正常な価格でsync成功`() {
+            // Arrange
+            whenever(stub.syncOfflineTransactions(any())).thenReturn(
+                SyncOfflineTransactionsResponse
+                    .newBuilder()
+                    .addResults(
+                        SyncResult
+                            .newBuilder()
+                            .setClientId(clientId)
+                            .setSuccess(true)
+                            .setTransactionId(UUID.randomUUID().toString())
+                            .build(),
+                    ).build(),
+            )
+
+            // Act
+            val result = resource.syncTransactions(buildBody())
+
+            // Assert
+            @Suppress("UNCHECKED_CAST")
+            val results = result["results"] as List<Map<String, Any?>>
+            assertEquals(1, results.size)
+            assertEquals(true, results[0]["success"])
+        }
+
+        @Test
+        fun `1銭（最小有効価格）でsync成功`() {
+            // Arrange
+            whenever(stub.syncOfflineTransactions(any())).thenReturn(
+                SyncOfflineTransactionsResponse
+                    .newBuilder()
+                    .addResults(
+                        SyncResult
+                            .newBuilder()
+                            .setClientId(clientId)
+                            .setSuccess(true)
+                            .setTransactionId(UUID.randomUUID().toString())
+                            .build(),
+                    ).build(),
+            )
+
+            // Act
+            val result =
+                resource.syncTransactions(
+                    buildBody(listOf(buildTransaction(items = listOf(buildItem(unitPrice = 1))))),
+                )
+
+            // Assert
+            @Suppress("UNCHECKED_CAST")
+            val results = result["results"] as List<Map<String, Any?>>
+            assertEquals(1, results.size)
+        }
+
+        @Test
+        fun `上限ちょうどの価格でsync成功`() {
+            // Arrange
+            whenever(stub.syncOfflineTransactions(any())).thenReturn(
+                SyncOfflineTransactionsResponse
+                    .newBuilder()
+                    .addResults(
+                        SyncResult
+                            .newBuilder()
+                            .setClientId(clientId)
+                            .setSuccess(true)
+                            .setTransactionId(UUID.randomUUID().toString())
+                            .build(),
+                    ).build(),
+            )
+
+            // Act
+            val result =
+                resource.syncTransactions(
+                    buildBody(listOf(buildTransaction(items = listOf(buildItem(unitPrice = 10_000_000))))),
+                )
+
+            // Assert
+            @Suppress("UNCHECKED_CAST")
+            val results = result["results"] as List<Map<String, Any?>>
+            assertEquals(1, results.size)
+        }
+    }
+
+    @Nested
+    inner class ZeroPrice {
+        @Test
+        fun `unitPrice=0でBadRequestException`() {
+            // Arrange
+            val body = buildBody(listOf(buildTransaction(items = listOf(buildItem(unitPrice = 0)))))
+
+            // Act & Assert
+            val ex =
+                assertThrows<BadRequestException> {
+                    resource.syncTransactions(body)
+                }
+            assertEquals(true, ex.message?.contains("must be greater than 0"))
+        }
+    }
+
+    @Nested
+    inner class NegativePrice {
+        @Test
+        fun `unitPrice=-1でBadRequestException`() {
+            // Arrange
+            val body = buildBody(listOf(buildTransaction(items = listOf(buildItem(unitPrice = -1)))))
+
+            // Act & Assert
+            val ex =
+                assertThrows<BadRequestException> {
+                    resource.syncTransactions(body)
+                }
+            assertEquals(true, ex.message?.contains("must be greater than 0"))
+        }
+
+        @Test
+        fun `大きな負の値でBadRequestException`() {
+            // Arrange
+            val body =
+                buildBody(
+                    listOf(buildTransaction(items = listOf(buildItem(unitPrice = -999_999_999)))),
+                )
+
+            // Act & Assert
+            assertThrows<BadRequestException> {
+                resource.syncTransactions(body)
+            }
+        }
+    }
+
+    @Nested
+    inner class ExceedsMaxPrice {
+        @Test
+        fun `上限超過でBadRequestException`() {
+            // Arrange
+            val body =
+                buildBody(
+                    listOf(buildTransaction(items = listOf(buildItem(unitPrice = 10_000_001)))),
+                )
+
+            // Act & Assert
+            val ex =
+                assertThrows<BadRequestException> {
+                    resource.syncTransactions(body)
+                }
+            assertEquals(true, ex.message?.contains("exceeds maximum allowed price"))
+        }
+
+        @Test
+        fun `大幅な上限超過でBadRequestException`() {
+            // Arrange
+            val body =
+                buildBody(
+                    listOf(buildTransaction(items = listOf(buildItem(unitPrice = Long.MAX_VALUE)))),
+                )
+
+            // Act & Assert
+            assertThrows<BadRequestException> {
+                resource.syncTransactions(body)
+            }
+        }
+    }
+
+    @Nested
+    inner class MultipleItems {
+        @Test
+        fun `複数アイテムのうち1つが不正な場合BadRequestException`() {
+            // Arrange
+            val items =
+                listOf(
+                    buildItem(unitPrice = 10000),
+                    buildItem(unitPrice = -1),
+                )
+            val body = buildBody(listOf(buildTransaction(items = items)))
+
+            // Act & Assert
+            assertThrows<BadRequestException> {
+                resource.syncTransactions(body)
+            }
+        }
+
+        @Test
+        fun `複数アイテムのうち1つが上限超過の場合BadRequestException`() {
+            // Arrange
+            val items =
+                listOf(
+                    buildItem(unitPrice = 10000),
+                    buildItem(unitPrice = 10_000_001),
+                )
+            val body = buildBody(listOf(buildTransaction(items = items)))
+
+            // Act & Assert
+            assertThrows<BadRequestException> {
+                resource.syncTransactions(body)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- SyncResource でオフライン取引同期時の unitPrice サーバー側検証を追加
- `unitPrice <= 0` は BadRequest で即座に拒否
- `unitPrice > maxUnitPrice` (設定可能、デフォルト: 10,000,000銭 = 100万円) は WARNING ログ出力後に BadRequest で拒否
- `openpos.sync.max-unit-price` ConfigProperty を追加（環境変数 `OPENPOS_SYNC_MAX_UNIT_PRICE` で上書き可能）
- 境界値テスト含む包括的なユニットテストを追加（0円、1銭、負値、上限ちょうど、上限超過、Long.MAX_VALUE、複数アイテム混在）

## Test plan
- [x] `./gradlew :services:api-gateway:test` 全テスト通過
- [ ] CI 通過を確認

Closes #934