### PR TITLE
test(pos-service): improve line coverage to 100%

### DIFF
--- a/services/pos-service/src/test/kotlin/com/openpos/pos/event/EventPublisherTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/event/EventPublisherTest.kt
@@ -17,6 +17,25 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
+class SaleCompletedEventDtoTest {
+    @Test
+    fun `default values are applied correctly`() {
+        val dto =
+            SaleCompletedEventDto(
+                transactionId = "tx-1",
+                storeId = "store-1",
+                terminalId = "term-1",
+                items = emptyList(),
+                totalAmount = 10000,
+                transactedAt = "2026-03-26T00:00:00Z",
+            )
+
+        assertEquals(0L, dto.taxTotal)
+        assertEquals(0L, dto.discountTotal)
+        assertEquals(emptyList<SalePaymentDto>(), dto.payments)
+    }
+}
+
 class EventPublisherTest {
     private val emitter: Emitter<String> = mock()
     private val objectMapper = ObjectMapper()

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/event/OutboxProcessorTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/event/OutboxProcessorTest.kt
@@ -133,6 +133,24 @@ class OutboxProcessorTest {
     }
 
     @Test
+    fun `PENDINGイベントがあるとき全件processEventを呼ぶ`() {
+        // Arrange
+        val event1 = createPendingEvent("sale.completed", """{"id":"1"}""")
+        val event2 = createPendingEvent("sale.voided", """{"id":"2"}""")
+        whenever(outboxRepository.findPendingEvents(OutboxProcessor.BATCH_SIZE))
+            .thenReturn(listOf(event1, event2))
+        whenever(outboxRepository.findById(event1.id)).thenReturn(event1)
+        whenever(outboxRepository.findById(event2.id)).thenReturn(event2)
+
+        // Act
+        outboxProcessor.processOutbox()
+
+        // Assert — 両イベントが送信される
+        assertEquals("SENT", event1.status)
+        assertEquals("SENT", event2.status)
+    }
+
+    @Test
     fun `リトライ9回目まではPENDINGを維持する`() {
         // Arrange
         val event = createPendingEvent("sale.voided", """{"eventType":"sale.voided"}""")

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceUnitTest.kt
@@ -1,0 +1,123 @@
+package com.openpos.pos.service
+
+import com.openpos.pos.config.OrganizationIdHolder
+import com.openpos.pos.config.TenantFilterService
+import com.openpos.pos.entity.DiscountReasonEntity
+import com.openpos.pos.repository.DiscountReasonRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+/**
+ * DiscountReasonService の純粋ユニットテスト。
+ * CDI プロキシを回避してカバレッジを確保する。
+ */
+class DiscountReasonServiceUnitTest {
+    private lateinit var service: DiscountReasonService
+    private lateinit var discountReasonRepository: DiscountReasonRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        discountReasonRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        service = DiscountReasonService()
+        service.discountReasonRepository = discountReasonRepository
+        service.tenantFilterService = tenantFilterService
+        service.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = orgId
+        doNothing().whenever(tenantFilterService).enableFilter()
+    }
+
+    @Nested
+    inner class Create {
+        @Test
+        fun `creates discount reason with correct fields`() {
+            doNothing().whenever(discountReasonRepository).persist(any<DiscountReasonEntity>())
+
+            val result = service.create("DAMAGE", "商品損傷")
+
+            assertEquals("DAMAGE", result.code)
+            assertEquals("商品損傷", result.description)
+            assertEquals(orgId, result.organizationId)
+        }
+
+        @Test
+        fun `throws when organizationId is not set`() {
+            organizationIdHolder.organizationId = null
+
+            assertThrows(IllegalArgumentException::class.java) {
+                service.create("DAMAGE", "商品損傷")
+            }
+        }
+    }
+
+    @Nested
+    inner class Update {
+        @Test
+        fun `returns null when not found`() {
+            whenever(discountReasonRepository.findById(any<UUID>())).thenReturn(null)
+
+            val result = service.update(UUID.randomUUID(), "新しい説明", null)
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `updates description only`() {
+            val id = UUID.randomUUID()
+            val entity =
+                DiscountReasonEntity().apply {
+                    this.id = id
+                    this.organizationId = orgId
+                    this.code = "DAMAGE"
+                    this.description = "旧説明"
+                    this.isActive = true
+                }
+            whenever(discountReasonRepository.findById(id)).thenReturn(entity)
+            doNothing().whenever(discountReasonRepository).persist(any<DiscountReasonEntity>())
+
+            val result = service.update(id, "新しい説明", null)
+
+            assertNotNull(result)
+            assertEquals("新しい説明", result?.description)
+            assertEquals(true, result?.isActive)
+        }
+    }
+
+    @Nested
+    inner class ListActive {
+        @Test
+        fun `returns active reasons`() {
+            val entity =
+                DiscountReasonEntity().apply {
+                    this.id = UUID.randomUUID()
+                    this.organizationId = orgId
+                    this.code = "PROMO"
+                    this.description = "キャンペーン"
+                    this.isActive = true
+                }
+            whenever(discountReasonRepository.findActive()).thenReturn(listOf(entity))
+
+            val result = service.listActive()
+
+            assertEquals(1, result.size)
+            assertEquals("PROMO", result[0].code)
+        }
+    }
+}

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/ReservationServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/ReservationServiceUnitTest.kt
@@ -8,6 +8,7 @@ import io.quarkus.panache.common.Page
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -124,6 +125,15 @@ class ReservationServiceUnitTest {
             assertEquals("[{\"productId\":\"abc\"}]", result.items)
             assertEquals(reservedUntil, result.reservedUntil)
             assertEquals("Note", result.note)
+        }
+
+        @Test
+        fun `throws when organizationId is not set`() {
+            organizationIdHolder.organizationId = null
+
+            assertThrows(IllegalArgumentException::class.java) {
+                service.create(storeId, "Customer", null, "[]", Instant.now().plusSeconds(3600), null)
+            }
         }
     }
 

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceUnitTest.kt
@@ -202,6 +202,15 @@ class TransactionServiceUnitTest {
         }
 
         @Test
+        fun `throws when transaction not found`() {
+            whenever(transactionRepository.findById(any<UUID>())).thenReturn(null)
+
+            assertThrows(ResourceNotFoundException::class.java) {
+                service.addItem(UUID.randomUUID(), productId, 1)
+            }
+        }
+
+        @Test
         fun `uses provided productSnapshot`() {
             val tx = createTransactionEntity()
             whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
@@ -398,6 +407,32 @@ class TransactionServiceUnitTest {
         }
 
         @Test
+        fun `throws when fixed amount item not found`() {
+            val tx = createTransactionEntity()
+            val fakeItemId = UUID.randomUUID()
+            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
+            whenever(itemRepository.findById(fakeItemId)).thenReturn(null)
+
+            assertThrows(IllegalArgumentException::class.java) {
+                service.applyDiscount(tx.id, null, "Item Off", "FIXED_AMOUNT", "1000", 1000, fakeItemId)
+            }
+        }
+
+        @Test
+        fun `throws when fixed amount item belongs to different transaction`() {
+            val tx = createTransactionEntity()
+            val item = createItemEntity(UUID.randomUUID()).apply { this.subtotal = 50000 } // different transaction
+            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
+            whenever(itemRepository.findById(item.id)).thenReturn(item)
+
+            assertThrows(IllegalArgumentException::class.java) {
+                service.applyDiscount(tx.id, null, "Item Off", "FIXED_AMOUNT", "1000", 1000, item.id)
+            }
+        }
+
+        @Test
         fun `throws on invalid percentage value`() {
             val tx = createTransactionEntity()
             whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
@@ -439,6 +474,15 @@ class TransactionServiceUnitTest {
             assertNotNull(result.completedAt)
             assertNotNull(result.contentHash)
             verify(eventPublisher).publish(eq("sale.completed"), eq(orgId), any())
+        }
+
+        @Test
+        fun `throws when transaction not found`() {
+            whenever(transactionRepository.findById(any<UUID>())).thenReturn(null)
+
+            assertThrows(ResourceNotFoundException::class.java) {
+                service.finalizeTransaction(UUID.randomUUID(), emptyList())
+            }
         }
 
         @Test
@@ -493,6 +537,15 @@ class TransactionServiceUnitTest {
 
             assertEquals("VOIDED", result.status)
             verify(eventPublisher).publish(eq("sale.voided"), eq(orgId), any())
+        }
+
+        @Test
+        fun `throws when transaction not found`() {
+            whenever(transactionRepository.findById(any<UUID>())).thenReturn(null)
+
+            assertThrows(ResourceNotFoundException::class.java) {
+                service.voidTransaction(UUID.randomUUID(), "reason")
+            }
         }
 
         @Test


### PR DESCRIPTION
## Summary
- pos-service の JaCoCo LINE カバレッジを 98.1% から 100% に改善
- 未カバーだった12行全てにユニットテストを追加

## 追加テスト
- OutboxProcessor.processOutbox(): pending events が存在するときのループ処理パス
- TransactionService: finalizeTransaction / voidTransaction / addItem の transaction not found パス
- TransactionService: FIXED_AMOUNT 割引の item not found / 別取引 item パス
- ReservationService.create(): organizationId 未設定時の例外パス
- DiscountReasonService.create(): organizationId 未設定時の例外パス (新規 DiscountReasonServiceUnitTest)
- SaleCompletedEventDto: デフォルト値パスのカバレッジ

## Test plan
- [x] `./gradlew :services:pos-service:test` 全テスト PASS
- [x] `./gradlew :services:pos-service:jacocoTestCoverageVerification` PASS (LINE >= 95%)
- [x] JaCoCo LINE coverage: 100% (621/621)