### PR TITLE
fix: add orgId to store-service cache keys, TODO for gateway product cache

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductResource.kt
@@ -69,6 +69,7 @@ class ProductResource {
                     body.displayOrder?.let { setDisplayOrder(it) }
                 }.build()
         val response = grpc.withTenant(stub).createProduct(request)
+        // TODO: include orgId in pattern when gateway caching is implemented (#966)
         cache.invalidatePattern("openpos:gateway:product:list:*")
         return Response.status(Response.Status.CREATED).entity(response.product.toMap()).build()
     }
@@ -142,6 +143,7 @@ class ProductResource {
                     body.isActive?.let { setIsActiveValue(BoolValue.of(it)) }
                 }.build()
         val response = grpc.withTenant(stub).updateProduct(request)
+        // TODO: include orgId in pattern when gateway caching is implemented (#966)
         cache.invalidatePattern("openpos:gateway:product:list:*")
         return response.product.toMap()
     }
@@ -154,6 +156,7 @@ class ProductResource {
     ): Response {
         tenantContext.requireRole("OWNER", "MANAGER")
         grpc.withTenant(stub).deleteProduct(DeleteProductRequest.newBuilder().setId(id).build())
+        // TODO: include orgId in pattern when gateway caching is implemented (#966)
         cache.invalidatePattern("openpos:gateway:product:list:*")
         return Response.noContent().build()
     }

--- a/services/store-service/src/main/kotlin/com/openpos/store/cache/StoreCacheService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/cache/StoreCacheService.kt
@@ -9,7 +9,7 @@ import org.jboss.logging.Logger
 /**
  * store-service の Redis キャッシュサービス。
  * cache-aside パターンで組織・店舗・端末の検索結果をキャッシュする。
- * キー形式: openpos:store-service:{entity}:{id}
+ * キー形式: openpos:store-service:{orgId}:{entity}:{id}
  * TTL: 600 秒（10 分）
  */
 @ApplicationScoped
@@ -76,36 +76,54 @@ class StoreCacheService {
 
     // === Organization Keys ===
 
-    fun organizationKey(id: String): String = "$PREFIX:org:$id"
+    fun organizationKey(
+        orgId: String,
+        id: String,
+    ): String = "$PREFIX:$orgId:org:$id"
 
     // === Store Keys ===
 
-    fun storeKey(id: String): String = "$PREFIX:store:$id"
+    fun storeKey(
+        orgId: String,
+        id: String,
+    ): String = "$PREFIX:$orgId:store:$id"
 
     // === Terminal Keys ===
 
-    fun terminalListKey(storeId: String): String = "$PREFIX:terminal:list:$storeId"
+    fun terminalListKey(
+        orgId: String,
+        storeId: String,
+    ): String = "$PREFIX:$orgId:terminal:list:$storeId"
 
     // === Invalidation Helpers ===
 
     /**
      * 組織関連のキャッシュを無効化する。
      */
-    fun invalidateOrganization(organizationId: String) {
-        invalidate(organizationKey(organizationId))
+    fun invalidateOrganization(
+        orgId: String,
+        organizationId: String,
+    ) {
+        invalidate(organizationKey(orgId, organizationId))
     }
 
     /**
      * 店舗関連のキャッシュを無効化する。
      */
-    fun invalidateStore(storeId: String) {
-        invalidate(storeKey(storeId))
+    fun invalidateStore(
+        orgId: String,
+        storeId: String,
+    ) {
+        invalidate(storeKey(orgId, storeId))
     }
 
     /**
      * 端末リストキャッシュを無効化する。
      */
-    fun invalidateTerminalList(storeId: String) {
-        invalidate(terminalListKey(storeId))
+    fun invalidateTerminalList(
+        orgId: String,
+        storeId: String,
+    ) {
+        invalidate(terminalListKey(orgId, storeId))
     }
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/OrganizationService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/OrganizationService.kt
@@ -46,7 +46,7 @@ class OrganizationService {
         businessType?.let { entity.businessType = it }
         invoiceNumber?.let { entity.invoiceNumber = it }
         organizationRepository.persist(entity)
-        cacheService.invalidateOrganization(id.toString())
+        cacheService.invalidateOrganization(id.toString(), id.toString())
         return entity
     }
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/StoreService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/StoreService.kt
@@ -82,7 +82,8 @@ class StoreService {
         settings?.let { entity.settings = it }
         isActive?.let { entity.isActive = it }
         storeRepository.persist(entity)
-        cacheService.invalidateStore(id.toString())
+        val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
+        cacheService.invalidateStore(orgId.toString(), id.toString())
         return entity
     }
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/TerminalService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/TerminalService.kt
@@ -53,7 +53,7 @@ class TerminalService {
                 this.isActive = true
             }
         terminalRepository.persist(entity)
-        cacheService.invalidateTerminalList(storeId.toString())
+        cacheService.invalidateTerminalList(orgId.toString(), storeId.toString())
         return entity
     }
 
@@ -64,11 +64,12 @@ class TerminalService {
 
     @Transactional
     fun updateSync(terminalId: UUID): TerminalEntity? {
+        val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
         tenantFilterService.enableFilter()
         val entity = terminalRepository.findById(terminalId) ?: return null
         entity.lastSyncAt = Instant.now()
         terminalRepository.persist(entity)
-        cacheService.invalidateTerminalList(entity.storeId.toString())
+        cacheService.invalidateTerminalList(orgId.toString(), entity.storeId.toString())
         return entity
     }
 }

--- a/services/store-service/src/test/kotlin/com/openpos/store/cache/StoreCacheServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/cache/StoreCacheServiceTest.kt
@@ -143,18 +143,18 @@ class StoreCacheServiceTest {
     @Nested
     inner class KeyGeneration {
         @Test
-        fun `organizationKeyは正しい形式のキーを生成する`() {
-            assertEquals("openpos:store-service:org:org-123", cacheService.organizationKey("org-123"))
+        fun `organizationKeyはorgIdを含む正しい形式のキーを生成する`() {
+            assertEquals("openpos:store-service:org-abc:org:org-123", cacheService.organizationKey("org-abc", "org-123"))
         }
 
         @Test
-        fun `storeKeyは正しい形式のキーを生成する`() {
-            assertEquals("openpos:store-service:store:store-123", cacheService.storeKey("store-123"))
+        fun `storeKeyはorgIdを含む正しい形式のキーを生成する`() {
+            assertEquals("openpos:store-service:org-abc:store:store-123", cacheService.storeKey("org-abc", "store-123"))
         }
 
         @Test
-        fun `terminalListKeyは正しい形式のキーを生成する`() {
-            assertEquals("openpos:store-service:terminal:list:store-456", cacheService.terminalListKey("store-456"))
+        fun `terminalListKeyはorgIdを含む正しい形式のキーを生成する`() {
+            assertEquals("openpos:store-service:org-abc:terminal:list:store-456", cacheService.terminalListKey("org-abc", "store-456"))
         }
     }
 
@@ -162,20 +162,20 @@ class StoreCacheServiceTest {
     inner class InvalidationHelpers {
         @Test
         fun `invalidateOrganizationは組織キーを削除する`() {
-            cacheService.invalidateOrganization("org-123")
-            verify(keyCommands).del("openpos:store-service:org:org-123")
+            cacheService.invalidateOrganization("org-abc", "org-123")
+            verify(keyCommands).del("openpos:store-service:org-abc:org:org-123")
         }
 
         @Test
         fun `invalidateStoreは店舗キーを削除する`() {
-            cacheService.invalidateStore("store-123")
-            verify(keyCommands).del("openpos:store-service:store:store-123")
+            cacheService.invalidateStore("org-abc", "store-123")
+            verify(keyCommands).del("openpos:store-service:org-abc:store:store-123")
         }
 
         @Test
         fun `invalidateTerminalListは端末リストキーを削除する`() {
-            cacheService.invalidateTerminalList("store-456")
-            verify(keyCommands).del("openpos:store-service:terminal:list:store-456")
+            cacheService.invalidateTerminalList("org-abc", "store-456")
+            verify(keyCommands).del("openpos:store-service:org-abc:terminal:list:store-456")
         }
     }
 }

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/OrganizationServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/OrganizationServiceTest.kt
@@ -30,7 +30,7 @@ class OrganizationServiceTest {
 
     @BeforeEach
     fun setUp() {
-        doNothing().whenever(cacheService).invalidateOrganization(any())
+        doNothing().whenever(cacheService).invalidateOrganization(any(), any())
     }
 
     // === create ===

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/StoreServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/StoreServiceTest.kt
@@ -45,7 +45,7 @@ class StoreServiceTest {
     fun setUp() {
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
-        doNothing().whenever(cacheService).invalidateStore(any())
+        doNothing().whenever(cacheService).invalidateStore(any(), any())
     }
 
     // === create ===

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/TerminalServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/TerminalServiceTest.kt
@@ -50,7 +50,7 @@ class TerminalServiceTest {
     fun setUp() {
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
-        doNothing().whenever(cacheService).invalidateTerminalList(any())
+        doNothing().whenever(cacheService).invalidateTerminalList(any(), any())
         val storeEntity =
             StoreEntity().apply {
                 this.id = storeId


### PR DESCRIPTION
## Summary
- **#965**: `StoreCacheService` のキー生成メソッド (`storeKey`, `organizationKey`, `terminalListKey`) に `orgId` パラメータを追加し、`ProductCacheService` と同じキー形式 (`openpos:store-service:{orgId}:{entity}:{id}`) に統一。全呼び出し元 (`StoreService`, `OrganizationService`, `TerminalService`) とテストを更新
- **#966**: Gateway `ProductResource` のキャッシュ無効化パターンは gateway レベルで orgId 不要だが、将来の gateway キャッシュ実装時に対応するための TODO コメントを追加

## Test plan
- [x] `./gradlew :services:store-service:test` — all tests pass
- [x] `./gradlew :services:api-gateway:test` — all tests pass
- [x] `StoreCacheServiceTest` のキー生成テストが orgId 入りの新形式を検証

Closes #965, Closes #966