### PR TITLE
fix: POS OptimisticLock mapping, webhook HTTPS-only, K8s manifest placeholders

### DIFF
--- a/infra/k8s/analytics-service.yaml
+++ b/infra/k8s/analytics-service.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: analytics-service
-          image: ghcr.io/akaitigo/open-pos/analytics-service:latest
+          image: ghcr.io/akaitigo/open-pos/analytics-service:__IMAGE_TAG__
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/infra/k8s/api-gateway.yaml
+++ b/infra/k8s/api-gateway.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: api-gateway
-          image: ghcr.io/akaitigo/open-pos/api-gateway:latest
+          image: ghcr.io/akaitigo/open-pos/api-gateway:__IMAGE_TAG__
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/infra/k8s/external-secret.yaml
+++ b/infra/k8s/external-secret.yaml
@@ -16,10 +16,9 @@ metadata:
 spec:
   provider:
     gcpsm:
-      # TODO(deploy): Replace with your GCP project ID before deploying.
-      # Find it via: gcloud config get-value project
-      # Example: projectID: my-company-prod-12345
-      projectID: CHANGE_ME
+      # CD pipeline replaces __GCP_PROJECT_ID__ via sed.
+      # To deploy manually: sed -i 's/__GCP_PROJECT_ID__/your-project-id/' external-secret.yaml
+      projectID: __GCP_PROJECT_ID__
 
 ---
 apiVersion: external-secrets.io/v1beta1

--- a/infra/k8s/inventory-service.yaml
+++ b/infra/k8s/inventory-service.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: inventory-service
-          image: ghcr.io/akaitigo/open-pos/inventory-service:latest
+          image: ghcr.io/akaitigo/open-pos/inventory-service:__IMAGE_TAG__
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/infra/k8s/pos-service.yaml
+++ b/infra/k8s/pos-service.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: pos-service
-          image: ghcr.io/akaitigo/open-pos/pos-service:latest
+          image: ghcr.io/akaitigo/open-pos/pos-service:__IMAGE_TAG__
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/infra/k8s/product-service.yaml
+++ b/infra/k8s/product-service.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: product-service
-          image: ghcr.io/akaitigo/open-pos/product-service:latest
+          image: ghcr.io/akaitigo/open-pos/product-service:__IMAGE_TAG__
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/infra/k8s/store-service.yaml
+++ b/infra/k8s/store-service.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: store-service
-          image: ghcr.io/akaitigo/open-pos/store-service:latest
+          image: ghcr.io/akaitigo/open-pos/store-service:__IMAGE_TAG__
           securityContext:
             runAsNonRoot: true
             readOnlyRootFilesystem: true

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/WebhookResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/WebhookResource.kt
@@ -50,7 +50,7 @@ class WebhookResource {
             } catch (e: Exception) {
                 return "Invalid URL"
             }
-        if (uri.scheme != "https" && uri.scheme != "http") return "URL scheme must be http or https"
+        if (uri.scheme != "https") return "URL scheme must be https"
         val host = uri.host ?: return "URL must have a host"
         return try {
             val address = InetAddress.getByName(host)

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/GrpcExceptionMapping.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/GrpcExceptionMapping.kt
@@ -2,6 +2,7 @@ package com.openpos.pos.grpc
 
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
+import jakarta.persistence.OptimisticLockException
 import org.jboss.logging.Logger
 
 /**
@@ -53,6 +54,10 @@ fun mapToGrpcException(e: Exception): StatusRuntimeException =
 
         is IllegalStateException -> {
             Status.FAILED_PRECONDITION.withDescription(e.message).asRuntimeException()
+        }
+
+        is OptimisticLockException -> {
+            Status.ABORTED.withDescription("Concurrent modification detected").asRuntimeException()
         }
 
         is StatusRuntimeException -> {


### PR DESCRIPTION
## Summary
- **#961**: Add `jakarta.persistence.OptimisticLockException` → `Status.ABORTED` mapping in pos-service `GrpcExceptionMapping`
- **#962**: Reject `http://` webhook URLs in `WebhookResource.validateWebhookUrl()` — only `https://` is now allowed
- **#964**: Replace `CHANGE_ME` with `__GCP_PROJECT_ID__` in `external-secret.yaml` and `:latest` with `__IMAGE_TAG__` in all 6 K8s service manifests, matching CD pipeline sed substitution

## Test plan
- [ ] `pos-service` compiles successfully with new `OptimisticLockException` mapping
- [ ] `api-gateway` compiles successfully with HTTPS-only validation
- [ ] K8s manifests contain `__IMAGE_TAG__` and `__GCP_PROJECT_ID__` placeholders (no `:latest` or `CHANGE_ME`)
- [ ] CI passes

Closes #961, Closes #962, Closes #964