### PR TITLE
feat: implement ListCoupons RPC in product-service

### DIFF
--- a/services/product-service/src/main/kotlin/com/openpos/product/grpc/ProductGrpcService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/grpc/ProductGrpcService.kt
@@ -46,6 +46,8 @@ import openpos.product.v1.GetProductRequest
 import openpos.product.v1.GetProductResponse
 import openpos.product.v1.ListCategoriesRequest
 import openpos.product.v1.ListCategoriesResponse
+import openpos.product.v1.ListCouponsRequest
+import openpos.product.v1.ListCouponsResponse
 import openpos.product.v1.ListDiscountsRequest
 import openpos.product.v1.ListDiscountsResponse
 import openpos.product.v1.ListProductsRequest
@@ -476,6 +478,18 @@ class ProductGrpcService : ProductServiceGrpc.ProductServiceImplBase() {
         result.discount?.let { builder.setDiscount(it.toProto()) }
         result.reason?.let { builder.setReason(it) }
         responseObserver.onNext(builder.build())
+        responseObserver.onCompleted()
+    }
+
+    override fun listCoupons(
+        request: ListCouponsRequest,
+        responseObserver: io.grpc.stub.StreamObserver<ListCouponsResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val coupons = couponService.list(request.activeOnly)
+        responseObserver.onNext(
+            ListCouponsResponse.newBuilder().addAllCoupons(coupons.map { it.toProto() }).build(),
+        )
         responseObserver.onCompleted()
     }
 

--- a/services/product-service/src/main/kotlin/com/openpos/product/repository/CouponRepository.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/repository/CouponRepository.kt
@@ -4,6 +4,7 @@ import com.openpos.product.entity.CouponEntity
 import io.quarkus.hibernate.orm.panache.kotlin.PanacheRepositoryBase
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.persistence.LockModeType
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -21,4 +22,18 @@ class CouponRepository : PanacheRepositoryBase<CouponEntity, UUID> {
      * 並行利用を防止するために redeem() で使用。
      */
     fun findByCodeForUpdate(code: String): CouponEntity? = find("code = ?1", code).withLock(LockModeType.PESSIMISTIC_WRITE).firstResult()
+
+    /**
+     * 有効かつ期間内のクーポンのみ取得する。
+     */
+    fun findActiveAndValid(now: Instant): List<CouponEntity> =
+        list(
+            "isActive = true AND (validFrom IS NULL OR validFrom <= ?1) AND (validUntil IS NULL OR validUntil >= ?1) ORDER BY code ASC",
+            now,
+        )
+
+    /**
+     * 全クーポンを取得する。
+     */
+    fun findAllOrdered(): List<CouponEntity> = list("ORDER BY code ASC")
 }

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/CouponService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/CouponService.kt
@@ -78,6 +78,19 @@ class CouponService {
     }
 
     /**
+     * クーポン一覧を取得する。
+     * activeOnly が true の場合は有効かつ期間内のもののみ返す。
+     */
+    fun list(activeOnly: Boolean): List<CouponEntity> {
+        tenantFilterService.enableFilter()
+        return if (activeOnly) {
+            couponRepository.findActiveAndValid(Instant.now())
+        } else {
+            couponRepository.findAllOrdered()
+        }
+    }
+
+    /**
      * クーポンコードで検索する。
      */
     fun findByCode(code: String): CouponEntity? {

--- a/services/product-service/src/test/kotlin/com/openpos/product/grpc/ProductGrpcServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/grpc/ProductGrpcServiceTest.kt
@@ -16,6 +16,7 @@ import com.openpos.product.service.TaxRateService
 import io.grpc.stub.StreamObserver
 import openpos.product.v1.CreateProductRequest
 import openpos.product.v1.DiscountType
+import openpos.product.v1.ListCouponsRequest
 import openpos.product.v1.UpdateDiscountRequest
 import openpos.product.v1.UpdateProductRequest
 import openpos.product.v1.UpdateTaxRateRequest
@@ -301,7 +302,93 @@ class ProductGrpcServiceTest {
         assertTrue(observer.value!!.isValid)
         assertTrue(observer.value!!.hasDiscount())
         assertTrue(observer.value!!.coupon.isActive)
-        assertFalse(observer.value!!.discount.value.isBlank())
+        assertFalse(
+            observer.value!!
+                .discount.value
+                .isBlank(),
+        )
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `listCoupons returns all coupons when activeOnly is false`() {
+        val couponId1 = UUID.randomUUID()
+        val couponId2 = UUID.randomUUID()
+        val discountId = UUID.randomUUID()
+        whenever(couponService.list(false)).thenReturn(
+            listOf(couponEntity(couponId1, discountId), couponEntity(couponId2, discountId)),
+        )
+
+        val observer = CapturingObserver<openpos.product.v1.ListCouponsResponse>()
+
+        grpcService.listCoupons(
+            ListCouponsRequest.newBuilder().setActiveOnly(false).build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        verify(couponService).list(false)
+        assertNotNull(observer.value)
+        assertEquals(2, observer.value?.couponsCount)
+        assertEquals(
+            couponId1.toString(),
+            observer.value
+                ?.couponsList
+                ?.get(0)
+                ?.id,
+        )
+        assertEquals(
+            couponId2.toString(),
+            observer.value
+                ?.couponsList
+                ?.get(1)
+                ?.id,
+        )
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `listCoupons filters active coupons when activeOnly is true`() {
+        val couponId = UUID.randomUUID()
+        val discountId = UUID.randomUUID()
+        whenever(couponService.list(true)).thenReturn(
+            listOf(couponEntity(couponId, discountId)),
+        )
+
+        val observer = CapturingObserver<openpos.product.v1.ListCouponsResponse>()
+
+        grpcService.listCoupons(
+            ListCouponsRequest.newBuilder().setActiveOnly(true).build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        verify(couponService).list(true)
+        assertNotNull(observer.value)
+        assertEquals(1, observer.value?.couponsCount)
+        assertTrue(
+            observer.value
+                ?.couponsList
+                ?.get(0)
+                ?.isActive ?: false,
+        )
+        assertTrue(observer.completed)
+    }
+
+    @Test
+    fun `listCoupons returns empty list when no coupons exist`() {
+        whenever(couponService.list(false)).thenReturn(emptyList())
+
+        val observer = CapturingObserver<openpos.product.v1.ListCouponsResponse>()
+
+        grpcService.listCoupons(
+            ListCouponsRequest.newBuilder().setActiveOnly(false).build(),
+            observer,
+        )
+
+        verify(tenantHelper).setupTenantContext()
+        assertNotNull(observer.value)
+        assertEquals(0, observer.value?.couponsCount)
         assertTrue(observer.completed)
     }
 
@@ -361,9 +448,7 @@ class ProductGrpcServiceTest {
             this.value = value
         }
 
-        override fun onError(t: Throwable) {
-            throw AssertionError("Unexpected error", t)
-        }
+        override fun onError(t: Throwable): Unit = throw AssertionError("Unexpected error", t)
 
         override fun onCompleted() {
             completed = true


### PR DESCRIPTION
## Summary
- Proto で定義済みだった `ListCoupons` RPC を ProductGrpcService に実装
- `CouponRepository` に `findActiveAndValid()` と `findAllOrdered()` クエリメソッドを追加
- `CouponService` に `list(activeOnly)` メソッドを追加
- ユニットテスト 3件追加（全件取得、activeOnly フィルター、空リスト）

## Test plan
- [x] `./gradlew :services:product-service:build` — ビルド + 全テスト + カバレッジ検証 pass