### PR TITLE
fix: 金額・割引率の入力範囲バリデーション追加

### DIFF
--- a/services/product-service/src/main/kotlin/com/openpos/product/service/CouponService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/CouponService.kt
@@ -56,6 +56,12 @@ class CouponService {
                 "organizationId is not set"
             }
 
+        val discount =
+            requireNotNull(discountRepository.findById(discountId)) {
+                "Discount not found: $discountId"
+            }
+        DiscountService.validateDiscountValue(discount.discountType, discount.value)
+
         val entity =
             CouponEntity().apply {
                 this.organizationId = orgId

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/DiscountService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/DiscountService.kt
@@ -42,6 +42,29 @@ class DiscountService {
     companion object {
         const val DISCOUNT_TTL_SECONDS = 1800L
         private const val PREFIX = "openpos:product-service"
+
+        /**
+         * 割引値のバリデーション。
+         * PERCENTAGE: 0..100, FIXED_AMOUNT: >= 0
+         */
+        fun validateDiscountValue(
+            discountType: String,
+            value: Long,
+        ) {
+            when (discountType) {
+                "PERCENTAGE" -> {
+                    require(value in 0..100) {
+                        "PERCENTAGE discount value must be between 0 and 100, but was $value"
+                    }
+                }
+
+                "FIXED_AMOUNT" -> {
+                    require(value >= 0) {
+                        "FIXED_AMOUNT discount value must be >= 0, but was $value"
+                    }
+                }
+            }
+        }
     }
 
     private fun discountKey(
@@ -65,6 +88,8 @@ class DiscountService {
         validFrom: Instant?,
         validUntil: Instant?,
     ): DiscountEntity {
+        validateDiscountValue(discountType, value)
+
         val orgId =
             requireNotNull(organizationIdHolder.organizationId) {
                 "organizationId is not set"

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/ProductService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/ProductService.kt
@@ -40,6 +40,8 @@ class ProductService {
         imageUrl: String?,
         displayOrder: Int,
     ): ProductEntity {
+        require(price >= 0) { "Product price must be >= 0, but was $price" }
+
         val orgId =
             requireNotNull(organizationIdHolder.organizationId) {
                 "organizationId is not set"

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/CouponServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/CouponServiceTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -61,6 +62,16 @@ class CouponServiceTest {
             val validFrom = Instant.now()
             val validUntil = Instant.now().plus(30, ChronoUnit.DAYS)
             doNothing().whenever(couponRepository).persist(any<CouponEntity>())
+            val discount =
+                DiscountEntity().apply {
+                    this.id = discountId
+                    this.organizationId = orgId
+                    this.name = "有効割引"
+                    this.discountType = "PERCENTAGE"
+                    this.value = 10
+                    this.isActive = true
+                }
+            whenever(discountRepository.findById(discountId)).thenReturn(discount)
 
             // Act
             val result =
@@ -88,6 +99,16 @@ class CouponServiceTest {
         fun `利用回数無制限のクーポンを作成する`() {
             // Arrange
             doNothing().whenever(couponRepository).persist(any<CouponEntity>())
+            val discount =
+                DiscountEntity().apply {
+                    this.id = discountId
+                    this.organizationId = orgId
+                    this.name = "有効割引"
+                    this.discountType = "FIXED_AMOUNT"
+                    this.value = 50000
+                    this.isActive = true
+                }
+            whenever(discountRepository.findById(discountId)).thenReturn(discount)
 
             // Act
             val result =
@@ -106,6 +127,49 @@ class CouponServiceTest {
             assertNull(result.validUntil)
             assertEquals(true, result.isActive)
             verify(couponRepository).persist(any<CouponEntity>())
+        }
+
+        @Test
+        fun `存在しない割引IDの場合はIllegalArgumentExceptionを投げる`() {
+            // Arrange
+            whenever(discountRepository.findById(discountId)).thenReturn(null)
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException::class.java) {
+                couponService.create(
+                    code = "INVALID_DISC",
+                    discountId = discountId,
+                    maxUses = null,
+                    validFrom = null,
+                    validUntil = null,
+                )
+            }
+        }
+
+        @Test
+        fun `紐付き割引のPERCENTAGE値が不正な場合はIllegalArgumentExceptionを投げる`() {
+            // Arrange
+            val invalidDiscount =
+                DiscountEntity().apply {
+                    this.id = discountId
+                    this.organizationId = orgId
+                    this.name = "不正割引"
+                    this.discountType = "PERCENTAGE"
+                    this.value = 150
+                    this.isActive = true
+                }
+            whenever(discountRepository.findById(discountId)).thenReturn(invalidDiscount)
+
+            // Act & Assert
+            assertThrows(IllegalArgumentException::class.java) {
+                couponService.create(
+                    code = "BAD_DISCOUNT",
+                    discountId = discountId,
+                    maxUses = null,
+                    validFrom = null,
+                    validUntil = null,
+                )
+            }
         }
     }
 

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/DiscountServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/DiscountServiceTest.kt
@@ -10,6 +10,7 @@ import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -99,6 +100,105 @@ class DiscountServiceTest {
             assertNull(result.validUntil)
             assertTrue(result.isActive)
             verify(discountRepository).persist(any<DiscountEntity>())
+        }
+
+        @Test
+        fun `パーセント割引の値が0の場合は作成できる`() {
+            // Arrange
+            doNothing().whenever(discountRepository).persist(any<DiscountEntity>())
+
+            // Act
+            val result =
+                discountService.create(
+                    name = "0%割引",
+                    discountType = "PERCENTAGE",
+                    value = 0,
+                    validFrom = null,
+                    validUntil = null,
+                )
+
+            // Assert
+            assertEquals(0L, result.value)
+        }
+
+        @Test
+        fun `パーセント割引の値が100の場合は作成できる`() {
+            // Arrange
+            doNothing().whenever(discountRepository).persist(any<DiscountEntity>())
+
+            // Act
+            val result =
+                discountService.create(
+                    name = "100%割引",
+                    discountType = "PERCENTAGE",
+                    value = 100,
+                    validFrom = null,
+                    validUntil = null,
+                )
+
+            // Assert
+            assertEquals(100L, result.value)
+        }
+
+        @Test
+        fun `パーセント割引の値が101以上の場合はIllegalArgumentExceptionを投げる`() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException::class.java) {
+                discountService.create(
+                    name = "不正割引",
+                    discountType = "PERCENTAGE",
+                    value = 101,
+                    validFrom = null,
+                    validUntil = null,
+                )
+            }
+        }
+
+        @Test
+        fun `パーセント割引の値が負数の場合はIllegalArgumentExceptionを投げる`() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException::class.java) {
+                discountService.create(
+                    name = "不正割引",
+                    discountType = "PERCENTAGE",
+                    value = -1,
+                    validFrom = null,
+                    validUntil = null,
+                )
+            }
+        }
+
+        @Test
+        fun `定額割引の値が負数の場合はIllegalArgumentExceptionを投げる`() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException::class.java) {
+                discountService.create(
+                    name = "不正割引",
+                    discountType = "FIXED_AMOUNT",
+                    value = -1,
+                    validFrom = null,
+                    validUntil = null,
+                )
+            }
+        }
+
+        @Test
+        fun `定額割引の値が0の場合は作成できる`() {
+            // Arrange
+            doNothing().whenever(discountRepository).persist(any<DiscountEntity>())
+
+            // Act
+            val result =
+                discountService.create(
+                    name = "0円割引",
+                    discountType = "FIXED_AMOUNT",
+                    value = 0,
+                    validFrom = null,
+                    validUntil = null,
+                )
+
+            // Assert
+            assertEquals(0L, result.value)
         }
     }
 

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/ProductServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/ProductServiceTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -121,6 +122,47 @@ class ProductServiceTest {
             assertNull(result.taxRateId)
             assertNull(result.imageUrl)
             verify(productRepository).persist(any<ProductEntity>())
+        }
+
+        @Test
+        fun `価格が0の場合は作成できる`() {
+            // Arrange
+            doNothing().whenever(productRepository).persist(any<ProductEntity>())
+
+            // Act
+            val result =
+                productService.create(
+                    name = "無料商品",
+                    description = null,
+                    barcode = null,
+                    sku = null,
+                    price = 0L,
+                    categoryId = null,
+                    taxRateId = null,
+                    imageUrl = null,
+                    displayOrder = 0,
+                )
+
+            // Assert
+            assertEquals(0L, result.price)
+        }
+
+        @Test
+        fun `価格が負数の場合はIllegalArgumentExceptionを投げる`() {
+            // Act & Assert
+            assertThrows(IllegalArgumentException::class.java) {
+                productService.create(
+                    name = "不正商品",
+                    description = null,
+                    barcode = null,
+                    sku = null,
+                    price = -1L,
+                    categoryId = null,
+                    taxRateId = null,
+                    imageUrl = null,
+                    displayOrder = 0,
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- DiscountService: PERCENTAGE 割引値を 0-100 の範囲に制限、FIXED_AMOUNT 割引値を >= 0 に制限
- ProductService: 商品価格を >= 0 に制限
- CouponService: クーポン作成時に紐付き割引の存在確認と割引値バリデーションを追加
- 各サービスに境界値テスト（0, 100, -1, 101 等）を追加

Closes #926

## Test plan
- [x] DiscountService: PERCENTAGE 0/100 は成功、-1/101 は IllegalArgumentException
- [x] DiscountService: FIXED_AMOUNT 0 は成功、-1 は IllegalArgumentException
- [x] ProductService: price 0 は成功、-1 は IllegalArgumentException
- [x] CouponService: 存在しない割引ID は IllegalArgumentException
- [x] CouponService: 不正な割引値の割引は IllegalArgumentException
- [x] `./gradlew :services:product-service:test` 全テスト通過