### PR TITLE
feat: implement DiscountReason, StockTransfer, FavoriteProduct resources

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/DiscountReasonResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/DiscountReasonResource.kt
@@ -1,40 +1,56 @@
 package com.openpos.gateway.resource
 
+import com.openpos.gateway.config.TenantContext
 import io.smallrye.common.annotation.Blocking
-import jakarta.annotation.security.DenyAll
+import jakarta.inject.Inject
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.PUT
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
 
 /**
  * 値引き理由コード REST リソース（#216）。
- * 未実装: gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * proto 定義が追加され次第、gRPC 呼び出しに置き換える。
  */
 @Path("/api/discount-reasons")
 @Blocking
-@DenyAll
+@Tag(name = "Discount Reasons", description = "値引き理由コード管理API")
 class DiscountReasonResource {
-    private fun notImplemented(): Response =
+    @Inject
+    lateinit var tenantContext: TenantContext
+
+    private fun notImplementedResponse(): Response =
         Response
             .status(501)
             .entity(mapOf("error" to "NOT_IMPLEMENTED", "message" to "Discount reason API is not yet implemented"))
             .build()
 
     @GET
-    fun list(): Response = notImplemented()
+    @Operation(summary = "値引き理由コード一覧を取得する")
+    fun list(): Response = notImplementedResponse()
 
     @POST
-    fun create(body: CreateDiscountReasonBody): Response = notImplemented()
+    @Operation(summary = "値引き理由コードを作成する")
+    fun create(body: CreateDiscountReasonBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplementedResponse()
+    }
 
     @PUT
     @Path("/{id}")
+    @Operation(summary = "値引き理由コードを更新する")
     fun update(
         @PathParam("id") id: String,
         body: UpdateDiscountReasonBody,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplementedResponse()
+    }
 }
 
 data class CreateDiscountReasonBody(

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/FavoriteProductResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/FavoriteProductResource.kt
@@ -1,47 +1,66 @@
 package com.openpos.gateway.resource
 
+import com.openpos.gateway.config.TenantContext
 import io.smallrye.common.annotation.Blocking
-import jakarta.annotation.security.DenyAll
+import jakarta.inject.Inject
 import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
 
 /**
  * お気に入り商品 REST リソース（#188）。
- * 未実装: gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * proto 定義が追加され次第、gRPC 呼び出しに置き換える。
  */
 @Path("/api/staff/{staffId}/favorites")
 @Blocking
-@DenyAll
+@Tag(name = "Favorite Products", description = "お気に入り商品管理API")
 class FavoriteProductResource {
-    private fun notImplemented(): Response =
+    @Inject
+    lateinit var tenantContext: TenantContext
+
+    private fun notImplementedResponse(): Response =
         Response
             .status(501)
             .entity(mapOf("error" to "NOT_IMPLEMENTED", "message" to "Favorite product API is not yet implemented"))
             .build()
 
     @GET
+    @Operation(summary = "スタッフのお気に入り商品一覧を取得する")
     fun list(
         @PathParam("staffId") staffId: String,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER", "STAFF")
+        return notImplementedResponse()
+    }
 
     @POST
-    fun toggle(
+    @Operation(summary = "お気に入り商品を追加する")
+    fun add(
         @PathParam("staffId") staffId: String,
-        body: ToggleFavoriteBody,
-    ): Response = notImplemented()
+        body: AddFavoriteBody,
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER", "STAFF")
+        return notImplementedResponse()
+    }
 
     @DELETE
     @Path("/{productId}")
+    @Operation(summary = "お気に入り商品を削除する")
     fun remove(
         @PathParam("staffId") staffId: String,
         @PathParam("productId") productId: String,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER", "STAFF")
+        return notImplementedResponse()
+    }
 }
 
-data class ToggleFavoriteBody(
+data class AddFavoriteBody(
     val productId: String,
 )

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StockTransferResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StockTransferResource.kt
@@ -1,7 +1,8 @@
 package com.openpos.gateway.resource
 
+import com.openpos.gateway.config.TenantContext
 import io.smallrye.common.annotation.Blocking
-import jakarta.annotation.security.DenyAll
+import jakarta.inject.Inject
 import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
@@ -10,34 +11,79 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
 
 /**
  * 在庫移動 REST リソース (#145)。
- * 未実装: gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * gRPC バックエンドが未整備のため全エンドポイントが 501 を返す。
+ * proto 定義が追加され次第、gRPC 呼び出しに置き換える。
  */
 @Path("/api/stock-transfers")
 @Blocking
-@DenyAll
+@Tag(name = "Stock Transfers", description = "在庫移動管理API")
 class StockTransferResource {
-    private fun notImplemented(): Response =
+    @Inject
+    lateinit var tenantContext: TenantContext
+
+    private fun notImplementedResponse(): Response =
         Response
             .status(501)
             .entity(mapOf("error" to "NOT_IMPLEMENTED", "message" to "Stock transfer API is not yet implemented"))
             .build()
 
     @GET
+    @Operation(summary = "在庫移動一覧を取得する")
     fun list(
         @QueryParam("page") @DefaultValue("1") page: Int,
         @QueryParam("pageSize") @DefaultValue("20") pageSize: Int,
-    ): Response = notImplemented()
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplementedResponse()
+    }
 
     @POST
-    fun create(body: Map<String, Any?>): Response = notImplemented()
+    @Operation(summary = "在庫移動を作成する")
+    fun create(body: CreateStockTransferBody): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplementedResponse()
+    }
+
+    @GET
+    @Path("/{id}")
+    @Operation(summary = "在庫移動を取得する")
+    fun get(
+        @PathParam("id") id: String,
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplementedResponse()
+    }
 
     @PUT
     @Path("/{id}/status")
+    @Operation(summary = "在庫移動のステータスを更新する")
     fun updateStatus(
         @PathParam("id") id: String,
-        body: Map<String, Any?>,
-    ): Response = notImplemented()
+        body: UpdateStockTransferStatusBody,
+    ): Response {
+        tenantContext.requireRole("OWNER", "MANAGER")
+        return notImplementedResponse()
+    }
 }
+
+data class CreateStockTransferBody(
+    val fromStoreId: String,
+    val toStoreId: String,
+    val items: List<StockTransferItemBody>,
+    val note: String? = null,
+)
+
+data class StockTransferItemBody(
+    val productId: String,
+    val quantity: Int,
+)
+
+data class UpdateStockTransferStatusBody(
+    val status: String,
+    val note: String? = null,
+)

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/DiscountReasonResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/DiscountReasonResourceTest.kt
@@ -1,0 +1,62 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.ForbiddenException
+import com.openpos.gateway.config.TenantContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DiscountReasonResourceTest {
+    private val tenantContext = TenantContext()
+    private val resource =
+        DiscountReasonResource().also { r ->
+            ProductResourceTest.setField(r, "tenantContext", tenantContext)
+        }
+
+    @Nested
+    inner class List {
+        @Test
+        fun `一覧取得で501を返す`() {
+            val response = resource.list()
+            assertEquals(501, response.status)
+            @Suppress("UNCHECKED_CAST")
+            val entity = response.entity as Map<String, Any>
+            assertEquals("NOT_IMPLEMENTED", entity["error"])
+        }
+    }
+
+    @Nested
+    inner class Create {
+        @Test
+        fun `作成で501を返す`() {
+            val body = CreateDiscountReasonBody(code = "EMPLOYEE", description = "従業員割引")
+            val response = resource.create(body)
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `STAFF権限で作成するとForbiddenException`() {
+            tenantContext.staffRole = "STAFF"
+            val body = CreateDiscountReasonBody(code = "EMPLOYEE", description = "従業員割引")
+            assertThrows<ForbiddenException> { resource.create(body) }
+        }
+    }
+
+    @Nested
+    inner class Update {
+        @Test
+        fun `更新で501を返す`() {
+            val body = UpdateDiscountReasonBody(description = "更新された説明")
+            val response = resource.update("some-id", body)
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `STAFF権限で更新するとForbiddenException`() {
+            tenantContext.staffRole = "STAFF"
+            val body = UpdateDiscountReasonBody(description = "更新された説明")
+            assertThrows<ForbiddenException> { resource.update("some-id", body) }
+        }
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/FavoriteProductResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/FavoriteProductResourceTest.kt
@@ -1,0 +1,45 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.TenantContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FavoriteProductResourceTest {
+    private val tenantContext = TenantContext()
+    private val resource =
+        FavoriteProductResource().also { r ->
+            ProductResourceTest.setField(r, "tenantContext", tenantContext)
+        }
+
+    @Nested
+    inner class List {
+        @Test
+        fun `お気に入り一覧取得で501を返す`() {
+            val response = resource.list("staff-1")
+            assertEquals(501, response.status)
+            @Suppress("UNCHECKED_CAST")
+            val entity = response.entity as Map<String, Any>
+            assertEquals("NOT_IMPLEMENTED", entity["error"])
+        }
+    }
+
+    @Nested
+    inner class Add {
+        @Test
+        fun `お気に入り追加で501を返す`() {
+            val body = AddFavoriteBody(productId = "prod-1")
+            val response = resource.add("staff-1", body)
+            assertEquals(501, response.status)
+        }
+    }
+
+    @Nested
+    inner class Remove {
+        @Test
+        fun `お気に入り削除で501を返す`() {
+            val response = resource.remove("staff-1", "prod-1")
+            assertEquals(501, response.status)
+        }
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/StockTransferResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/StockTransferResourceTest.kt
@@ -1,0 +1,91 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.ForbiddenException
+import com.openpos.gateway.config.TenantContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class StockTransferResourceTest {
+    private val tenantContext = TenantContext()
+    private val resource =
+        StockTransferResource().also { r ->
+            ProductResourceTest.setField(r, "tenantContext", tenantContext)
+        }
+
+    @Nested
+    inner class List {
+        @Test
+        fun `一覧取得で501を返す`() {
+            val response = resource.list(page = 1, pageSize = 20)
+            assertEquals(501, response.status)
+            @Suppress("UNCHECKED_CAST")
+            val entity = response.entity as Map<String, Any>
+            assertEquals("NOT_IMPLEMENTED", entity["error"])
+        }
+
+        @Test
+        fun `STAFF権限で一覧取得するとForbiddenException`() {
+            tenantContext.staffRole = "STAFF"
+            assertThrows<ForbiddenException> { resource.list(page = 1, pageSize = 20) }
+        }
+    }
+
+    @Nested
+    inner class Create {
+        @Test
+        fun `作成で501を返す`() {
+            val body = CreateStockTransferBody(
+                fromStoreId = "store-1",
+                toStoreId = "store-2",
+                items = listOf(StockTransferItemBody(productId = "prod-1", quantity = 10)),
+            )
+            val response = resource.create(body)
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `STAFF権限で作成するとForbiddenException`() {
+            tenantContext.staffRole = "STAFF"
+            val body = CreateStockTransferBody(
+                fromStoreId = "store-1",
+                toStoreId = "store-2",
+                items = listOf(StockTransferItemBody(productId = "prod-1", quantity = 10)),
+            )
+            assertThrows<ForbiddenException> { resource.create(body) }
+        }
+    }
+
+    @Nested
+    inner class Get {
+        @Test
+        fun `取得で501を返す`() {
+            val response = resource.get("transfer-id")
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `STAFF権限で取得するとForbiddenException`() {
+            tenantContext.staffRole = "STAFF"
+            assertThrows<ForbiddenException> { resource.get("transfer-id") }
+        }
+    }
+
+    @Nested
+    inner class UpdateStatus {
+        @Test
+        fun `ステータス更新で501を返す`() {
+            val body = UpdateStockTransferStatusBody(status = "SHIPPED")
+            val response = resource.updateStatus("transfer-id", body)
+            assertEquals(501, response.status)
+        }
+
+        @Test
+        fun `STAFF権限でステータス更新するとForbiddenException`() {
+            tenantContext.staffRole = "STAFF"
+            val body = UpdateStockTransferStatusBody(status = "SHIPPED")
+            assertThrows<ForbiddenException> { resource.updateStatus("transfer-id", body) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **DiscountReasonResource**: Remove `@DenyAll`, add RBAC (OWNER/MANAGER for create/update, list is open), inject TenantContext
- **StockTransferResource**: Remove `@DenyAll`, add RBAC (OWNER/MANAGER only), add typed body classes (`CreateStockTransferBody`, `UpdateStockTransferStatusBody`), add GET `/{id}` endpoint
- **FavoriteProductResource**: Remove `@DenyAll`, add RBAC (all authenticated staff), rename `toggle` to `add`, add typed `AddFavoriteBody`

All endpoints still return 501 as gRPC proto definitions do not exist yet. The resources now have proper structure with TenantContext injection and role checks ready for when backends are implemented.

## Test plan
- [x] Unit tests for DiscountReasonResource (501 responses, RBAC ForbiddenException)
- [x] Unit tests for StockTransferResource (501 responses, RBAC ForbiddenException for all 4 endpoints)
- [x] Unit tests for FavoriteProductResource (501 responses for list/add/remove)
- [x] `./gradlew :services:api-gateway:test` passes