### PR TITLE
fix: address MEDIUM issues #981-#986

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -136,7 +136,7 @@ api-gateway には SmallRye OpenAPI (`quarkus-smallrye-openapi`) が組み込ま
 ```json
 {
   "data": [ ... ],
-  "meta": { "page": 0, "size": 20, "total": 150, "totalPages": 8 }
+  "pagination": { "page": 1, "pageSize": 20, "totalCount": 150, "totalPages": 8 }
 }
 ```
 
@@ -155,8 +155,11 @@ api-gateway には SmallRye OpenAPI (`quarkus-smallrye-openapi`) が組み込ま
 ## ページネーション
 
 ```
-GET /api/products?page=0&size=20&sort=display_order,asc
+GET /api/products?page=1&pageSize=20
 ```
+
+- `page` は 1 始まり（0 以下を指定すると 400 Bad Request）
+- `pageSize` のデフォルトは 20
 
 ## gRPC サービス（内部通信）
 

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/PinAuthRateLimitFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/PinAuthRateLimitFilter.kt
@@ -1,0 +1,86 @@
+package com.openpos.gateway.config
+
+import io.quarkus.redis.datasource.RedisDataSource
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.ws.rs.Priorities
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerRequestFilter
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.ext.Provider
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.time.Instant
+
+/**
+ * PIN 認証エンドポイント専用の per-IP レートリミッター。
+ * ブルートフォース攻撃を防止するため、1分あたり 10 回に制限する。
+ */
+@Provider
+@Priority(Priorities.AUTHENTICATION + 3)
+@ApplicationScoped
+class PinAuthRateLimitFilter : ContainerRequestFilter {
+    @Inject
+    lateinit var redis: RedisDataSource
+
+    @ConfigProperty(name = "openpos.rate-limit.pin-auth-per-minute", defaultValue = "10")
+    var pinAuthPerMinute: Int = 10
+
+    private val log = Logger.getLogger(PinAuthRateLimitFilter::class.java)
+
+    companion object {
+        private const val TTL_SECONDS = 60L
+        private val PIN_AUTH_PATH_REGEX = Regex("^api/staff/[^/]+/authenticate$")
+    }
+
+    override fun filter(requestContext: ContainerRequestContext) {
+        if (!requestContext.method.equals("POST", ignoreCase = true)) return
+
+        val path = requestContext.uriInfo.path
+        if (!PIN_AUTH_PATH_REGEX.matches(path)) return
+
+        val clientIp = extractClientIp(requestContext)
+        val minuteKey = (Instant.now().epochSecond / 60).toString()
+        val redisKey = "openpos:api-gateway:pin-ratelimit:$clientIp:$minuteKey"
+
+        val currentCount = tryIncrement(redisKey)
+
+        if (currentCount < 0 || currentCount > pinAuthPerMinute) {
+            log.warnf("PIN auth rate limit exceeded: ip=%s, count=%d", clientIp, currentCount)
+            requestContext.abortWith(
+                Response
+                    .status(429)
+                    .header("Retry-After", 60)
+                    .entity(
+                        mapOf(
+                            "error" to "Too Many Requests",
+                            "message" to "Too many PIN authentication attempts. Please try again later.",
+                        ),
+                    ).build(),
+            )
+        }
+    }
+
+    private fun extractClientIp(requestContext: ContainerRequestContext): String =
+        requestContext
+            .getHeaderString("X-Forwarded-For")
+            ?.split(",")
+            ?.firstOrNull()
+            ?.trim()
+            ?: requestContext.getHeaderString("X-Real-IP")
+            ?: "unknown"
+
+    internal fun tryIncrement(key: String): Long =
+        try {
+            val valueCommands = redis.value(Long::class.java)
+            val count = valueCommands.incr(key)
+            if (count == 1L) {
+                redis.key().expire(key, TTL_SECONDS)
+            }
+            count
+        } catch (e: Exception) {
+            log.warnf("Redis PIN rate-limit INCR failed for key=%s: %s", key, e.message)
+            -1L
+        }
+}

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/ProtoMapper.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/ProtoMapper.kt
@@ -451,3 +451,12 @@ fun <T> paginatedResponse(
         "data" to data,
         "pagination" to pagination.toMap(),
     )
+
+/**
+ * ページ番号のバリデーション。1未満の場合は 400 Bad Request を返す。
+ */
+fun requireValidPage(page: Int) {
+    if (page < 1) {
+        throw jakarta.ws.rs.BadRequestException("page must be >= 1, got $page")
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/InventoryResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/InventoryResource.kt
@@ -3,6 +3,7 @@ package com.openpos.gateway.resource
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.paginatedResponse
+import com.openpos.gateway.config.requireValidPage
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -56,6 +57,7 @@ class InventoryResource {
         @QueryParam("pageSize") @DefaultValue("20") pageSize: Int,
         @QueryParam("lowStockOnly") @DefaultValue("false") lowStockOnly: Boolean,
     ): Map<String, Any> {
+        requireValidPage(page)
         val request =
             ListStocksRequest
                 .newBuilder()
@@ -126,6 +128,7 @@ class InventoryResource {
         @QueryParam("startDate") startDate: String?,
         @QueryParam("endDate") endDate: String?,
     ): Map<String, Any> {
+        requireValidPage(page)
         val request =
             ListStockMovementsRequest
                 .newBuilder()
@@ -201,6 +204,7 @@ class InventoryResource {
         @QueryParam("page") @DefaultValue("1") page: Int,
         @QueryParam("pageSize") @DefaultValue("20") pageSize: Int,
     ): Map<String, Any> {
+        requireValidPage(page)
         val request =
             ListPurchaseOrdersRequest
                 .newBuilder()

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/JournalResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/JournalResource.kt
@@ -3,6 +3,7 @@ package com.openpos.gateway.resource
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.paginatedResponse
+import com.openpos.gateway.config.requireValidPage
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -40,6 +41,7 @@ class JournalResource {
         @QueryParam("endDate") endDate: String?,
     ): Map<String, Any> {
         tenantContext.requireRole("OWNER", "MANAGER")
+        requireValidPage(page)
         val request =
             ListJournalEntriesRequest
                 .newBuilder()

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductResource.kt
@@ -7,6 +7,7 @@ import com.openpos.gateway.cache.RedisCacheService
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.paginatedResponse
+import com.openpos.gateway.config.requireValidPage
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -97,6 +98,7 @@ class ProductResource {
         @QueryParam("search") search: String?,
         @QueryParam("activeOnly") @DefaultValue("false") activeOnly: Boolean,
     ): Map<String, Any> {
+        requireValidPage(page)
         val request =
             ListProductsRequest
                 .newBuilder()

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StaffResource.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.BoolValue
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.SessionTokenService
 import com.openpos.gateway.config.paginatedResponse
+import com.openpos.gateway.config.requireValidPage
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -86,6 +87,7 @@ class StaffResource {
         @QueryParam("page") @DefaultValue("1") page: Int,
         @QueryParam("pageSize") @DefaultValue("20") pageSize: Int,
     ): Map<String, Any> {
+        requireValidPage(page)
         val request =
             ListStaffRequest
                 .newBuilder()

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StoreResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StoreResource.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.BoolValue
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.paginatedResponse
+import com.openpos.gateway.config.requireValidPage
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -74,6 +75,7 @@ class StoreResource {
         @QueryParam("page") @DefaultValue("1") page: Int,
         @QueryParam("pageSize") @DefaultValue("20") pageSize: Int,
     ): Map<String, Any> {
+        requireValidPage(page)
         val request =
             ListStoresRequest
                 .newBuilder()

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SyncResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/SyncResource.kt
@@ -45,9 +45,27 @@ class SyncResource {
     @ConfigProperty(name = "openpos.sync.max-unit-price", defaultValue = "10000000")
     var maxUnitPrice: Long = 10_000_000
 
+    @ConfigProperty(name = "openpos.sync.max-transactions", defaultValue = "100")
+    var maxTransactions: Int = 100
+
+    @ConfigProperty(name = "openpos.sync.max-items-per-transaction", defaultValue = "500")
+    var maxItemsPerTransaction: Int = 500
+
     @POST
     @Path("/transactions")
     fun syncTransactions(body: SyncTransactionsBody): Map<String, Any> {
+        if (body.transactions.size > maxTransactions) {
+            throw BadRequestException(
+                "Too many transactions: ${body.transactions.size} exceeds maximum of $maxTransactions",
+            )
+        }
+        body.transactions.forEachIndexed { index, t ->
+            if (t.items.size > maxItemsPerTransaction) {
+                throw BadRequestException(
+                    "Transaction[$index] has too many items: ${t.items.size} exceeds maximum of $maxItemsPerTransaction",
+                )
+            }
+        }
         val request =
             SyncOfflineTransactionsRequest
                 .newBuilder()

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TransactionResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TransactionResource.kt
@@ -4,6 +4,7 @@ import com.openpos.gateway.cache.RedisCacheService
 import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
 import com.openpos.gateway.config.paginatedResponse
+import com.openpos.gateway.config.requireValidPage
 import com.openpos.gateway.config.toMap
 import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
@@ -91,6 +92,7 @@ class TransactionResource {
         @QueryParam("startDate") startDate: String?,
         @QueryParam("endDate") endDate: String?,
     ): Map<String, Any> {
+        requireValidPage(page)
         val request =
             ListTransactionsRequest
                 .newBuilder()

--- a/services/store-service/src/main/kotlin/com/openpos/store/config/DataMaskingUtil.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/config/DataMaskingUtil.kt
@@ -1,0 +1,20 @@
+package com.openpos.store.config
+
+/**
+ * 個人情報（PII）のマスキングユーティリティ。
+ * 監査ログ出力時に使用し、平文での PII 記録を防止する。
+ */
+object DataMaskingUtil {
+    /**
+     * 名前をマスクする。先頭 N 文字だけ表示してマスク。
+     * 例: "田中太郎" → "田中**"
+     */
+    fun maskName(
+        name: String?,
+        visibleChars: Int = 2,
+    ): String {
+        if (name.isNullOrBlank()) return "***"
+        if (name.length <= visibleChars) return name
+        return name.take(visibleChars) + "**"
+    }
+}

--- a/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
@@ -2,6 +2,7 @@ package com.openpos.store.grpc
 
 import at.favre.lib.crypto.bcrypt.BCrypt
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openpos.store.config.DataMaskingUtil
 import com.openpos.store.entity.DataProcessingConsentEntity
 import com.openpos.store.entity.OrganizationEntity
 import com.openpos.store.entity.StaffEntity
@@ -318,7 +319,7 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
             entityId = entity.id.toString(),
             details =
                 objectMapper.writeValueAsString(
-                    mapOf("name" to entity.name, "role" to entity.role, "storeId" to entity.storeId.toString()),
+                    mapOf("name" to DataMaskingUtil.maskName(entity.name), "role" to entity.role, "storeId" to entity.storeId.toString()),
                 ),
         )
         responseObserver.onNext(
@@ -405,7 +406,7 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
             entityId = entity.id.toString(),
             details =
                 objectMapper.writeValueAsString(
-                    mapOf("name" to entity.name, "role" to entity.role),
+                    mapOf("name" to DataMaskingUtil.maskName(entity.name), "role" to entity.role),
                 ),
         )
         responseObserver.onNext(


### PR DESCRIPTION
## Summary
- **#981**: Add `requireValidPage(page)` validation to all paginated gateway resources (Product, Transaction, Inventory, Store, Staff, Journal). Returns 400 Bad Request if `page < 1`.
- **#982**: Update `docs/api-reference.md` pagination section to match actual 1-based page API and correct `pagination` response field name.
- **#983**: Mask staff names using `DataMaskingUtil.maskName()` in audit log details for `createStaff` and `updateStaff` in `StoreGrpcService`.
- **#984**: Closed as duplicate of #908 (webhook async already documented as TODO).
- **#985**: Add `PinAuthRateLimitFilter` for per-IP rate limiting (10 attempts/min) on `POST /api/staff/*/authenticate` to prevent PIN brute-force attacks.
- **#986**: Add configurable batch size limits to `SyncResource`: max 100 transactions and 500 items per transaction. Returns 400 if exceeded.

Closes #981, Closes #982, Closes #983, Closes #985, Closes #986

## Test plan
- [x] `./gradlew --parallel :services:api-gateway:build :services:store-service:build` passes
- [ ] CI passes all checks