### PR TITLE
fix(infra): harden Promtail container security

### DIFF
--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -423,11 +423,15 @@ services:
   promtail:
     image: grafana/promtail:3.4.2
     container_name: openpos-promtail
+    # WARNING: Docker socket はローカル開発専用。本番 K8s では DaemonSet + hostPath(/var/log) を使用。
     volumes:
       - /var/log:/var/log:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./promtail/config.yml:/etc/promtail/config.yml:ro
     command: -config.file=/etc/promtail/config.yml
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
     depends_on:
       loki:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Added `read_only: true` and `no-new-privileges` to Promtail container
- Added WARNING comment that Docker socket mount is for local dev only
- Production K8s uses DaemonSet + hostPath(/var/log) pattern

## Test plan
- [x] `docker compose config` validates YAML
- [ ] E2E tests pass

Closes #925