### PR TITLE
feat: implement Reservation, Accounting, Plan resources with RBAC

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AccountingResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AccountingResource.kt
@@ -1,20 +1,26 @@
 package com.openpos.gateway.resource
 
+import com.openpos.gateway.config.TenantContext
 import io.smallrye.common.annotation.Blocking
-import jakarta.annotation.security.DenyAll
+import jakarta.inject.Inject
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 /**
  * 会計ソフト連携 REST リソース（#195 freee / MFクラウド）。
- * 未実装: 外部 API 連携が未整備のため全エンドポイントが 501 を返す。
+ * gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * RBAC: OWNER のみアクセス可能。
  */
 @Path("/api/accounting")
 @Blocking
-@DenyAll
+@Timeout(30000)
 class AccountingResource {
+    @Inject
+    lateinit var tenantContext: TenantContext
+
     private fun notImplemented(): Response =
         Response
             .status(501)
@@ -25,12 +31,18 @@ class AccountingResource {
     @Path("/export/daily")
     fun exportDailySales(
         @QueryParam("date") date: String,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER")
+        return notImplemented()
+    }
 
     @GET
     @Path("/export/transactions")
     fun exportTransactions(
         @QueryParam("startDate") startDate: String,
         @QueryParam("endDate") endDate: String,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER")
+        return notImplemented()
+    }
 }

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/PlanResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/PlanResource.kt
@@ -1,20 +1,27 @@
 package com.openpos.gateway.resource
 
+import com.openpos.gateway.config.TenantContext
 import io.smallrye.common.annotation.Blocking
-import jakarta.annotation.security.DenyAll
+import jakarta.inject.Inject
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 /**
  * プラン・サブスクリプション管理 REST リソース。
- * 未実装: gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * RBAC: OWNER のみアクセス可能。
  */
 @Path("/api/plans")
 @Blocking
-@DenyAll
+@Timeout(30000)
 class PlanResource {
+    @Inject
+    lateinit var tenantContext: TenantContext
+
     private fun notImplemented(): Response =
         Response
             .status(501)
@@ -22,12 +29,36 @@ class PlanResource {
             .build()
 
     @GET
-    fun listPlans(): Response = notImplemented()
+    fun listPlans(): Response {
+        tenantContext.requireRole("OWNER")
+        return notImplemented()
+    }
+
+    @GET
+    @Path("/current")
+    fun getCurrentPlan(): Response {
+        tenantContext.requireRole("OWNER")
+        return notImplemented()
+    }
+
+    @PUT
+    @Path("/change")
+    fun changePlan(body: ChangePlanBody): Response {
+        tenantContext.requireRole("OWNER")
+        return notImplemented()
+    }
 
     @POST
     @Path("/subscribe")
-    fun subscribe(body: SubscribeBody): Response = notImplemented()
+    fun subscribe(body: SubscribeBody): Response {
+        tenantContext.requireRole("OWNER")
+        return notImplemented()
+    }
 }
+
+data class ChangePlanBody(
+    val planId: String,
+)
 
 data class SubscribeBody(
     val planId: String,

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ReservationResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ReservationResource.kt
@@ -1,7 +1,8 @@
 package com.openpos.gateway.resource
 
+import com.openpos.gateway.config.TenantContext
 import io.smallrye.common.annotation.Blocking
-import jakarta.annotation.security.DenyAll
+import jakarta.inject.Inject
 import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
@@ -10,15 +11,20 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.faulttolerance.Timeout
 
 /**
  * 予約注文 REST リソース（#193）。
- * 未実装: gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * RBAC: 予約一覧は全ロール、作成/履行/キャンセルは OWNER/MANAGER のみ。
  */
 @Path("/api/reservations")
 @Blocking
-@DenyAll
+@Timeout(30000)
 class ReservationResource {
+    @Inject
+    lateinit var tenantContext: TenantContext
+
     private fun notImplemented(): Response =
         Response
             .status(501)
@@ -31,22 +37,34 @@ class ReservationResource {
         @QueryParam("status") status: String?,
         @QueryParam("page") @DefaultValue("1") page: Int,
         @QueryParam("pageSize") @DefaultValue("20") pageSize: Int,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER", "CASHIER")
+        return notImplemented()
+    }
 
     @POST
-    fun create(body: CreateReservationBody): Response = notImplemented()
+    fun create(body: CreateReservationBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplemented()
+    }
 
     @PUT
     @Path("/{id}/fulfill")
     fun fulfill(
         @PathParam("id") id: String,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplemented()
+    }
 
     @PUT
     @Path("/{id}/cancel")
     fun cancel(
         @PathParam("id") id: String,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplemented()
+    }
 }
 
 data class CreateReservationBody(

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/AccountingResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/AccountingResourceTest.kt
@@ -1,0 +1,94 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.ForbiddenException
+import com.openpos.gateway.config.TenantContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class AccountingResourceTest {
+    private fun createResource(role: String? = null): AccountingResource {
+        val ctx = TenantContext()
+        ctx.organizationId = UUID.randomUUID()
+        ctx.staffRole = role
+        return AccountingResource().also { r ->
+            ProductResourceTest.setField(r, "tenantContext", ctx)
+        }
+    }
+
+    @Nested
+    inner class ExportDailySales {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.exportDailySales("2026-03-27")
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `MANAGERはアクセス不可`() {
+            // Arrange
+            val resource = createResource("MANAGER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.exportDailySales("2026-03-27")
+            }
+        }
+
+        @Test
+        fun `CASHIERはアクセス不可`() {
+            // Arrange
+            val resource = createResource("CASHIER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.exportDailySales("2026-03-27")
+            }
+        }
+    }
+
+    @Nested
+    inner class ExportTransactions {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.exportTransactions("2026-03-01", "2026-03-27")
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `MANAGERはアクセス不可`() {
+            // Arrange
+            val resource = createResource("MANAGER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.exportTransactions("2026-03-01", "2026-03-27")
+            }
+        }
+
+        @Test
+        fun `CASHIERはアクセス不可`() {
+            // Arrange
+            val resource = createResource("CASHIER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.exportTransactions("2026-03-01", "2026-03-27")
+            }
+        }
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/PlanResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/PlanResourceTest.kt
@@ -1,0 +1,146 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.ForbiddenException
+import com.openpos.gateway.config.TenantContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class PlanResourceTest {
+    private fun createResource(role: String? = null): PlanResource {
+        val ctx = TenantContext()
+        ctx.organizationId = UUID.randomUUID()
+        ctx.staffRole = role
+        return PlanResource().also { r ->
+            ProductResourceTest.setField(r, "tenantContext", ctx)
+        }
+    }
+
+    @Nested
+    inner class ListPlans {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.listPlans()
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `MANAGERはアクセス不可`() {
+            // Arrange
+            val resource = createResource("MANAGER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.listPlans()
+            }
+        }
+
+        @Test
+        fun `CASHIERはアクセス不可`() {
+            // Arrange
+            val resource = createResource("CASHIER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.listPlans()
+            }
+        }
+    }
+
+    @Nested
+    inner class GetCurrentPlan {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.getCurrentPlan()
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `MANAGERはアクセス不可`() {
+            // Arrange
+            val resource = createResource("MANAGER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.getCurrentPlan()
+            }
+        }
+    }
+
+    @Nested
+    inner class ChangePlan {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.changePlan(ChangePlanBody(planId = "plan-pro"))
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `MANAGERはプラン変更不可`() {
+            // Arrange
+            val resource = createResource("MANAGER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.changePlan(ChangePlanBody(planId = "plan-pro"))
+            }
+        }
+
+        @Test
+        fun `CASHIERはプラン変更不可`() {
+            // Arrange
+            val resource = createResource("CASHIER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.changePlan(ChangePlanBody(planId = "plan-pro"))
+            }
+        }
+    }
+
+    @Nested
+    inner class Subscribe {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.subscribe(SubscribeBody(planId = "plan-starter"))
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `MANAGERはサブスクライブ不可`() {
+            // Arrange
+            val resource = createResource("MANAGER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.subscribe(SubscribeBody(planId = "plan-starter"))
+            }
+        }
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/ReservationResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/ReservationResourceTest.kt
@@ -1,0 +1,166 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.ForbiddenException
+import com.openpos.gateway.config.TenantContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class ReservationResourceTest {
+    private fun createResource(role: String? = null): ReservationResource {
+        val ctx = TenantContext()
+        ctx.organizationId = UUID.randomUUID()
+        ctx.staffRole = role
+        return ReservationResource().also { r ->
+            ProductResourceTest.setField(r, "tenantContext", ctx)
+        }
+    }
+
+    @Nested
+    inner class List {
+        @Test
+        fun `全ロールで501を返す`() {
+            // Arrange
+            val resource = createResource("CASHIER")
+
+            // Act
+            val response = resource.list(storeId = null, status = null, page = 1, pageSize = 20)
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.list(storeId = "store-1", status = "PENDING", page = 1, pageSize = 10)
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+    }
+
+    @Nested
+    inner class Create {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+            val body =
+                CreateReservationBody(
+                    storeId = "store-1",
+                    customerName = "テスト太郎",
+                    reservedUntil = "2026-04-01T10:00:00Z",
+                )
+
+            // Act
+            val response = resource.create(body)
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `MANAGERで501を返す`() {
+            // Arrange
+            val resource = createResource("MANAGER")
+            val body =
+                CreateReservationBody(
+                    storeId = "store-1",
+                    reservedUntil = "2026-04-01T10:00:00Z",
+                    items = listOf(ReservationItemBody(productId = "prod-1", quantity = 2)),
+                )
+
+            // Act
+            val response = resource.create(body)
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `CASHIERは作成不可`() {
+            // Arrange
+            val resource = createResource("CASHIER")
+            val body =
+                CreateReservationBody(
+                    storeId = "store-1",
+                    reservedUntil = "2026-04-01T10:00:00Z",
+                )
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.create(body)
+            }
+        }
+    }
+
+    @Nested
+    inner class Fulfill {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.fulfill("reservation-1")
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `CASHIERは履行不可`() {
+            // Arrange
+            val resource = createResource("CASHIER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.fulfill("reservation-1")
+            }
+        }
+    }
+
+    @Nested
+    inner class Cancel {
+        @Test
+        fun `OWNERで501を返す`() {
+            // Arrange
+            val resource = createResource("OWNER")
+
+            // Act
+            val response = resource.cancel("reservation-1")
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `MANAGERで501を返す`() {
+            // Arrange
+            val resource = createResource("MANAGER")
+
+            // Act
+            val response = resource.cancel("reservation-1")
+
+            // Assert
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `CASHIERはキャンセル不可`() {
+            // Arrange
+            val resource = createResource("CASHIER")
+
+            // Act & Assert
+            assertThrows<ForbiddenException> {
+                resource.cancel("reservation-1")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **ReservationResource**: Remove `@DenyAll`, add RBAC (list: all roles, create/fulfill/cancel: OWNER/MANAGER), keep 501 until gRPC backend is ready
- **AccountingResource**: Remove `@DenyAll`, add OWNER-only RBAC for daily sales export and transaction export endpoints
- **PlanResource**: Remove `@DenyAll`, add OWNER-only RBAC, add `GET /current` and `PUT /change` endpoints per SaaS architecture spec

All endpoints retain 501 status (gRPC backends not yet implemented) but are now accessible with proper role-based access control instead of being completely blocked by `@DenyAll`.

## Test plan

- [x] ReservationResourceTest: 9 tests covering RBAC for all 4 endpoints (list/create/fulfill/cancel)
- [x] AccountingResourceTest: 6 tests covering OWNER-only access for both export endpoints
- [x] PlanResourceTest: 10 tests covering OWNER-only access for all 4 endpoints (list/current/change/subscribe)
- [x] `./gradlew :services:api-gateway:test` passes