### PR TITLE
fix: address Claude nitpick review issues #993-#998

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ apps/*/public/demo-config.json
 proto/gen/
 services/*/src/main/proto/openpos/
 
+# === Stale build artifacts ===
+services/com/
+
 # === Docker ===
 docker-compose.override.yml
 compose.override.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ subprojects {
 
         afterEvaluate {
             dependencies {
+                "implementation"(rootProject.libs.quarkus.logging.json)
                 "testImplementation"(rootProject.libs.testcontainers)
                 "testImplementation"(rootProject.libs.testcontainers.postgresql)
                 "testImplementation"(rootProject.libs.testcontainers.junit.jupiter)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ quarkus-smallrye-openapi = { module = "io.quarkus:quarkus-smallrye-openapi" }
 quarkus-smallrye-fault-tolerance = { module = "io.quarkus:quarkus-smallrye-fault-tolerance" }
 quarkus-micrometer-registry-prometheus = { module = "io.quarkus:quarkus-micrometer-registry-prometheus" }
 quarkus-opentelemetry = { module = "io.quarkus:quarkus-opentelemetry" }
+quarkus-logging-json = { module = "io.quarkus:quarkus-logging-json" }
 quarkus-scheduler = { module = "io.quarkus:quarkus-scheduler" }
 
 # Kotlin

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/config/OrganizationIdInterceptor.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/config/OrganizationIdInterceptor.kt
@@ -2,6 +2,7 @@ package com.openpos.analytics.config
 
 import io.grpc.Context
 import io.grpc.Contexts
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
 import io.grpc.Metadata
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
@@ -98,7 +99,37 @@ class OrganizationIdInterceptor : ServerInterceptor {
                 .current()
                 .withValue(ORGANIZATION_ID_CTX_KEY, orgId)
                 .withValue(REQUEST_ID_CTX_KEY, requestId)
-        return Contexts.interceptCall(ctx, call, headers, next)
+        val delegate = Contexts.interceptCall(ctx, call, headers, next)
+        return MdcCleanupListener(delegate)
+    }
+
+    private class MdcCleanupListener<ReqT>(
+        delegate: ServerCall.Listener<ReqT>,
+    ) : SimpleForwardingServerCallListener<ReqT>(delegate) {
+        private fun cleanupMdc() {
+            org.jboss.logging.MDC
+                .remove("requestId")
+            org.jboss.logging.MDC
+                .remove("trace_id")
+            org.jboss.logging.MDC
+                .remove("organization_id")
+        }
+
+        override fun onComplete() {
+            try {
+                super.onComplete()
+            } finally {
+                cleanupMdc()
+            }
+        }
+
+        override fun onCancel() {
+            try {
+                super.onCancel()
+            } finally {
+                cleanupMdc()
+            }
+        }
     }
 
     private fun extractOrGenerateRequestId(headers: Metadata): String {

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/SalesEventProcessor.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/SalesEventProcessor.kt
@@ -9,9 +9,10 @@ import com.openpos.analytics.repository.ProductSalesRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.transaction.Transactional
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
+import java.time.ZoneId
 import java.util.UUID
 
 /**
@@ -28,6 +29,12 @@ class SalesEventProcessor {
     @Inject
     lateinit var hourlySalesRepository: HourlySalesRepository
 
+    @ConfigProperty(name = "openpos.analytics.timezone", defaultValue = "Asia/Tokyo")
+    lateinit var timezoneName: String
+
+    val timezone: ZoneId
+        get() = ZoneId.of(timezoneName)
+
     /**
      * 売上完了イベントを処理する。
      * 日次・商品別・時間帯別の集計を更新する。
@@ -39,8 +46,8 @@ class SalesEventProcessor {
     ) {
         val storeId = UUID.fromString(payload.storeId)
         val transactedAt = Instant.parse(payload.transactedAt)
-        val saleDate = transactedAt.atZone(ZoneOffset.UTC).toLocalDate()
-        val hour = transactedAt.atZone(ZoneOffset.UTC).hour
+        val saleDate = transactedAt.atZone(timezone).toLocalDate()
+        val hour = transactedAt.atZone(timezone).hour
 
         // 日次売上更新
         updateDailySales(organizationId, storeId, saleDate, payload.totalAmount, payload.taxTotal, payload.discountTotal, payload.payments)
@@ -74,8 +81,8 @@ class SalesEventProcessor {
     ) {
         val storeId = UUID.fromString(payload.storeId)
         val originalTransactedAt = Instant.parse(payload.originalTransactedAt)
-        val originalDate = originalTransactedAt.atZone(ZoneOffset.UTC).toLocalDate()
-        val originalHour = originalTransactedAt.atZone(ZoneOffset.UTC).hour
+        val originalDate = originalTransactedAt.atZone(timezone).toLocalDate()
+        val originalHour = originalTransactedAt.atZone(timezone).hour
 
         // 日次売上ロールバック（取消合計を計算）
         val totalAmount = payload.items.sumOf { it.subtotal }

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/AnalyticsQueryService.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/AnalyticsQueryService.kt
@@ -5,6 +5,8 @@ import com.openpos.analytics.repository.DailySalesRepository
 import com.openpos.analytics.repository.ProductSalesRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.LocalDate
 import java.util.UUID
 
@@ -55,9 +57,10 @@ class AnalyticsQueryService {
         val totalRevenue = grouped.sumOf { it.third }
         if (totalRevenue == 0L) return emptyList()
 
+        val totalRevenueBd = BigDecimal.valueOf(totalRevenue)
         var cumulative = 0.0
         return grouped.map { (productId, name, revenue) ->
-            val ratio = revenue.toDouble() / totalRevenue
+            val ratio = BigDecimal.valueOf(revenue).divide(totalRevenueBd, 10, RoundingMode.HALF_UP).toDouble()
             cumulative += ratio
             val rank =
                 when {
@@ -112,7 +115,12 @@ class AnalyticsQueryService {
                     val totalCost = records.sumOf { it.costAmount }
                     val totalQty = records.sumOf { it.quantitySold }
                     val grossProfit = totalRevenue - totalCost
-                    val marginRate = if (totalRevenue > 0) grossProfit.toDouble() / totalRevenue else 0.0
+                    val marginRate =
+                        if (totalRevenue > 0) {
+                            BigDecimal.valueOf(grossProfit).divide(BigDecimal.valueOf(totalRevenue), 10, RoundingMode.HALF_UP).toDouble()
+                        } else {
+                            0.0
+                        }
                     GrossProfitItem(
                         productId = productId,
                         productName = name,

--- a/services/analytics-service/src/main/resources/application.properties
+++ b/services/analytics-service/src/main/resources/application.properties
@@ -36,6 +36,7 @@ rabbitmq-password=${RABBITMQ_PASS:openpos_dev}
 
 # Structured Logging
 quarkus.log.level=INFO
+%prod.quarkus.log.console.json=true
 
 # RabbitMQ Incoming (Event Consumer)
 mp.messaging.incoming.sale-completed-events.connector=smallrye-rabbitmq

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/SalesEventProcessorUnitTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/SalesEventProcessorUnitTest.kt
@@ -43,6 +43,7 @@ class SalesEventProcessorUnitTest {
         processor.dailySalesRepository = dailySalesRepository
         processor.productSalesRepository = productSalesRepository
         processor.hourlySalesRepository = hourlySalesRepository
+        processor.timezoneName = "UTC"
 
         doNothing().whenever(dailySalesRepository).persist(any<DailySalesEntity>())
         doNothing().whenever(productSalesRepository).persist(any<ProductSalesEntity>())

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -68,6 +68,7 @@ openpos.auth.skip-paths=/api/health,/q/,/api/staff/{id}/authenticate
 
 # Structured Logging
 quarkus.log.level=INFO
+%prod.quarkus.log.console.json=true
 
 # Dev profile (quarkusDev with local infra via Docker Compose)
 %dev.quarkus.redis.hosts=redis://:openpos_dev@localhost:16379

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/config/OrganizationIdInterceptor.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/config/OrganizationIdInterceptor.kt
@@ -2,6 +2,7 @@ package com.openpos.inventory.config
 
 import io.grpc.Context
 import io.grpc.Contexts
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
 import io.grpc.Metadata
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
@@ -104,7 +105,37 @@ class OrganizationIdInterceptor : ServerInterceptor {
                 .current()
                 .withValue(ORGANIZATION_ID_CTX_KEY, orgId)
                 .withValue(REQUEST_ID_CTX_KEY, requestId)
-        return Contexts.interceptCall(ctx, call, headers, next)
+        val delegate = Contexts.interceptCall(ctx, call, headers, next)
+        return MdcCleanupListener(delegate)
+    }
+
+    private class MdcCleanupListener<ReqT>(
+        delegate: ServerCall.Listener<ReqT>,
+    ) : SimpleForwardingServerCallListener<ReqT>(delegate) {
+        private fun cleanupMdc() {
+            org.jboss.logging.MDC
+                .remove("requestId")
+            org.jboss.logging.MDC
+                .remove("trace_id")
+            org.jboss.logging.MDC
+                .remove("organization_id")
+        }
+
+        override fun onComplete() {
+            try {
+                super.onComplete()
+            } finally {
+                cleanupMdc()
+            }
+        }
+
+        override fun onCancel() {
+            try {
+                super.onCancel()
+            } finally {
+                cleanupMdc()
+            }
+        }
     }
 
     private fun extractOrGenerateRequestId(headers: Metadata): String {

--- a/services/inventory-service/src/main/resources/application.properties
+++ b/services/inventory-service/src/main/resources/application.properties
@@ -59,6 +59,7 @@ mp.messaging.incoming.sale-voided.reconnect-interval=5
 
 # Structured Logging
 quarkus.log.level=INFO
+%prod.quarkus.log.console.json=true
 
 # RabbitMQ Outgoing (StockLowEvent Publisher)
 mp.messaging.outgoing.stock-low-events.connector=smallrye-rabbitmq

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/config/OrganizationIdInterceptor.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/config/OrganizationIdInterceptor.kt
@@ -2,6 +2,7 @@ package com.openpos.pos.config
 
 import io.grpc.Context
 import io.grpc.Contexts
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
 import io.grpc.Metadata
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
@@ -114,7 +115,37 @@ class OrganizationIdInterceptor : ServerInterceptor {
         if (!idempotencyKey.isNullOrBlank()) {
             ctx = ctx.withValue(IDEMPOTENCY_KEY_CTX_KEY, idempotencyKey.trim())
         }
-        return Contexts.interceptCall(ctx, call, headers, next)
+        val delegate = Contexts.interceptCall(ctx, call, headers, next)
+        return MdcCleanupListener(delegate)
+    }
+
+    private class MdcCleanupListener<ReqT>(
+        delegate: ServerCall.Listener<ReqT>,
+    ) : SimpleForwardingServerCallListener<ReqT>(delegate) {
+        private fun cleanupMdc() {
+            org.jboss.logging.MDC
+                .remove("requestId")
+            org.jboss.logging.MDC
+                .remove("trace_id")
+            org.jboss.logging.MDC
+                .remove("organization_id")
+        }
+
+        override fun onComplete() {
+            try {
+                super.onComplete()
+            } finally {
+                cleanupMdc()
+            }
+        }
+
+        override fun onCancel() {
+            try {
+                super.onCancel()
+            } finally {
+                cleanupMdc()
+            }
+        }
     }
 
     private fun extractOrGenerateRequestId(headers: Metadata): String {

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -483,6 +483,7 @@ class TransactionService {
 
         // ビジネスメトリクス更新
         transactionsCompletedCounter.increment()
+        // Micrometer Counter.increment() accepts double — acceptable for metrics (not financial calc)
         revenueCounter.increment(tx.total.toDouble())
 
         return tx
@@ -769,6 +770,7 @@ class TransactionService {
         // 7. イベント発行 + メトリクス
         publishSaleCompletedEvent(tx, savedItems)
         transactionsCompletedCounter.increment()
+        // Micrometer Counter.increment() accepts double — acceptable for metrics (not financial calc)
         revenueCounter.increment(tx.total.toDouble())
 
         return tx

--- a/services/pos-service/src/main/resources/application.properties
+++ b/services/pos-service/src/main/resources/application.properties
@@ -55,6 +55,7 @@ quarkus.grpc.clients.store-service.deadline=5000
 
 # Structured Logging
 quarkus.log.level=INFO
+%prod.quarkus.log.console.json=true
 
 # Health (Quarkus standard: /q/health/live, /q/health/ready)
 quarkus.smallrye-health.root-path=/q/health

--- a/services/product-service/src/main/kotlin/com/openpos/product/cache/ProductCacheService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/cache/ProductCacheService.kt
@@ -23,6 +23,9 @@ class ProductCacheService {
         /** デフォルト TTL: 3600 秒（1 時間） — products, categories 用 */
         const val TTL_SECONDS = 3600L
         private const val PREFIX = "openpos:product-service"
+        private const val LOCK_TTL_SECONDS = 5L
+        private const val LOCK_RETRY_DELAY_MS = 50L
+        private const val LOCK_MAX_RETRIES = 10
     }
 
     // === Generic Operations ===
@@ -45,6 +48,58 @@ class ProductCacheService {
         } catch (e: Exception) {
             log.warnf("Redis SET failed for key=%s: %s", key, e.message)
         }
+    }
+
+    /**
+     * Cache stampede 防止付きの cache-aside 取得。
+     * キャッシュミス時に Redis SETNX でロックを取得し、1リクエストのみがキャッシュを再構築する。
+     * ロックを取得できなかったリクエストは短時間待機後にキャッシュを再取得する。
+     */
+    fun getOrLoad(
+        key: String,
+        ttlSeconds: Long = TTL_SECONDS,
+        loader: () -> String?,
+    ): String? {
+        get(key)?.let { return it }
+
+        val lockKey = "$key:lock"
+        val acquired =
+            try {
+                redis.value(String::class.java).setnx(lockKey, "1")
+            } catch (e: Exception) {
+                log.warnf("Redis SETNX failed for lock=%s: %s", lockKey, e.message)
+                false
+            }
+
+        if (acquired) {
+            try {
+                redis.key().expire(lockKey, LOCK_TTL_SECONDS)
+                val value = loader()
+                if (value != null) {
+                    set(key, value, ttlSeconds)
+                }
+                return value
+            } finally {
+                try {
+                    redis.key().del(lockKey)
+                } catch (e: Exception) {
+                    log.warnf("Redis DEL lock failed for key=%s: %s", lockKey, e.message)
+                }
+            }
+        }
+
+        // ロック取得失敗: 短時間待機後にキャッシュを再取得
+        for (i in 1..LOCK_MAX_RETRIES) {
+            try {
+                Thread.sleep(LOCK_RETRY_DELAY_MS)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                break
+            }
+            get(key)?.let { return it }
+        }
+        // フォールバック: ロック待機タイムアウト後は直接ロードする
+        return loader()
     }
 
     fun invalidate(vararg keys: String) {

--- a/services/product-service/src/main/kotlin/com/openpos/product/config/OrganizationIdInterceptor.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/config/OrganizationIdInterceptor.kt
@@ -2,6 +2,7 @@ package com.openpos.product.config
 
 import io.grpc.Context
 import io.grpc.Contexts
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
 import io.grpc.Metadata
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
@@ -104,7 +105,37 @@ class OrganizationIdInterceptor : ServerInterceptor {
                 .current()
                 .withValue(ORGANIZATION_ID_CTX_KEY, orgId)
                 .withValue(REQUEST_ID_CTX_KEY, requestId)
-        return Contexts.interceptCall(ctx, call, headers, next)
+        val delegate = Contexts.interceptCall(ctx, call, headers, next)
+        return MdcCleanupListener(delegate)
+    }
+
+    private class MdcCleanupListener<ReqT>(
+        delegate: ServerCall.Listener<ReqT>,
+    ) : SimpleForwardingServerCallListener<ReqT>(delegate) {
+        private fun cleanupMdc() {
+            org.jboss.logging.MDC
+                .remove("requestId")
+            org.jboss.logging.MDC
+                .remove("trace_id")
+            org.jboss.logging.MDC
+                .remove("organization_id")
+        }
+
+        override fun onComplete() {
+            try {
+                super.onComplete()
+            } finally {
+                cleanupMdc()
+            }
+        }
+
+        override fun onCancel() {
+            try {
+                super.onCancel()
+            } finally {
+                cleanupMdc()
+            }
+        }
     }
 
     private fun extractOrGenerateRequestId(headers: Metadata): String {

--- a/services/product-service/src/main/resources/application.properties
+++ b/services/product-service/src/main/resources/application.properties
@@ -36,6 +36,7 @@ rabbitmq-password=${RABBITMQ_PASS:openpos_dev}
 
 # Structured Logging
 quarkus.log.level=INFO
+%prod.quarkus.log.console.json=true
 
 # Health (Quarkus standard: /q/health/live, /q/health/ready)
 quarkus.smallrye-health.root-path=/q/health

--- a/services/product-service/src/test/kotlin/com/openpos/product/cache/ProductCacheServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/cache/ProductCacheServiceTest.kt
@@ -174,6 +174,126 @@ class ProductCacheServiceTest {
     }
 
     @Nested
+    inner class GetOrLoad {
+        @Test
+        fun `キャッシュヒット時はloaderを呼ばずにキャッシュ値を返す`() {
+            val key = "openpos:product-service:product:123"
+            whenever(valueCommands.get(key)).thenReturn("cached-value")
+
+            val result = cacheService.getOrLoad(key) { "loaded-value" }
+
+            assertEquals("cached-value", result)
+            verify(valueCommands, never()).setnx(any(), any())
+        }
+
+        @Test
+        fun `キャッシュミスでロック取得成功時はloaderを呼んでキャッシュに設定する`() {
+            val key = "openpos:product-service:product:456"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(true)
+
+            val result = cacheService.getOrLoad(key) { "loaded-value" }
+
+            assertEquals("loaded-value", result)
+            verify(valueCommands).setex(key, 3600L, "loaded-value")
+            verify(keyCommands).del(lockKey)
+        }
+
+        @Test
+        fun `loaderがnullを返す場合はキャッシュに設定せずnullを返す`() {
+            val key = "openpos:product-service:product:789"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(true)
+
+            val result = cacheService.getOrLoad(key) { null }
+
+            assertNull(result)
+            verify(valueCommands, never()).setex(any(), any(), any())
+            verify(keyCommands).del(lockKey)
+        }
+
+        @Test
+        fun `ロック取得失敗時はリトライ後にキャッシュ値を返す`() {
+            val key = "openpos:product-service:product:retry"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key))
+                .thenReturn(null)
+                .thenReturn("eventually-cached")
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(false)
+
+            val result = cacheService.getOrLoad(key) { "fallback" }
+
+            assertEquals("eventually-cached", result)
+        }
+
+        @Test
+        fun `SETNX例外時はフォールバックでloaderを呼ぶ`() {
+            val key = "openpos:product-service:product:err"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(any(), any())).thenThrow(RuntimeException("Redis down"))
+
+            val result = cacheService.getOrLoad(key) { "fallback-value" }
+
+            assertEquals("fallback-value", result)
+        }
+
+        @Test
+        fun `ロック解放失敗時でもloaderの結果は返される`() {
+            val key = "openpos:product-service:product:lock-del-fail"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(true)
+            whenever(keyCommands.del(lockKey)).thenThrow(RuntimeException("Redis down"))
+
+            val result = cacheService.getOrLoad(key) { "loaded-despite-error" }
+
+            assertEquals("loaded-despite-error", result)
+        }
+
+        @Test
+        fun `ロック取得失敗でリトライ全て失敗した場合はloaderを直接呼ぶ`() {
+            val key = "openpos:product-service:product:timeout"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(false)
+
+            val result = cacheService.getOrLoad(key) { "direct-load" }
+
+            assertEquals("direct-load", result)
+        }
+
+        @Test
+        fun `リトライ中にInterruptedException発生時はloaderを直接呼ぶ`() {
+            val key = "openpos:product-service:product:interrupt"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(false)
+
+            Thread.currentThread().interrupt()
+            val result = cacheService.getOrLoad(key) { "interrupted-fallback" }
+
+            assertEquals("interrupted-fallback", result)
+            // interrupted フラグがクリアされていることを確認
+            Thread.interrupted()
+        }
+
+        @Test
+        fun `カスタムTTLでgetOrLoadが動作する`() {
+            val key = "openpos:product-service:product:custom-ttl"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(true)
+
+            val result = cacheService.getOrLoad(key, ttlSeconds = 120L) { "loaded" }
+
+            assertEquals("loaded", result)
+            verify(valueCommands).setex(key, 120L, "loaded")
+        }
+    }
+
+    @Nested
     inner class KeyGeneration {
         @Test
         fun `productKeyはorgIdを含む正しい形式のキーを生成する`() {
@@ -243,6 +363,21 @@ class ProductCacheServiceTest {
 
             // Assert
             verify(keyCommands).del("openpos:product-service:org-1:category:cat-001")
+        }
+    }
+
+    @Nested
+    inner class InvalidateAllCategoryLists {
+        @Test
+        fun `全カテゴリリストキャッシュのパターン削除が呼ばれる`() {
+            val cursor: KeyScanCursor<String> = mock()
+            whenever(keyCommands.scan(any())).thenReturn(cursor)
+            whenever(cursor.hasNext()).thenReturn(true, false)
+            whenever(cursor.next()).thenReturn(setOf("openpos:product-service:org-1:category:list:root"))
+
+            cacheService.invalidateAllCategoryLists("org-1")
+
+            verify(keyCommands).del("openpos:product-service:org-1:category:list:root")
         }
     }
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/cache/StoreCacheService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/cache/StoreCacheService.kt
@@ -22,6 +22,9 @@ class StoreCacheService {
     companion object {
         const val TTL_SECONDS = 600L
         private const val PREFIX = "openpos:store-service"
+        private const val LOCK_TTL_SECONDS = 5L
+        private const val LOCK_RETRY_DELAY_MS = 50L
+        private const val LOCK_MAX_RETRIES = 10
     }
 
     // === Generic Operations ===
@@ -44,6 +47,58 @@ class StoreCacheService {
         } catch (e: Exception) {
             log.warnf("Redis SET failed for key=%s: %s", key, e.message)
         }
+    }
+
+    /**
+     * Cache stampede 防止付きの cache-aside 取得。
+     * キャッシュミス時に Redis SETNX でロックを取得し、1リクエストのみがキャッシュを再構築する。
+     * ロックを取得できなかったリクエストは短時間待機後にキャッシュを再取得する。
+     */
+    fun getOrLoad(
+        key: String,
+        ttlSeconds: Long = TTL_SECONDS,
+        loader: () -> String?,
+    ): String? {
+        get(key)?.let { return it }
+
+        val lockKey = "$key:lock"
+        val acquired =
+            try {
+                redis.value(String::class.java).setnx(lockKey, "1")
+            } catch (e: Exception) {
+                log.warnf("Redis SETNX failed for lock=%s: %s", lockKey, e.message)
+                false
+            }
+
+        if (acquired) {
+            try {
+                redis.key().expire(lockKey, LOCK_TTL_SECONDS)
+                val value = loader()
+                if (value != null) {
+                    set(key, value, ttlSeconds)
+                }
+                return value
+            } finally {
+                try {
+                    redis.key().del(lockKey)
+                } catch (e: Exception) {
+                    log.warnf("Redis DEL lock failed for key=%s: %s", lockKey, e.message)
+                }
+            }
+        }
+
+        // ロック取得失敗: 短時間待機後にキャッシュを再取得
+        for (i in 1..LOCK_MAX_RETRIES) {
+            try {
+                Thread.sleep(LOCK_RETRY_DELAY_MS)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                break
+            }
+            get(key)?.let { return it }
+        }
+        // フォールバック: ロック待機タイムアウト後は直接ロードする
+        return loader()
     }
 
     fun invalidate(vararg keys: String) {

--- a/services/store-service/src/main/kotlin/com/openpos/store/config/OrganizationIdInterceptor.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/config/OrganizationIdInterceptor.kt
@@ -2,6 +2,7 @@ package com.openpos.store.config
 
 import io.grpc.Context
 import io.grpc.Contexts
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
 import io.grpc.Metadata
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
@@ -55,7 +56,8 @@ class OrganizationIdInterceptor : ServerInterceptor {
         val methodName = call.methodDescriptor.bareMethodName
         if (methodName == "CreateOrganization") {
             val ctx = Context.current().withValue(REQUEST_ID_CTX_KEY, requestId)
-            return Contexts.interceptCall(ctx, call, headers, next)
+            val delegate = Contexts.interceptCall(ctx, call, headers, next)
+            return MdcCleanupListener(delegate)
         }
 
         val orgIdStr = headers.get(ORGANIZATION_ID_KEY)
@@ -104,7 +106,37 @@ class OrganizationIdInterceptor : ServerInterceptor {
                 .current()
                 .withValue(ORGANIZATION_ID_CTX_KEY, orgId)
                 .withValue(REQUEST_ID_CTX_KEY, requestId)
-        return Contexts.interceptCall(ctx, call, headers, next)
+        val delegate = Contexts.interceptCall(ctx, call, headers, next)
+        return MdcCleanupListener(delegate)
+    }
+
+    private class MdcCleanupListener<ReqT>(
+        delegate: ServerCall.Listener<ReqT>,
+    ) : SimpleForwardingServerCallListener<ReqT>(delegate) {
+        private fun cleanupMdc() {
+            org.jboss.logging.MDC
+                .remove("requestId")
+            org.jboss.logging.MDC
+                .remove("trace_id")
+            org.jboss.logging.MDC
+                .remove("organization_id")
+        }
+
+        override fun onComplete() {
+            try {
+                super.onComplete()
+            } finally {
+                cleanupMdc()
+            }
+        }
+
+        override fun onCancel() {
+            try {
+                super.onCancel()
+            } finally {
+                cleanupMdc()
+            }
+        }
     }
 
     private fun extractOrGenerateRequestId(headers: Metadata): String {

--- a/services/store-service/src/main/resources/application.properties
+++ b/services/store-service/src/main/resources/application.properties
@@ -36,6 +36,7 @@ rabbitmq-password=${RABBITMQ_PASS:openpos_dev}
 
 # Structured Logging
 quarkus.log.level=INFO
+%prod.quarkus.log.console.json=true
 
 # Health (Quarkus standard: /q/health/live, /q/health/ready)
 quarkus.smallrye-health.root-path=/q/health

--- a/services/store-service/src/test/kotlin/com/openpos/store/cache/StoreCacheServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/cache/StoreCacheServiceTest.kt
@@ -141,6 +141,111 @@ class StoreCacheServiceTest {
     }
 
     @Nested
+    inner class GetOrLoad {
+        @Test
+        fun `キャッシュヒット時はloaderを呼ばずにキャッシュ値を返す`() {
+            val key = "openpos:store-service:store:123"
+            whenever(valueCommands.get(key)).thenReturn("cached-value")
+
+            val result = cacheService.getOrLoad(key) { "loaded-value" }
+
+            assertEquals("cached-value", result)
+            verify(valueCommands, never()).setnx(any(), any())
+        }
+
+        @Test
+        fun `キャッシュミスでロック取得成功時はloaderを呼んでキャッシュに設定する`() {
+            val key = "openpos:store-service:store:456"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(true)
+
+            val result = cacheService.getOrLoad(key) { "loaded-value" }
+
+            assertEquals("loaded-value", result)
+            verify(valueCommands).setex(key, 600L, "loaded-value")
+            verify(keyCommands).del(lockKey)
+        }
+
+        @Test
+        fun `loaderがnullを返す場合はキャッシュに設定せずnullを返す`() {
+            val key = "openpos:store-service:store:789"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(true)
+
+            val result = cacheService.getOrLoad(key) { null }
+
+            assertNull(result)
+            verify(valueCommands, never()).setex(any(), any(), any())
+            verify(keyCommands).del(lockKey)
+        }
+
+        @Test
+        fun `ロック取得失敗時はリトライ後にキャッシュ値を返す`() {
+            val key = "openpos:store-service:store:retry"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key))
+                .thenReturn(null)
+                .thenReturn("eventually-cached")
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(false)
+
+            val result = cacheService.getOrLoad(key) { "fallback" }
+
+            assertEquals("eventually-cached", result)
+        }
+
+        @Test
+        fun `SETNX例外時はフォールバックでloaderを呼ぶ`() {
+            val key = "openpos:store-service:store:err"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(any(), any())).thenThrow(RuntimeException("Redis down"))
+
+            val result = cacheService.getOrLoad(key) { "fallback-value" }
+
+            assertEquals("fallback-value", result)
+        }
+
+        @Test
+        fun `ロック解放失敗時でもloaderの結果は返される`() {
+            val key = "openpos:store-service:store:lock-del-fail"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(true)
+            whenever(keyCommands.del(lockKey)).thenThrow(RuntimeException("Redis down"))
+
+            val result = cacheService.getOrLoad(key) { "loaded-despite-error" }
+
+            assertEquals("loaded-despite-error", result)
+        }
+
+        @Test
+        fun `ロック取得失敗でリトライ全て失敗した場合はloaderを直接呼ぶ`() {
+            val key = "openpos:store-service:store:timeout"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(false)
+
+            val result = cacheService.getOrLoad(key) { "direct-load" }
+
+            assertEquals("direct-load", result)
+        }
+
+        @Test
+        fun `カスタムTTLでgetOrLoadが動作する`() {
+            val key = "openpos:store-service:store:custom-ttl"
+            val lockKey = "$key:lock"
+            whenever(valueCommands.get(key)).thenReturn(null)
+            whenever(valueCommands.setnx(lockKey, "1")).thenReturn(true)
+
+            val result = cacheService.getOrLoad(key, ttlSeconds = 120L) { "loaded" }
+
+            assertEquals("loaded", result)
+            verify(valueCommands).setex(key, 120L, "loaded")
+        }
+    }
+
+    @Nested
     inner class KeyGeneration {
         @Test
         fun `organizationKeyはorgIdを含む正しい形式のキーを生成する`() {


### PR DESCRIPTION
## Summary

- **#993 Structured JSON logging**: Add `%prod.quarkus.log.console.json=true` to all 6 services and `quarkus-logging-json` dependency
- **#994 Analytics timezone**: Replace hardcoded `ZoneOffset.UTC` with configurable `openpos.analytics.timezone` (default: `Asia/Tokyo`) via `@ConfigProperty`
- **#995 Cache stampede prevention**: Add `getOrLoad()` with Redis SETNX distributed lock to `ProductCacheService` and `StoreCacheService`
- **#996 Remove services/com/**: Directory already removed; added `services/com/` to `.gitignore` to prevent reappearance
- **#997 MDC cleanup**: Wrap `ServerCall.Listener` with `MdcCleanupListener` in all 5 `OrganizationIdInterceptor` implementations to remove MDC keys on `onComplete`/`onCancel`
- **#998 toDouble() removal**: Use `BigDecimal` for ratio calculations in `AnalyticsQueryService`; added explanatory comment for Micrometer `Counter.increment(double)` in `TransactionService`

Closes #993, Closes #994, Closes #995, Closes #996, Closes #997, Closes #998

## Test plan

- [x] `./gradlew --parallel build` passes (all 6 services compile + tests + coverage >= 95%)
- [ ] CI passes all checks