### PR TITLE
fix(ci): add Docker Hub logout before E2E to fix auth errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,8 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package.json') }}
+      - name: Clear Docker Hub credentials
+        run: docker logout docker.io 2>/dev/null || true
       - name: Install Playwright & Start demo stack in parallel
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
CI E2E tests were consistently failing with Docker Hub `unauthorized: incorrect username or password` errors when pulling base images (postgres:17-alpine, redis, etc.). Adds an explicit `docker logout docker.io` step before starting the demo stack to clear stale credentials on the runner.

## Root Cause
GitHub Actions runners may retain Docker credentials from previous workflow steps (e.g., GHCR login) that interfere with Docker Hub anonymous pulls.

## Test plan
- [ ] E2E Test (Playwright) passes after this fix
- Fixes CI for PRs #1004, #1005, #1006