### PR TITLE
fix: OutboxProcessor の二重パブリッシュを防止

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/event/OutboxProcessor.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/event/OutboxProcessor.kt
@@ -1,5 +1,6 @@
 package com.openpos.pos.event
 
+import com.openpos.pos.entity.OutboxEventEntity
 import com.openpos.pos.repository.OutboxRepository
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata
@@ -17,6 +18,10 @@ import java.time.Instant
  * アウトボックスプロセッサ。
  * 定期的に PENDING イベントを取得し、RabbitMQ への再送信を試みる。
  * 最大リトライ回数（10回）を超えた場合は FAILED に遷移する。
+ *
+ * 二重パブリッシュ防止:
+ * SELECT FOR UPDATE → IN_PROGRESS 更新を同一トランザクション内で実行し、
+ * 他インスタンスが同じイベントを取得できないようにする。
  */
 @ApplicationScoped
 class OutboxProcessor {
@@ -40,17 +45,25 @@ class OutboxProcessor {
      */
     @Scheduled(every = "10s", identity = "outbox-processor")
     fun processOutbox() {
-        val pendingEvents = outboxRepository.findPendingEvents(BATCH_SIZE)
-        if (pendingEvents.isEmpty()) {
+        val claimedEvents = claimPendingEvents()
+        if (claimedEvents.isEmpty()) {
             return
         }
 
-        log.infof("Processing %d pending outbox events", pendingEvents.size)
+        log.infof("Processing %d claimed outbox events", claimedEvents.size)
 
-        for (event in pendingEvents) {
+        for (event in claimedEvents) {
             processEvent(event.id.toString(), event.eventType, event.payload, event.retryCount)
         }
     }
+
+    /**
+     * PENDING イベントを取得し IN_PROGRESS に遷移する。
+     * SELECT FOR UPDATE とステータス更新が同一トランザクション内で実行され、
+     * 複数インスタンス間での二重取得を防止する。
+     */
+    @Transactional
+    fun claimPendingEvents(): List<OutboxEventEntity> = outboxRepository.findPendingAndMarkInProgress(BATCH_SIZE)
 
     /**
      * 個別のアウトボックスイベントを処理する。
@@ -92,6 +105,7 @@ class OutboxProcessor {
                     MAX_RETRY_COUNT,
                 )
             } else {
+                event.status = "PENDING"
                 log.warnf(
                     e,
                     "Failed to send outbox event %s (type=%s), retry %d/%d",

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/OutboxRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/OutboxRepository.kt
@@ -22,4 +22,26 @@ class OutboxRepository : PanacheRepositoryBase<OutboxEventEntity, UUID> {
             .withLock(LockModeType.PESSIMISTIC_WRITE)
             .range(0, limit - 1)
             .list()
+
+    /**
+     * PENDING ステータスのイベントを悲観ロック付きで取得し、
+     * 即座に IN_PROGRESS に更新する。
+     *
+     * 呼び出し元が @Transactional であること。SELECT FOR UPDATE と
+     * ステータス更新が同一トランザクション内で実行されることで、
+     * 複数インスタンス間での二重取得を防止する。
+     *
+     * @param limit 最大取得件数
+     * @return IN_PROGRESS に遷移したイベントのリスト
+     */
+    fun findPendingAndMarkInProgress(limit: Int): List<OutboxEventEntity> {
+        val events = findPendingEvents(limit)
+
+        for (event in events) {
+            event.status = "IN_PROGRESS"
+            persist(event)
+        }
+
+        return events
+    }
 }

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/event/OutboxProcessorTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/event/OutboxProcessorTest.kt
@@ -53,7 +53,8 @@ class OutboxProcessorTest {
     @Test
     fun `PENDINGイベントなし時は何もしない`() {
         // Arrange
-        whenever(outboxRepository.findPendingEvents(OutboxProcessor.BATCH_SIZE)).thenReturn(emptyList())
+        whenever(outboxRepository.findPendingAndMarkInProgress(OutboxProcessor.BATCH_SIZE))
+            .thenReturn(emptyList())
 
         // Act
         outboxProcessor.processOutbox()
@@ -84,7 +85,7 @@ class OutboxProcessorTest {
     }
 
     @Test
-    fun `送信失敗時はretryCountをインクリメントしPENDINGのまま`() {
+    fun `送信失敗時はretryCountをインクリメントしPENDINGに戻す`() {
         // Arrange
         val event = createPendingEvent("sale.completed", """{"eventType":"sale.completed"}""")
         whenever(outboxRepository.findById(event.id)).thenReturn(event)
@@ -137,7 +138,7 @@ class OutboxProcessorTest {
         // Arrange
         val event1 = createPendingEvent("sale.completed", """{"id":"1"}""")
         val event2 = createPendingEvent("sale.voided", """{"id":"2"}""")
-        whenever(outboxRepository.findPendingEvents(OutboxProcessor.BATCH_SIZE))
+        whenever(outboxRepository.findPendingAndMarkInProgress(OutboxProcessor.BATCH_SIZE))
             .thenReturn(listOf(event1, event2))
         whenever(outboxRepository.findById(event1.id)).thenReturn(event1)
         whenever(outboxRepository.findById(event2.id)).thenReturn(event2)
@@ -151,7 +152,7 @@ class OutboxProcessorTest {
     }
 
     @Test
-    fun `リトライ9回目まではPENDINGを維持する`() {
+    fun `リトライ9回目まではPENDINGに戻す`() {
         // Arrange
         val event = createPendingEvent("sale.voided", """{"eventType":"sale.voided"}""")
         event.retryCount = OutboxProcessor.MAX_RETRY_COUNT - 2 // 8
@@ -173,5 +174,40 @@ class OutboxProcessorTest {
         assertEquals("PENDING", event.status)
         assertEquals(OutboxProcessor.MAX_RETRY_COUNT - 1, event.retryCount) // 9
         verify(outboxRepository).persist(event)
+    }
+
+    @Test
+    fun `claimPendingEventsはfindPendingAndMarkInProgressに委譲する`() {
+        // Arrange
+        val event = createPendingEvent("sale.completed", """{"id":"1"}""")
+        whenever(outboxRepository.findPendingAndMarkInProgress(OutboxProcessor.BATCH_SIZE))
+            .thenReturn(listOf(event))
+
+        // Act
+        val result = outboxProcessor.claimPendingEvents()
+
+        // Assert
+        assertEquals(1, result.size)
+        assertEquals(event.id, result[0].id)
+        verify(outboxRepository).findPendingAndMarkInProgress(OutboxProcessor.BATCH_SIZE)
+    }
+
+    @Test
+    fun `存在しないイベントIDの場合は何もしない`() {
+        // Arrange
+        val nonExistentId = UUID.randomUUID()
+        whenever(outboxRepository.findById(nonExistentId)).thenReturn(null)
+
+        // Act
+        outboxProcessor.processEvent(
+            nonExistentId.toString(),
+            "sale.completed",
+            """{"eventType":"sale.completed"}""",
+            0,
+        )
+
+        // Assert
+        verify(emitter, never()).send(any<Message<String>>())
+        verify(outboxRepository, never()).persist(any<OutboxEventEntity>())
     }
 }


### PR DESCRIPTION
## Summary
- `processOutbox()` で SELECT FOR UPDATE と IN_PROGRESS 更新が別トランザクションで実行されており、複数インスタンスが同じ PENDING イベントを取得して二重パブリッシュする可能性があった
- `claimPendingEvents()` メソッドを `@Transactional` で追加し、SELECT FOR UPDATE → IN_PROGRESS 更新を同一トランザクション内で実行するよう修正
- 送信失敗時はステータスを PENDING に戻してリトライ可能にする

## Changes
- `OutboxRepository`: `findPendingAndMarkInProgress()` メソッドを追加（SELECT FOR UPDATE + IN_PROGRESS 更新を一括実行）
- `OutboxProcessor`: `claimPendingEvents()` を `@Transactional` で追加し、`processOutbox()` から呼び出し
- `OutboxProcessorTest`: 新フローに合わせてテスト更新、2件のテストケースを追加（全8件 pass）

## Test plan
- [x] `./gradlew :services:pos-service:test --tests "com.openpos.pos.event.OutboxProcessorTest"` — 全 8 テスト pass
- [ ] CI pipeline pass

Closes #977