### PR TITLE
fix(infra): add gRPC and RabbitMQ env vars to K8s manifests

### DIFF
--- a/infra/k8s/analytics-service.yaml
+++ b/infra/k8s/analytics-service.yaml
@@ -66,6 +66,10 @@ spec:
                 secretKeyRef:
                   name: openpos-secrets
                   key: RABBITMQ_PASS
+            - name: RABBITMQ_HOST
+              value: rabbitmq
+            - name: RABBITMQ_PORT
+              value: '5672'
           startupProbe:
             httpGet:
               path: /q/health/live

--- a/infra/k8s/api-gateway.yaml
+++ b/infra/k8s/api-gateway.yaml
@@ -55,6 +55,30 @@ spec:
                 secretKeyRef:
                   name: openpos-secrets
                   key: OPENPOS_SESSION_JWT_SECRET
+            - name: PRODUCT_SERVICE_HOST
+              value: product-service
+            - name: PRODUCT_SERVICE_PORT
+              value: '9000'
+            - name: STORE_SERVICE_HOST
+              value: store-service
+            - name: STORE_SERVICE_PORT
+              value: '9000'
+            - name: POS_SERVICE_HOST
+              value: pos-service
+            - name: POS_SERVICE_PORT
+              value: '9000'
+            - name: INVENTORY_SERVICE_HOST
+              value: inventory-service
+            - name: INVENTORY_SERVICE_PORT
+              value: '9000'
+            - name: ANALYTICS_SERVICE_HOST
+              value: analytics-service
+            - name: ANALYTICS_SERVICE_PORT
+              value: '9000'
+            - name: RABBITMQ_HOST
+              value: rabbitmq
+            - name: RABBITMQ_PORT
+              value: '5672'
           startupProbe:
             httpGet:
               path: /q/health/live

--- a/infra/k8s/inventory-service.yaml
+++ b/infra/k8s/inventory-service.yaml
@@ -66,6 +66,10 @@ spec:
                 secretKeyRef:
                   name: openpos-secrets
                   key: RABBITMQ_PASS
+            - name: RABBITMQ_HOST
+              value: rabbitmq
+            - name: RABBITMQ_PORT
+              value: '5672'
           startupProbe:
             httpGet:
               path: /q/health/live

--- a/infra/k8s/pos-service.yaml
+++ b/infra/k8s/pos-service.yaml
@@ -66,6 +66,18 @@ spec:
                 secretKeyRef:
                   name: openpos-secrets
                   key: RABBITMQ_PASS
+            - name: PRODUCT_SERVICE_HOST
+              value: product-service
+            - name: PRODUCT_SERVICE_PORT
+              value: '9000'
+            - name: INVENTORY_SERVICE_HOST
+              value: inventory-service
+            - name: INVENTORY_SERVICE_PORT
+              value: '9000'
+            - name: RABBITMQ_HOST
+              value: rabbitmq
+            - name: RABBITMQ_PORT
+              value: '5672'
           startupProbe:
             httpGet:
               path: /q/health/live


### PR DESCRIPTION
## Summary
- Add gRPC service discovery env vars (HOST/PORT) to K8s deployment manifests for inter-service communication (#959)
- Add RABBITMQ_HOST and RABBITMQ_PORT env vars to services that consume RabbitMQ (#960)

### Changes
| Manifest | gRPC env vars | RabbitMQ env vars |
|----------|--------------|-------------------|
| api-gateway | PRODUCT, STORE, POS, INVENTORY, ANALYTICS SERVICE_HOST/PORT | RABBITMQ_HOST/PORT |
| pos-service | PRODUCT, INVENTORY SERVICE_HOST/PORT | RABBITMQ_HOST/PORT |
| inventory-service | — | RABBITMQ_HOST/PORT |
| analytics-service | — | RABBITMQ_HOST/PORT |

All host values use K8s service names (e.g., `product-service`, `rabbitmq`) and gRPC port `9000` / AMQP port `5672`.

## Test plan
- [ ] Verify `kubectl apply -f infra/k8s/` succeeds without errors
- [ ] Verify env vars are injected into pods via `kubectl exec <pod> -- env | grep SERVICE`
- [ ] Verify gRPC connectivity between api-gateway and backend services
- [ ] Verify RabbitMQ connectivity from pos/inventory/analytics services

Closes #959, Closes #960