### PR TITLE
feat: implement full offline sync (#958)

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -11,6 +11,7 @@ import com.openpos.pos.entity.TransactionEntity
 import com.openpos.pos.entity.TransactionItemEntity
 import com.openpos.pos.service.DrawerService
 import com.openpos.pos.service.JournalService
+import com.openpos.pos.service.OfflineItemInput
 import com.openpos.pos.service.PaymentInput
 import com.openpos.pos.service.SettlementService
 import com.openpos.pos.service.TransactionService
@@ -690,14 +691,42 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         val results =
             request.transactionsList.map { offlineTx ->
                 try {
-                    val type = "SALE"
+                    val items =
+                        offlineTx.itemsList.map { item ->
+                            OfflineItemInput(
+                                productId = item.productId.toUUID(),
+                                productName = item.productName,
+                                unitPrice = item.unitPrice,
+                                quantity = item.quantity,
+                                taxRateName = item.taxRateName,
+                                taxRate = item.taxRate,
+                                isReducedTax = item.isReducedTax,
+                            )
+                        }
+                    val payments =
+                        offlineTx.paymentsList.map { p ->
+                            PaymentInput(
+                                method = p.method.toDbValue(),
+                                amount = p.amount,
+                                received = if (p.received > 0) p.received else null,
+                                reference = p.reference.ifBlank { null },
+                            )
+                        }
+                    val createdAt =
+                        if (offlineTx.createdAt.isNotBlank()) {
+                            Instant.parse(offlineTx.createdAt)
+                        } else {
+                            null
+                        }
                     val entity =
-                        transactionService.createTransaction(
+                        transactionService.syncOfflineTransaction(
                             storeId = offlineTx.storeId.toUUID(),
                             terminalId = offlineTx.terminalId.toUUID(),
                             staffId = offlineTx.staffId.toUUID(),
-                            type = type,
-                            clientId = offlineTx.clientId.ifBlank { null },
+                            clientId = offlineTx.clientId,
+                            items = items,
+                            payments = payments,
+                            createdAt = createdAt,
                         )
                     SyncResult
                         .newBuilder()

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -636,6 +636,144 @@ class TransactionService {
         return TransactionRelations(items, payments, discounts, taxSummaries)
     }
 
+    // === Offline Sync ===
+
+    /**
+     * オフライン取引を一括同期する。
+     *
+     * クライアント端末がオフライン中に記録した取引データを受け取り、
+     * アイテム作成・支払い登録・税サマリ集計・ステータス COMPLETED 化を一括で実行する。
+     * clientId による冪等性を保証し、重複送信時は既存取引を返す。
+     */
+    @Transactional
+    fun syncOfflineTransaction(
+        storeId: UUID,
+        terminalId: UUID,
+        staffId: UUID,
+        clientId: String,
+        items: List<OfflineItemInput>,
+        payments: List<PaymentInput>,
+        createdAt: Instant?,
+    ): TransactionEntity {
+        val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
+
+        // 冪等性: 同一 clientId の既存取引があればそのまま返す
+        if (clientId.isNotBlank()) {
+            val existing = transactionRepository.findByClientId(clientId, orgId)
+            if (existing != null) return existing
+        }
+
+        require(items.isNotEmpty()) { "Offline transaction must have at least one item" }
+        require(payments.isNotEmpty()) { "Offline transaction must have at least one payment" }
+
+        // 1. 取引作成
+        val tx =
+            TransactionEntity().apply {
+                this.organizationId = orgId
+                this.storeId = storeId
+                this.terminalId = terminalId
+                this.staffId = staffId
+                this.transactionNumber = generateTransactionNumber()
+                this.type = "SALE"
+                this.status = "DRAFT"
+                this.clientId = clientId.ifBlank { null }
+            }
+        transactionRepository.persist(tx)
+
+        // 2. アイテム作成（端末キャッシュのスナップショットをそのまま使用）
+        for (offlineItem in items) {
+            val taxResult =
+                taxCalculationService.calculateItemTax(
+                    offlineItem.unitPrice,
+                    offlineItem.quantity,
+                    offlineItem.taxRate,
+                )
+            val item =
+                TransactionItemEntity().apply {
+                    this.organizationId = orgId
+                    this.transactionId = tx.id
+                    this.productId = offlineItem.productId
+                    this.productName = offlineItem.productName
+                    this.unitPrice = offlineItem.unitPrice
+                    this.quantity = offlineItem.quantity
+                    this.taxRateName = offlineItem.taxRateName
+                    this.taxRate = offlineItem.taxRate
+                    this.isReducedTax = offlineItem.isReducedTax
+                    this.subtotal = taxResult.subtotal
+                    this.taxAmount = taxResult.taxAmount
+                    this.total = taxResult.total
+                }
+            itemRepository.persist(item)
+        }
+
+        // 3. 取引合計を計算
+        val savedItems = itemRepository.findByTransactionId(tx.id)
+        tx.subtotal = savedItems.sumOf { it.subtotal }
+        tx.taxTotal = savedItems.sumOf { it.taxAmount }
+        tx.total = tx.subtotal + tx.taxTotal
+
+        // 4. 支払い検証・登録
+        val paymentTotal = payments.sumOf { it.amount }
+        require(paymentTotal >= tx.total) {
+            "Payment total ($paymentTotal) is less than transaction total (${tx.total})"
+        }
+        tx.changeAmount = paymentTotal - tx.total
+
+        for (input in payments) {
+            val payment =
+                PaymentEntity().apply {
+                    this.organizationId = orgId
+                    this.transactionId = tx.id
+                    this.method = input.method
+                    this.amount = input.amount
+                    if (input.method == "CASH") {
+                        this.received = input.received ?: input.amount
+                        this.change = (input.received ?: input.amount) - input.amount
+                    }
+                    this.reference = input.reference
+                }
+            paymentRepository.persist(payment)
+        }
+
+        // 5. 税サマリ集計
+        val taxableItems =
+            savedItems.map {
+                TaxableItem(
+                    taxRateName = it.taxRateName,
+                    taxRate = it.taxRate,
+                    isReducedTax = it.isReducedTax,
+                    subtotal = it.subtotal,
+                )
+            }
+        val summaries = taxCalculationService.aggregateTaxSummaries(taxableItems)
+        for (summary in summaries) {
+            val entity =
+                TaxSummaryEntity().apply {
+                    this.organizationId = orgId
+                    this.transactionId = tx.id
+                    this.taxRateName = summary.taxRateName
+                    this.taxRate = summary.taxRate
+                    this.isReduced = summary.isReduced
+                    this.taxableAmount = summary.taxableAmount
+                    this.taxAmount = summary.taxAmount
+                }
+            taxSummaryRepository.persist(entity)
+        }
+
+        // 6. ステータスを COMPLETED に遷移
+        tx.status = "COMPLETED"
+        tx.completedAt = createdAt ?: Instant.now()
+        tx.contentHash = computeContentHash(tx, savedItems)
+        transactionRepository.persist(tx)
+
+        // 7. イベント発行 + メトリクス
+        publishSaleCompletedEvent(tx, savedItems)
+        transactionsCompletedCounter.increment()
+        revenueCounter.increment(tx.total.toDouble())
+
+        return tx
+    }
+
     // === Internal Helpers ===
 
     private fun getWritableTransaction(transactionId: UUID): TransactionEntity {
@@ -756,4 +894,14 @@ data class PaymentInput(
     val amount: Long,
     val received: Long?,
     val reference: String?,
+)
+
+data class OfflineItemInput(
+    val productId: UUID,
+    val productName: String,
+    val unitPrice: Long,
+    val quantity: Int,
+    val taxRateName: String,
+    val taxRate: String,
+    val isReducedTax: Boolean,
 )

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceTest.kt
@@ -571,6 +571,217 @@ class TransactionServiceTest {
         }
     }
 
+    // === syncOfflineTransaction ===
+
+    @Nested
+    inner class SyncOfflineTransaction {
+        private val clientId = UUID.randomUUID().toString()
+
+        private fun standardOfflineItem() =
+            OfflineItemInput(
+                productId = productId,
+                productName = "テスト商品A",
+                unitPrice = 10000L,
+                quantity = 2,
+                taxRateName = "標準税率10%",
+                taxRate = "0.10",
+                isReducedTax = false,
+            )
+
+        private fun reducedOfflineItem() =
+            OfflineItemInput(
+                productId = UUID.randomUUID(),
+                productName = "テスト食品B",
+                unitPrice = 15000L,
+                quantity = 1,
+                taxRateName = "軽減税率8%",
+                taxRate = "0.08",
+                isReducedTax = true,
+            )
+
+        @Test
+        fun `オフライン取引を正常に同期しCOMPLETEDにする`() {
+            val items = listOf(standardOfflineItem())
+            val payments = listOf(PaymentInput(method = "CASH", amount = 22000, received = 30000, reference = null))
+
+            val result =
+                transactionService.syncOfflineTransaction(
+                    storeId,
+                    terminalId,
+                    staffId,
+                    clientId,
+                    items,
+                    payments,
+                    null,
+                )
+
+            assertEquals("COMPLETED", result.status)
+            assertNotNull(result.completedAt)
+            assertEquals(clientId, result.clientId)
+            assertEquals(20000L, result.subtotal)
+            assertEquals(2000L, result.taxTotal)
+            assertEquals(22000L, result.total)
+            assertEquals(0L, result.changeAmount)
+
+            val savedItems = itemRepository.findByTransactionId(result.id)
+            assertEquals(1, savedItems.size)
+            assertEquals("テスト商品A", savedItems[0].productName)
+            assertEquals(10000L, savedItems[0].unitPrice)
+            assertEquals(2, savedItems[0].quantity)
+
+            val savedPayments = paymentRepository.findByTransactionId(result.id)
+            assertEquals(1, savedPayments.size)
+            assertEquals("CASH", savedPayments[0].method)
+            assertEquals(22000L, savedPayments[0].amount)
+            assertEquals(30000L, savedPayments[0].received)
+            assertEquals(8000L, savedPayments[0].change)
+
+            val taxSummaries = taxSummaryRepository.findByTransactionId(result.id)
+            assertEquals(1, taxSummaries.size)
+            assertEquals("標準税率10%", taxSummaries[0].taxRateName)
+            assertEquals(20000L, taxSummaries[0].taxableAmount)
+            assertEquals(2000L, taxSummaries[0].taxAmount)
+
+            verify(eventPublisher).publish(eq("sale.completed"), eq(orgId), any())
+        }
+
+        @Test
+        fun `複数税率の商品を含むオフライン取引を正常に同期する`() {
+            val items = listOf(standardOfflineItem(), reducedOfflineItem())
+            val payments = listOf(PaymentInput(method = "CASH", amount = 38200, received = 40000, reference = null))
+
+            val result =
+                transactionService.syncOfflineTransaction(
+                    storeId,
+                    terminalId,
+                    staffId,
+                    clientId,
+                    items,
+                    payments,
+                    null,
+                )
+
+            assertEquals("COMPLETED", result.status)
+            assertEquals(35000L, result.subtotal)
+            assertEquals(3200L, result.taxTotal)
+            assertEquals(38200L, result.total)
+
+            val taxSummaries = taxSummaryRepository.findByTransactionId(result.id)
+            assertEquals(2, taxSummaries.size)
+
+            val standard = taxSummaries.find { it.taxRateName == "標準税率10%" }
+            assertNotNull(standard)
+            assertEquals(20000L, standard?.taxableAmount)
+            assertEquals(2000L, standard?.taxAmount)
+
+            val reduced = taxSummaries.find { it.taxRateName == "軽減税率8%" }
+            assertNotNull(reduced)
+            assertEquals(15000L, reduced?.taxableAmount)
+            assertEquals(1200L, reduced?.taxAmount)
+        }
+
+        @Test
+        fun `同一clientIdで再送信すると既存取引を返す（冪等性）`() {
+            val items = listOf(standardOfflineItem())
+            val payments = listOf(PaymentInput(method = "CASH", amount = 22000, received = 22000, reference = null))
+
+            val first =
+                transactionService.syncOfflineTransaction(
+                    storeId,
+                    terminalId,
+                    staffId,
+                    clientId,
+                    items,
+                    payments,
+                    null,
+                )
+            val second =
+                transactionService.syncOfflineTransaction(
+                    storeId,
+                    terminalId,
+                    staffId,
+                    clientId,
+                    items,
+                    payments,
+                    null,
+                )
+
+            assertEquals(first.id, second.id)
+        }
+
+        @Test
+        fun `アイテムが空の場合はエラー`() {
+            val payments = listOf(PaymentInput(method = "CASH", amount = 0, received = 0, reference = null))
+
+            assertThrows(IllegalArgumentException::class.java) {
+                transactionService.syncOfflineTransaction(
+                    storeId,
+                    terminalId,
+                    staffId,
+                    clientId,
+                    emptyList(),
+                    payments,
+                    null,
+                )
+            }
+        }
+
+        @Test
+        fun `支払いが空の場合はエラー`() {
+            val items = listOf(standardOfflineItem())
+
+            assertThrows(IllegalArgumentException::class.java) {
+                transactionService.syncOfflineTransaction(
+                    storeId,
+                    terminalId,
+                    staffId,
+                    clientId,
+                    items,
+                    emptyList(),
+                    null,
+                )
+            }
+        }
+
+        @Test
+        fun `支払い合計が不足の場合はエラー`() {
+            val items = listOf(standardOfflineItem())
+            val payments = listOf(PaymentInput(method = "CASH", amount = 10000, received = 10000, reference = null))
+
+            assertThrows(IllegalArgumentException::class.java) {
+                transactionService.syncOfflineTransaction(
+                    storeId,
+                    terminalId,
+                    staffId,
+                    clientId,
+                    items,
+                    payments,
+                    null,
+                )
+            }
+        }
+
+        @Test
+        fun `createdAtを指定するとcompletedAtに設定される`() {
+            val items = listOf(standardOfflineItem())
+            val payments = listOf(PaymentInput(method = "CASH", amount = 22000, received = 22000, reference = null))
+            val offlineCreatedAt = java.time.Instant.parse("2026-03-25T10:00:00Z")
+
+            val result =
+                transactionService.syncOfflineTransaction(
+                    storeId,
+                    terminalId,
+                    staffId,
+                    clientId,
+                    items,
+                    payments,
+                    offlineCreatedAt,
+                )
+
+            assertEquals(offlineCreatedAt, result.completedAt)
+        }
+    }
+
     // === ヘルパーメソッド ===
 
     private fun createDraftTransaction(): TransactionEntity =


### PR DESCRIPTION
## Summary
- Replace skeleton `syncOfflineTransactions` (only created DRAFT) with complete offline sync implementation
- `TransactionService.syncOfflineTransaction()`: creates items from offline snapshots, registers payments, aggregates tax summaries, finalizes to COMPLETED, publishes `SaleCompletedEvent`
- `PosGrpcService`: maps proto `OfflineTransaction` to new service method with item/payment/createdAt conversion
- Idempotency guaranteed via `clientId` deduplication (existing DB unique constraint)

## Test plan
- [x] 7 unit tests added (`SyncOfflineTransaction` nested class)
  - Happy path: single item CASH payment -> COMPLETED
  - Multi-tax-rate: standard 10% + reduced 8% -> correct tax summaries
  - Idempotency: duplicate clientId returns same transaction
  - Empty items -> error
  - Empty payments -> error
  - Insufficient payment -> error
  - createdAt propagation -> sets completedAt
- [x] `./gradlew :services:pos-service:test` — all tests pass

Closes #958