### PR TITLE
fix: handle Idempotency-Key in pos-service finalizeTransaction

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/config/OrganizationIdInterceptor.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/config/OrganizationIdInterceptor.kt
@@ -37,6 +37,12 @@ class OrganizationIdInterceptor : ServerInterceptor {
         val REQUEST_ID_CTX_KEY: Context.Key<String> =
             Context.key("requestId")
 
+        private val IDEMPOTENCY_KEY: Metadata.Key<String> =
+            Metadata.Key.of("x-idempotency-key", Metadata.ASCII_STRING_MARSHALLER)
+
+        val IDEMPOTENCY_KEY_CTX_KEY: Context.Key<String> =
+            Context.key("idempotencyKey")
+
         private val UUID_REGEX = Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
         private val INJECTION_PATTERN = Regex("[\\r\\n\\x00]")
     }
@@ -99,11 +105,15 @@ class OrganizationIdInterceptor : ServerInterceptor {
         org.jboss.logging.MDC
             .put("organization_id", orgId.toString())
 
-        val ctx =
+        var ctx =
             Context
                 .current()
                 .withValue(ORGANIZATION_ID_CTX_KEY, orgId)
                 .withValue(REQUEST_ID_CTX_KEY, requestId)
+        val idempotencyKey = headers.get(IDEMPOTENCY_KEY)
+        if (!idempotencyKey.isNullOrBlank()) {
+            ctx = ctx.withValue(IDEMPOTENCY_KEY_CTX_KEY, idempotencyKey.trim())
+        }
         return Contexts.interceptCall(ctx, call, headers, next)
     }
 

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/entity/TransactionEntity.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/entity/TransactionEntity.kt
@@ -78,6 +78,10 @@ class TransactionEntity : BaseEntity() {
     @Column(name = "content_hash", length = 64)
     var contentHash: String? = null
 
+    /** 冪等性キー（finalize の重複実行を防止） */
+    @Column(name = "idempotency_key", length = 128)
+    var idempotencyKey: String? = null
+
     /**
      * 楽観的ロック用バージョン番号。
      */

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -1,5 +1,6 @@
 package com.openpos.pos.grpc
 
+import com.openpos.pos.config.OrganizationIdInterceptor
 import com.openpos.pos.entity.DrawerEntity
 import com.openpos.pos.entity.JournalEntryEntity
 import com.openpos.pos.entity.PaymentEntity
@@ -326,10 +327,12 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
                         reference = p.reference.ifBlank { null },
                     )
                 }
+            val idempotencyKey = OrganizationIdInterceptor.IDEMPOTENCY_KEY_CTX_KEY.get()
             val entity =
                 transactionService.finalizeTransaction(
                     transactionId = request.transactionId.toUUID(),
                     payments = payments,
+                    idempotencyKey = idempotencyKey,
                 )
             val receipt = buildReceipt(entity)
             responseObserver.onNext(

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
@@ -10,6 +10,8 @@ import java.util.UUID
 
 @ApplicationScoped
 class TransactionRepository : PanacheRepositoryBase<TransactionEntity, UUID> {
+    fun findByIdempotencyKey(idempotencyKey: String): TransactionEntity? = find("idempotencyKey = ?1", idempotencyKey).firstResult()
+
     fun findByClientId(
         clientId: String,
         organizationId: UUID,

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -393,8 +393,18 @@ class TransactionService {
     fun finalizeTransaction(
         transactionId: UUID,
         payments: List<PaymentInput>,
+        idempotencyKey: String? = null,
     ): TransactionEntity {
         tenantFilterService.enableFilter()
+
+        // Idempotency check: return existing COMPLETED transaction for same key
+        if (!idempotencyKey.isNullOrBlank()) {
+            val existing = transactionRepository.findByIdempotencyKey(idempotencyKey)
+            if (existing != null && existing.status == "COMPLETED") {
+                return existing
+            }
+        }
+
         val tx =
             transactionRepository.findById(transactionId)
                 ?: throw ResourceNotFoundException("Transaction not found: $transactionId")
@@ -464,6 +474,9 @@ class TransactionService {
         tx.status = "COMPLETED"
         tx.completedAt = Instant.now()
         tx.contentHash = computeContentHash(tx, items)
+        if (!idempotencyKey.isNullOrBlank()) {
+            tx.idempotencyKey = idempotencyKey
+        }
         transactionRepository.persist(tx)
 
         publishSaleCompletedEvent(tx, items)

--- a/services/pos-service/src/main/resources/db/migration/V19__add_idempotency_key_to_transactions.sql
+++ b/services/pos-service/src/main/resources/db/migration/V19__add_idempotency_key_to_transactions.sql
@@ -1,0 +1,7 @@
+-- Add idempotency_key column for finalize transaction deduplication (#955)
+ALTER TABLE pos_schema.transactions
+    ADD COLUMN idempotency_key VARCHAR(128);
+
+CREATE UNIQUE INDEX idx_transactions_idempotency_key
+    ON pos_schema.transactions (idempotency_key)
+    WHERE idempotency_key IS NOT NULL;

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceTest.kt
@@ -3,8 +3,11 @@ package com.openpos.pos.service
 import com.openpos.pos.config.OrganizationIdHolder
 import com.openpos.pos.entity.TransactionEntity
 import com.openpos.pos.event.EventPublisher
+import com.openpos.pos.grpc.BusinessPreconditionException
+import com.openpos.pos.grpc.InvalidInputException
 import com.openpos.pos.grpc.ProductServiceClient
 import com.openpos.pos.grpc.ProductSnapshot
+import com.openpos.pos.grpc.ResourceNotFoundException
 import com.openpos.pos.repository.PaymentRepository
 import com.openpos.pos.repository.TaxSummaryRepository
 import com.openpos.pos.repository.TransactionDiscountRepository
@@ -16,9 +19,6 @@ import jakarta.inject.Inject
 import jakarta.transaction.Transactional
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import com.openpos.pos.grpc.BusinessPreconditionException
-import com.openpos.pos.grpc.InvalidInputException
-import com.openpos.pos.grpc.ResourceNotFoundException
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -417,6 +417,33 @@ class TransactionServiceTest {
             assertNotNull(reduced)
             assertEquals(15000L, reduced!!.taxableAmount)
             assertEquals(1200L, reduced.taxAmount)
+        }
+
+        @Test
+        fun `同一idempotencyKeyで再度finalizeすると既存のCOMPLETED取引を返す`() {
+            val tx = createDraftTransaction()
+            val idempotencyKey = "test-idempotency-key-${UUID.randomUUID()}"
+            whenever(productServiceClient.getProductSnapshot(eq(productId), eq(orgId)))
+                .thenReturn(standardProduct)
+            transactionService.addItem(tx.id, productId, 1)
+            val payments = listOf(PaymentInput(method = "CASH", amount = 11000, received = 11000, reference = null))
+            val first = transactionService.finalizeTransaction(tx.id, payments, idempotencyKey)
+            val second = transactionService.finalizeTransaction(tx.id, payments, idempotencyKey)
+            assertEquals(first.id, second.id)
+            assertEquals("COMPLETED", second.status)
+            assertEquals(idempotencyKey, second.idempotencyKey)
+        }
+
+        @Test
+        fun `idempotencyKeyがnullの場合はキーを保存しない`() {
+            val tx = createDraftTransaction()
+            whenever(productServiceClient.getProductSnapshot(eq(productId), eq(orgId)))
+                .thenReturn(standardProduct)
+            transactionService.addItem(tx.id, productId, 1)
+            val payments = listOf(PaymentInput(method = "CASH", amount = 11000, received = 11000, reference = null))
+            val result = transactionService.finalizeTransaction(tx.id, payments, null)
+            assertEquals("COMPLETED", result.status)
+            assertEquals(null, result.idempotencyKey)
         }
     }
 

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceUnitTest.kt
@@ -519,6 +519,58 @@ class TransactionServiceUnitTest {
                 service.finalizeTransaction(tx.id, listOf(PaymentInput("CASH", 100, 100, null)))
             }
         }
+
+        @Test
+        fun `returns existing COMPLETED transaction for same idempotency key`() {
+            val idempotencyKey = "idem-key-123"
+            val existing =
+                createTransactionEntity().apply {
+                    this.status = "COMPLETED"
+                    this.idempotencyKey = idempotencyKey
+                }
+            whenever(transactionRepository.findByIdempotencyKey(idempotencyKey)).thenReturn(existing)
+
+            val result = service.finalizeTransaction(UUID.randomUUID(), emptyList(), idempotencyKey)
+
+            assertEquals(existing.id, result.id)
+            assertEquals("COMPLETED", result.status)
+        }
+
+        @Test
+        fun `stores idempotency key on finalized transaction`() {
+            val idempotencyKey = "idem-key-456"
+            val tx = createTransactionEntity()
+            val item = createItemEntity(tx.id)
+            whenever(transactionRepository.findByIdempotencyKey(idempotencyKey)).thenReturn(null)
+            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
+            whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
+            whenever(paymentRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
+            doNothing().whenever(taxSummaryRepository).deleteByTransactionId(tx.id)
+
+            val payments = listOf(PaymentInput("CASH", 11000, 15000, null))
+            val result = service.finalizeTransaction(tx.id, payments, idempotencyKey)
+
+            assertEquals("COMPLETED", result.status)
+            assertEquals(idempotencyKey, result.idempotencyKey)
+        }
+
+        @Test
+        fun `null idempotency key does not store key`() {
+            val tx = createTransactionEntity()
+            val item = createItemEntity(tx.id)
+            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
+            whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
+            whenever(paymentRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
+            doNothing().whenever(taxSummaryRepository).deleteByTransactionId(tx.id)
+
+            val payments = listOf(PaymentInput("CASH", 11000, 15000, null))
+            val result = service.finalizeTransaction(tx.id, payments, null)
+
+            assertEquals("COMPLETED", result.status)
+            assertEquals(null, result.idempotencyKey)
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

- **OrganizationIdInterceptor**: `x-idempotency-key` gRPC metadata を抽出し、gRPC Context に伝播
- **TransactionService.finalizeTransaction**: optional な `idempotencyKey` パラメータを追加。同一キーで COMPLETED 済み取引が存在する場合はそのまま返却し、完了時にキーを保存
- **PosGrpcService**: Context から idempotency key を読み取り TransactionService に渡す
- **TransactionEntity/Repository**: `idempotencyKey` フィールドと `findByIdempotencyKey` クエリを追加
- **V19 Flyway migration**: `idempotency_key` カラムと部分ユニークインデックスを追加
- ユニットテスト 3件 + 統合テスト 2件を追加

## Test plan

- [x] 同一 idempotency key で finalize を2回呼ぶと、既存の COMPLETED 取引が返される（冪等性）
- [x] idempotency key が null の場合はキーを保存しない（後方互換性）
- [x] 新規 finalize 時に idempotency key が保存される
- [x] 既存の全テスト（167件）が通過

Closes #955