### PR TITLE
fix: address HIGH issues #978 #979 #980

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/ServiceHealthCheck.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/ServiceHealthCheck.kt
@@ -1,6 +1,7 @@
 package com.openpos.analytics
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.persistence.EntityManager
@@ -16,7 +17,7 @@ class ServiceLivenessCheck : HealthCheck {
 }
 
 /**
- * Readiness check: DB + Redis の接続を検証する。
+ * Readiness check: DB + Redis + RabbitMQ の接続を検証する。
  */
 @Readiness
 @ApplicationScoped
@@ -26,6 +27,9 @@ class ServiceReadinessCheck : HealthCheck {
 
     @Inject
     lateinit var redis: ReactiveRedisDataSource
+
+    @Inject
+    lateinit var healthCenter: HealthCenter
 
     override fun call(): HealthCheckResponse {
         val builder = HealthCheckResponse.named("analytics-service-readiness")
@@ -46,6 +50,11 @@ class ServiceReadinessCheck : HealthCheck {
             builder.withData("redis", "error: ${e.message}")
             return builder.down().build()
         }
+        if (!healthCenter.readiness.isOk) {
+            builder.withData("rabbitmq", "not ready")
+            return builder.down().build()
+        }
+        builder.withData("rabbitmq", "ok")
         return builder.up().build()
     }
 }

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/ServiceHealthCheck.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/ServiceHealthCheck.kt
@@ -1,6 +1,7 @@
 package com.openpos.inventory
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.persistence.EntityManager
@@ -16,7 +17,7 @@ class ServiceLivenessCheck : HealthCheck {
 }
 
 /**
- * Readiness check: DB + Redis の接続を検証する。
+ * Readiness check: DB + Redis + RabbitMQ の接続を検証する。
  */
 @Readiness
 @ApplicationScoped
@@ -26,6 +27,9 @@ class ServiceReadinessCheck : HealthCheck {
 
     @Inject
     lateinit var redis: ReactiveRedisDataSource
+
+    @Inject
+    lateinit var healthCenter: HealthCenter
 
     override fun call(): HealthCheckResponse {
         val builder = HealthCheckResponse.named("inventory-service-readiness")
@@ -46,6 +50,11 @@ class ServiceReadinessCheck : HealthCheck {
             builder.withData("redis", "error: ${e.message}")
             return builder.down().build()
         }
+        if (!healthCenter.readiness.isOk) {
+            builder.withData("rabbitmq", "not ready")
+            return builder.down().build()
+        }
+        builder.withData("rabbitmq", "ok")
         return builder.up().build()
     }
 }

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/grpc/InventoryGrpcService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/grpc/InventoryGrpcService.kt
@@ -402,7 +402,7 @@ class InventoryGrpcService : InventoryServiceGrpc.InventoryServiceImplBase() {
             )
             responseObserver.onCompleted()
         } catch (e: Exception) {
-            responseObserver.onError(Status.INTERNAL.withDescription(e.message).asRuntimeException())
+            responseObserver.onError(Status.INTERNAL.withDescription("Internal server error").asRuntimeException())
         }
     }
 
@@ -490,7 +490,7 @@ class InventoryGrpcService : InventoryServiceGrpc.InventoryServiceImplBase() {
         } catch (e: IllegalArgumentException) {
             responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(e.message).asRuntimeException())
         } catch (e: Exception) {
-            responseObserver.onError(Status.INTERNAL.withDescription(e.message).asRuntimeException())
+            responseObserver.onError(Status.INTERNAL.withDescription("Internal server error").asRuntimeException())
         }
     }
 

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/ServiceHealthCheck.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/ServiceHealthCheck.kt
@@ -1,6 +1,7 @@
 package com.openpos.pos
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.persistence.EntityManager
@@ -16,7 +17,7 @@ class ServiceLivenessCheck : HealthCheck {
 }
 
 /**
- * Readiness check: DB + Redis の接続を検証する。
+ * Readiness check: DB + Redis + RabbitMQ の接続を検証する。
  */
 @Readiness
 @ApplicationScoped
@@ -26,6 +27,9 @@ class ServiceReadinessCheck : HealthCheck {
 
     @Inject
     lateinit var redis: ReactiveRedisDataSource
+
+    @Inject
+    lateinit var healthCenter: HealthCenter
 
     override fun call(): HealthCheckResponse {
         val builder = HealthCheckResponse.named("pos-service-readiness")
@@ -46,6 +50,11 @@ class ServiceReadinessCheck : HealthCheck {
             builder.withData("redis", "error: ${e.message}")
             return builder.down().build()
         }
+        if (!healthCenter.readiness.isOk) {
+            builder.withData("rabbitmq", "not ready")
+            return builder.down().build()
+        }
+        builder.withData("rabbitmq", "ok")
         return builder.up().build()
     }
 }

--- a/services/product-service/src/main/kotlin/com/openpos/product/ServiceHealthCheck.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/ServiceHealthCheck.kt
@@ -1,6 +1,7 @@
 package com.openpos.product
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.persistence.EntityManager
@@ -16,7 +17,7 @@ class ServiceLivenessCheck : HealthCheck {
 }
 
 /**
- * Readiness check: DB + Redis の接続を検証する。
+ * Readiness check: DB + Redis + RabbitMQ の接続を検証する。
  */
 @Readiness
 @ApplicationScoped
@@ -26,6 +27,9 @@ class ServiceReadinessCheck : HealthCheck {
 
     @Inject
     lateinit var redis: ReactiveRedisDataSource
+
+    @Inject
+    lateinit var healthCenter: HealthCenter
 
     override fun call(): HealthCheckResponse {
         val builder = HealthCheckResponse.named("product-service-readiness")
@@ -48,6 +52,11 @@ class ServiceReadinessCheck : HealthCheck {
             builder.withData("redis", "error: ${e.message}")
             return builder.down().build()
         }
+        if (!healthCenter.readiness.isOk) {
+            builder.withData("rabbitmq", "not ready")
+            return builder.down().build()
+        }
+        builder.withData("rabbitmq", "ok")
         return builder.up().build()
     }
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/ServiceHealthCheck.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/ServiceHealthCheck.kt
@@ -1,6 +1,7 @@
 package com.openpos.store
 
 import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.smallrye.reactive.messaging.providers.extension.HealthCenter
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.persistence.EntityManager
@@ -16,7 +17,7 @@ class ServiceLivenessCheck : HealthCheck {
 }
 
 /**
- * Readiness check: DB + Redis の接続を検証する。
+ * Readiness check: DB + Redis + RabbitMQ の接続を検証する。
  */
 @Readiness
 @ApplicationScoped
@@ -26,6 +27,9 @@ class ServiceReadinessCheck : HealthCheck {
 
     @Inject
     lateinit var redis: ReactiveRedisDataSource
+
+    @Inject
+    lateinit var healthCenter: HealthCenter
 
     override fun call(): HealthCheckResponse {
         val builder = HealthCheckResponse.named("store-service-readiness")
@@ -46,6 +50,11 @@ class ServiceReadinessCheck : HealthCheck {
             builder.withData("redis", "error: ${e.message}")
             return builder.down().build()
         }
+        if (!healthCenter.readiness.isOk) {
+            builder.withData("rabbitmq", "not ready")
+            return builder.down().build()
+        }
+        builder.withData("rabbitmq", "ok")
         return builder.up().build()
     }
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/repository/StaffRepository.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/repository/StaffRepository.kt
@@ -5,6 +5,7 @@ import io.quarkus.hibernate.orm.panache.kotlin.PanacheRepositoryBase
 import io.quarkus.panache.common.Page
 import io.quarkus.panache.common.Sort
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.persistence.LockModeType
 import java.util.UUID
 
 @ApplicationScoped
@@ -15,6 +16,8 @@ class StaffRepository : PanacheRepositoryBase<StaffEntity, UUID> {
     ): List<StaffEntity> = find("storeId = ?1", Sort.ascending("name"), storeId).page(page).list()
 
     fun countByStoreId(storeId: UUID): Long = count("storeId = ?1", storeId)
+
+    fun findByIdForUpdate(id: UUID): StaffEntity? = find("id = ?1", id).withLock(LockModeType.PESSIMISTIC_WRITE).firstResult()
 
     fun findByEmail(email: String): StaffEntity? = find("email = ?1", email).firstResult()
 

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/StaffService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/StaffService.kt
@@ -112,6 +112,7 @@ class StaffService {
     /**
      * PIN 認証を行う。
      * pinVerifier は bcrypt 検証関数をコールバックとして受け取る（DI の bcrypt 依存を避ける）。
+     * 悲観的ロック（SELECT FOR UPDATE）で pinFailedCount の read-modify-write を保護する。
      */
     @Transactional
     fun authenticateByPin(
@@ -121,7 +122,7 @@ class StaffService {
         pinVerifier: (String, String) -> Boolean,
     ): PinAuthResult {
         tenantFilterService.enableFilter()
-        val staff = staffRepository.findById(staffId)
+        val staff = staffRepository.findByIdForUpdate(staffId)
         if (staff == null || staff.storeId != storeId) {
             // タイミングサイドチャネル対策: ダミー bcrypt 検証で応答時間を均一化
             pinVerifier("dummy", DUMMY_BCRYPT_HASH)

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/StaffServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/StaffServiceTest.kt
@@ -276,7 +276,7 @@ class StaffServiceTest {
                     this.pinFailedCount = 0
                     this.pinLockedUntil = null
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
@@ -295,7 +295,7 @@ class StaffServiceTest {
         fun `存在しないスタッフIDの場合はNOT_FOUNDを返す`() {
             // Arrange
             val staffId = UUID.randomUUID()
-            whenever(staffRepository.findById(staffId)).thenReturn(null)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(null)
 
             // Act
             val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
@@ -321,7 +321,7 @@ class StaffServiceTest {
                     this.pinHash = "1234"
                     this.isActive = true
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
 
             // Act
             val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
@@ -346,7 +346,7 @@ class StaffServiceTest {
                     this.pinHash = "1234"
                     this.isActive = false
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
 
             // Act
             val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
@@ -373,7 +373,7 @@ class StaffServiceTest {
                     this.pinFailedCount = 5
                     this.pinLockedUntil = Instant.now().plusSeconds(3600)
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
 
             // Act
             val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
@@ -400,7 +400,7 @@ class StaffServiceTest {
                     this.pinFailedCount = 0
                     this.pinLockedUntil = null
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
 
             // Act
             val result = staffService.authenticateByPin(staffId, storeId, "1234") { plain, hash -> plain == hash }
@@ -427,7 +427,7 @@ class StaffServiceTest {
                     this.pinFailedCount = 0
                     this.pinLockedUntil = null
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
@@ -456,7 +456,7 @@ class StaffServiceTest {
                     this.pinFailedCount = 4
                     this.pinLockedUntil = null
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
@@ -485,7 +485,7 @@ class StaffServiceTest {
                     this.pinFailedCount = 3
                     this.pinLockedUntil = null
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
@@ -513,7 +513,7 @@ class StaffServiceTest {
                     this.pinFailedCount = 5
                     this.pinLockedUntil = Instant.now().minusSeconds(3600)
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
@@ -541,7 +541,7 @@ class StaffServiceTest {
                     this.pinFailedCount = 5
                     this.pinLockedUntil = Instant.now().minusSeconds(3600)
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            whenever(staffRepository.findByIdForUpdate(staffId)).thenReturn(entity)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act


### PR DESCRIPTION
## Summary

- **#978 Staff PIN lockout concurrency**: Use `SELECT FOR UPDATE` (pessimistic lock) via `findByIdForUpdate()` during PIN authentication to prevent race conditions on `pinFailedCount` read-modify-write
- **#979 Inventory gRPC error leakage**: Replace `e.message` with fixed `"Internal server error"` in catch-all blocks of `createPurchaseOrder` and `updatePurchaseOrderStatus` to prevent internal details from leaking to gRPC clients
- **#980 Health check missing RabbitMQ**: Add RabbitMQ connectivity check via SmallRye `HealthCenter.readiness` to all 5 service readiness checks (pos, store, inventory, product, analytics)

## Test plan
- [x] store-service tests pass (StaffServiceTest updated to mock `findByIdForUpdate`)
- [x] inventory-service tests pass
- [x] All 4 non-pos services compile successfully
- [ ] CI full test suite

Closes #978, Closes #979, Closes #980