### PR TITLE
fix(security): enforce explicit prod CORS/auth configuration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -196,6 +196,23 @@ jobs:
           kubectl get nodes -o wide
           kubectl get ns openpos || kubectl create ns openpos
 
+      - name: Validate required secrets exist
+        run: |
+          echo "Validating required secrets in openpos-secrets..."
+          REQUIRED_KEYS=(CORS_ALLOWED_ORIGINS HYDRA_JWKS_URL HYDRA_ISSUER OPENPOS_SESSION_JWT_SECRET REDIS_URL DB_URL)
+          MISSING=()
+          for KEY in "${REQUIRED_KEYS[@]}"; do
+            if ! kubectl get secret openpos-secrets -n openpos -o jsonpath="{.data.${KEY}}" 2>/dev/null | base64 -d | grep -q .; then
+              MISSING+=("$KEY")
+            fi
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::Missing or empty required secrets: ${MISSING[*]}"
+            echo "Ensure these are configured in GCP Secret Manager and ExternalSecret has synced."
+            exit 1
+          fi
+          echo "All required secrets validated."
+
       - name: Apply ExternalSecret for GCP Secret Manager
         run: |
           kubectl apply -f infra/k8s/external-secret.yaml

--- a/infra/k8s/api-gateway.yaml
+++ b/infra/k8s/api-gateway.yaml
@@ -55,6 +55,11 @@ spec:
                 secretKeyRef:
                   name: openpos-secrets
                   key: OPENPOS_SESSION_JWT_SECRET
+            - name: CORS_ALLOWED_ORIGINS
+              valueFrom:
+                secretKeyRef:
+                  name: openpos-secrets
+                  key: CORS_ALLOWED_ORIGINS
             - name: PRODUCT_SERVICE_HOST
               value: product-service
             - name: PRODUCT_SERVICE_PORT

--- a/infra/k8s/configmap-prod.yaml.example
+++ b/infra/k8s/configmap-prod.yaml.example
@@ -23,6 +23,8 @@ data:
   QUARKUS_HTTP_PORT: '8080'
   QUARKUS_LOG_LEVEL: 'INFO'
   QUARKUS_LOG_CONSOLE_JSON: 'true'
+  # CORS — also stored in ExternalSecret for env var injection
+  # CORS_ALLOWED_ORIGINS: managed via GCP Secret Manager (see external-secret.yaml)
   # gRPC service endpoints
   PRODUCT_SERVICE_HOST: 'product-service'
   PRODUCT_SERVICE_PORT: '9000'

--- a/infra/k8s/external-secret.yaml
+++ b/infra/k8s/external-secret.yaml
@@ -73,3 +73,8 @@ spec:
     - secretKey: OPENPOS_SESSION_JWT_SECRET
       remoteRef:
         key: openpos-session-jwt-secret
+
+    # --- CORS ---
+    - secretKey: CORS_ALLOWED_ORIGINS
+      remoteRef:
+        key: openpos-cors-allowed-origins

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -20,11 +20,17 @@ quarkus.http.cors.origins=http://localhost:5173,http://localhost:5174
 quarkus.http.cors.methods=GET,POST,PUT,DELETE,PATCH,OPTIONS
 quarkus.http.cors.headers=accept,authorization,content-type,x-requested-with,x-organization-id
 quarkus.http.cors.exposed-headers=location
-%prod.quarkus.http.cors.origins=${CORS_ALLOWED_ORIGINS:https://pos.example.com}
+# Production CORS: no default — deployment MUST set CORS_ALLOWED_ORIGINS.
+# Quarkus will fail to start if the env var is missing, preventing misconfigured deploys.
+%prod.quarkus.http.cors.origins=${CORS_ALLOWED_ORIGINS}
 
 # JWT (ORY Hydra)
+# Dev/test defaults point to local Docker Compose Hydra instance.
+# Production overrides below remove defaults to enforce explicit configuration.
 mp.jwt.verify.publickey.location=${HYDRA_JWKS_URL:http://localhost:14444/.well-known/jwks.json}
 mp.jwt.verify.issuer=${HYDRA_ISSUER:http://localhost:14444/}
+%prod.mp.jwt.verify.publickey.location=${HYDRA_JWKS_URL}
+%prod.mp.jwt.verify.issuer=${HYDRA_ISSUER}
 
 # Session JWT signing key (Base64-encoded HMAC-SHA256 secret, min 256 bits)
 # Production: inject via GCP Secret Manager → OPENPOS_SESSION_JWT_SECRET env var


### PR DESCRIPTION
## Summary
- `application.properties` の prod プロファイルから `CORS_ALLOWED_ORIGINS`, `HYDRA_JWKS_URL`, `HYDRA_ISSUER` のデフォルト値を除去
- 環境変数が未設定の場合、Quarkus が起動時に fail-fast する（プレースホルダー値での本番運用を防止）
- K8s `api-gateway.yaml` に `CORS_ALLOWED_ORIGINS` env を追加（ExternalSecret 経由）
- `external-secret.yaml` に `openpos-cors-allowed-origins` を追加
- CD pipeline に `Validate required secrets exist` ステップを追加（デプロイ前に必須シークレットの存在を検証）

## Security Impact
- **Before**: prod デフォルトが `https://pos.example.com`（プレースホルダー）や `http://localhost:14444/`（ローカル）で、設定漏れに気づかない
- **After**: 未設定なら起動失敗 + CD パイプラインでもデプロイ前にブロック

## Deployment Notes
本番デプロイ前に GCP Secret Manager に以下を追加する必要あり:
```bash
gcloud secrets create openpos-cors-allowed-origins \
  --data-file=- <<< "https://your-actual-domain.com"
```

## Test plan
- [x] `./gradlew :services:api-gateway:test` — 全テスト pass（dev/test プロファイルは従来通り動作）
- [x] prod プロファイルで `CORS_ALLOWED_ORIGINS` 未設定時に Quarkus が起動失敗することを設計上確認