### PR TITLE
fix(api-gateway): reject JWTs missing organization_id or role claims

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/AuthFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/AuthFilter.kt
@@ -83,15 +83,36 @@ class AuthFilter : ContainerRequestFilter {
         // スタッフ情報をヘッダーに設定（下流サービス向け）
         requestContext.headers.putSingle("X-Staff-Id", subject)
 
+        // role クレーム必須: 欠落時は認可不可
         val role = jwt.getClaim<String>("role")
-        if (!role.isNullOrBlank()) {
-            requestContext.headers.putSingle("X-Staff-Role", role)
-            tenantContext.staffRole = role
+        if (role.isNullOrBlank()) {
+            logger.debug("JWT missing required 'role' claim")
+            requestContext.abortWith(
+                Response
+                    .status(Response.Status.FORBIDDEN)
+                    .entity(mapOf("error" to "Forbidden", "message" to "Token missing required 'role' claim"))
+                    .build(),
+            )
+            return
+        }
+        requestContext.headers.putSingle("X-Staff-Role", role)
+        tenantContext.staffRole = role
+
+        // organization_id クレーム必須: 欠落時はテナント境界検証不可
+        val jwtOrgId = jwt.getClaim<String>("organization_id")
+        if (jwtOrgId.isNullOrBlank()) {
+            logger.debug("JWT missing required 'organization_id' claim")
+            requestContext.abortWith(
+                Response
+                    .status(Response.Status.FORBIDDEN)
+                    .entity(mapOf("error" to "Forbidden", "message" to "Token missing required 'organization_id' claim"))
+                    .build(),
+            )
+            return
         }
 
         // テナント境界検証: JWT の organization_id クレームと X-Organization-Id ヘッダーを照合
-        val jwtOrgId = jwt.getClaim<String>("organization_id")
-        if (!jwtOrgId.isNullOrBlank() && tenantContext.organizationId != null) {
+        if (tenantContext.organizationId != null) {
             try {
                 val jwtOrgUuid = java.util.UUID.fromString(jwtOrgId)
                 if (jwtOrgUuid != tenantContext.organizationId) {

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/config/AuthFilterTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/config/AuthFilterTest.kt
@@ -160,6 +160,7 @@ class AuthFilterTest {
             whenever(requestContext.getHeaderString("Authorization")).thenReturn("Bearer valid-token")
             whenever(jwt.subject).thenReturn(staffId)
             whenever(jwt.getClaim<String>("role")).thenReturn("MANAGER")
+            whenever(jwt.getClaim<String>("organization_id")).thenReturn("550e8400-e29b-41d4-a716-446655440099")
 
             // Act
             filter.filter(requestContext)


### PR DESCRIPTION
## Summary
- AuthFilter now returns 403 when JWT lacks `role` or `organization_id` claims
- Previously these checks were silently skipped (fail-open)
- Test updated to include organization_id claim

Closes #952