### PR TITLE
fix: gateway security — PIN auth skip-path, webhook RBAC, staff role escalation

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
@@ -50,6 +50,12 @@ class StaffResource {
     @POST
     fun create(body: CreateStaffBody): Response {
         tenantContext.requireRole("OWNER", "MANAGER")
+        // Role escalation prevention: only OWNERs can assign the OWNER role
+        if (body.role.uppercase() == "OWNER" && tenantContext.staffRole != null && tenantContext.staffRole != "OWNER") {
+            throw com.openpos.gateway.config.ForbiddenException(
+                "Only OWNER can assign the OWNER role",
+            )
+        }
         val request =
             CreateStaffRequest
                 .newBuilder()

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/WebhookResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/WebhookResource.kt
@@ -102,6 +102,7 @@ class WebhookResource {
         @PathParam("id") id: String,
         body: UpdateWebhookBody,
     ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val orgId = tenantContext.organizationId ?: return Response.status(Response.Status.BAD_REQUEST).build()
         val webhookId =
             try {
@@ -134,6 +135,7 @@ class WebhookResource {
     fun delete(
         @PathParam("id") id: String,
     ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val orgId = tenantContext.organizationId ?: return Response.status(Response.Status.BAD_REQUEST).build()
         val webhookId =
             try {
@@ -155,6 +157,7 @@ class WebhookResource {
     @POST
     @Path("/test")
     fun testDelivery(body: TestWebhookBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val orgId = tenantContext.organizationId ?: return Response.status(Response.Status.BAD_REQUEST).build()
         val deliveries =
             deliveryService.deliver(
@@ -194,6 +197,7 @@ class WebhookResource {
     @POST
     @Path("/retry")
     fun retryPending(): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
         val orgId = tenantContext.organizationId ?: return Response.status(Response.Status.BAD_REQUEST).build()
         val retried = deliveryService.retryPendingDeliveries(orgId)
         return Response.ok(mapOf("retriedCount" to retried)).build()

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -64,6 +64,7 @@ quarkus.otel.propagators=tracecontext,baggage
 
 # Production auth: always enforce authentication
 %prod.openpos.auth.enabled=true
+openpos.auth.skip-paths=/api/health,/q/,/api/staff/{id}/authenticate
 
 # Structured Logging
 quarkus.log.level=INFO

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/StaffResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/StaffResourceTest.kt
@@ -195,6 +195,53 @@ class StaffResourceTest {
             // Cleanup
             tenantContext.staffRole = "OWNER"
         }
+
+        @Test
+        fun `create - MANAGERがOWNERロールで作成しようとするとForbiddenException`() {
+            // Arrange
+            tenantContext.staffRole = "MANAGER"
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.create(CreateStaffBody(storeId = storeId, name = "新人", pin = "1234", role = "OWNER"))
+            }
+
+            // Cleanup
+            tenantContext.staffRole = "OWNER"
+        }
+
+        @Test
+        fun `create - OWNERはOWNERロールでスタッフ作成できる`() {
+            // Arrange
+            tenantContext.staffRole = "OWNER"
+            whenever(stub.createStaff(any())).thenReturn(
+                CreateStaffResponse.newBuilder().setStaff(buildStaff()).build(),
+            )
+
+            // Act
+            val response = resource.create(CreateStaffBody(storeId = storeId, name = "新人", pin = "1234", role = "OWNER"))
+
+            // Assert — no exception thrown
+            assertEquals(201, response.status)
+        }
+
+        @Test
+        fun `create - MANAGERはCASHIERロールでスタッフ作成できる`() {
+            // Arrange
+            tenantContext.staffRole = "MANAGER"
+            whenever(stub.createStaff(any())).thenReturn(
+                CreateStaffResponse.newBuilder().setStaff(buildStaff()).build(),
+            )
+
+            // Act
+            val response = resource.create(CreateStaffBody(storeId = storeId, name = "新人", pin = "1234", role = "CASHIER"))
+
+            // Assert — no exception thrown
+            assertEquals(201, response.status)
+
+            // Cleanup
+            tenantContext.staffRole = "OWNER"
+        }
     }
 
     @Nested

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/WebhookResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/WebhookResourceTest.kt
@@ -1,0 +1,162 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.ForbiddenException
+import com.openpos.gateway.config.TenantContext
+import com.openpos.gateway.webhook.WebhookDeliveryService
+import com.openpos.gateway.webhook.WebhookRegistration
+import com.openpos.gateway.webhook.WebhookStore
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class WebhookResourceTest {
+    private val webhookStore: WebhookStore = mock()
+    private val deliveryService: WebhookDeliveryService = mock()
+    private val tenantContext = TenantContext().apply { staffRole = "OWNER" }
+    private val resource =
+        WebhookResource().also { r ->
+            ProductResourceTest.setField(r, "webhookStore", webhookStore)
+            ProductResourceTest.setField(r, "deliveryService", deliveryService)
+            ProductResourceTest.setField(r, "tenantContext", tenantContext)
+        }
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        tenantContext.organizationId = orgId
+        tenantContext.staffRole = "OWNER"
+    }
+
+    @Nested
+    inner class UpdateRBAC {
+        @Test
+        fun `CASHIERはWebhook更新できない`() {
+            // Arrange
+            tenantContext.staffRole = "CASHIER"
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.update(UUID.randomUUID().toString(), UpdateWebhookBody(url = "https://example.com"))
+            }
+        }
+
+        @Test
+        fun `MANAGERはWebhook更新できる`() {
+            // Arrange
+            tenantContext.staffRole = "MANAGER"
+            val webhookId = UUID.randomUUID()
+            val existing =
+                WebhookRegistration(
+                    id = webhookId,
+                    organizationId = orgId,
+                    url = "https://example.com/hook",
+                    events = listOf("sale.completed"),
+                    secret = "a".repeat(32),
+                )
+            whenever(webhookStore.findById(webhookId)).thenReturn(existing)
+            whenever(webhookStore.update(any())).thenReturn(existing)
+
+            // Act
+            val response = resource.update(webhookId.toString(), UpdateWebhookBody(events = listOf("sale.completed", "product.created")))
+
+            // Assert
+            assertEquals(200, response.status)
+        }
+    }
+
+    @Nested
+    inner class DeleteRBAC {
+        @Test
+        fun `CASHIERはWebhook削除できない`() {
+            // Arrange
+            tenantContext.staffRole = "CASHIER"
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.delete(UUID.randomUUID().toString())
+            }
+        }
+
+        @Test
+        fun `OWNERはWebhook削除できる`() {
+            // Arrange
+            val webhookId = UUID.randomUUID()
+            val existing =
+                WebhookRegistration(
+                    id = webhookId,
+                    organizationId = orgId,
+                    url = "https://example.com/hook",
+                    events = listOf("sale.completed"),
+                    secret = "a".repeat(32),
+                )
+            whenever(webhookStore.findById(webhookId)).thenReturn(existing)
+            whenever(webhookStore.delete(webhookId)).thenReturn(true)
+
+            // Act
+            val response = resource.delete(webhookId.toString())
+
+            // Assert
+            assertEquals(204, response.status)
+        }
+    }
+
+    @Nested
+    inner class TestDeliveryRBAC {
+        @Test
+        fun `CASHIERはテスト配信できない`() {
+            // Arrange
+            tenantContext.staffRole = "CASHIER"
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.testDelivery(TestWebhookBody(eventType = "sale.completed", payload = "{}"))
+            }
+        }
+
+        @Test
+        fun `MANAGERはテスト配信できる`() {
+            // Arrange
+            tenantContext.staffRole = "MANAGER"
+            whenever(deliveryService.deliver(any(), any(), any())).thenReturn(emptyList())
+
+            // Act
+            val response = resource.testDelivery(TestWebhookBody(eventType = "sale.completed", payload = "{}"))
+
+            // Assert
+            assertEquals(200, response.status)
+        }
+    }
+
+    @Nested
+    inner class RetryPendingRBAC {
+        @Test
+        fun `CASHIERはリトライ実行できない`() {
+            // Arrange
+            tenantContext.staffRole = "CASHIER"
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.retryPending()
+            }
+        }
+
+        @Test
+        fun `OWNERはリトライ実行できる`() {
+            // Arrange
+            whenever(deliveryService.retryPendingDeliveries(orgId)).thenReturn(2)
+
+            // Act
+            val response = resource.retryPending()
+
+            // Assert
+            assertEquals(200, response.status)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **#953**: Add `/api/staff/{id}/authenticate` to `openpos.auth.skip-paths` so PIN login works without a JWT
- **#956**: Add `tenantContext.requireRole("OWNER", "MANAGER")` to WebhookResource `update`, `delete`, `testDelivery`, `retryPending` — CASHIER role is now blocked from mutating webhooks
- **#957**: Add role escalation guard to `StaffResource.create()` matching the existing `update()` logic — non-OWNER callers cannot create staff with OWNER role

## Test plan
- [x] WebhookResourceTest: RBAC enforcement for update/delete/testDelivery/retryPending (CASHIER blocked, MANAGER/OWNER allowed)
- [x] StaffResourceTest: create() role escalation prevention (MANAGER blocked from creating OWNER, OWNER allowed, MANAGER can create CASHIER)
- [x] `./gradlew :services:api-gateway:test` passes

Closes #953, Closes #956, Closes #957