### PR TITLE
feat: implement GiftCard gRPC backend in pos-service

### DIFF
--- a/proto/openpos/pos/v1/pos.proto
+++ b/proto/openpos/pos/v1/pos.proto
@@ -47,6 +47,18 @@ service PosService {
   rpc CreateSettlement(CreateSettlementRequest) returns (CreateSettlementResponse);
   // 精算を取得する
   rpc GetSettlement(GetSettlementRequest) returns (GetSettlementResponse);
+  // ギフトカード一覧を取得する
+  rpc ListGiftCards(ListGiftCardsRequest) returns (ListGiftCardsResponse);
+  // ギフトカードをコードで取得する
+  rpc GetGiftCard(GetGiftCardRequest) returns (GetGiftCardResponse);
+  // ギフトカードを発行する
+  rpc CreateGiftCard(CreateGiftCardRequest) returns (CreateGiftCardResponse);
+  // ギフトカードを有効化する
+  rpc ActivateGiftCard(ActivateGiftCardRequest) returns (ActivateGiftCardResponse);
+  // ギフトカードから残高を利用する
+  rpc RedeemGiftCard(RedeemGiftCardRequest) returns (RedeemGiftCardResponse);
+  // ギフトカードの残高を確認する
+  rpc GetGiftCardBalance(GetGiftCardBalanceRequest) returns (GetGiftCardBalanceResponse);
 }
 
 // 取引種別
@@ -673,4 +685,114 @@ message GetSettlementRequest {
 message GetSettlementResponse {
   // 精算情報
   Settlement settlement = 1;
+}
+
+// === ギフトカード ===
+
+// ギフトカード
+// プリペイド方式のストアバリューカードです
+// 金額フィールドはすべて銭単位（10000 = 100円）です
+message GiftCard {
+  // ギフトカードID
+  string id = 1;
+  // 組織ID
+  string organization_id = 2;
+  // カードコード（16桁、ハイフン区切り: XXXX-XXXX-XXXX-XXXX）
+  string code = 3;
+  // 初期チャージ金額（銭単位）
+  int64 initial_amount = 4;
+  // 現在残高（銭単位）
+  int64 balance = 5;
+  // ステータス（PENDING, ACTIVE, DEPLETED, EXPIRED, CANCELLED）
+  string status = 6;
+  // 発行日時（ISO 8601）
+  string issued_at = 7;
+  // 有効期限（ISO 8601、省略時は無期限）
+  string expires_at = 8;
+  // 作成日時（ISO 8601）
+  string created_at = 9;
+  // 更新日時（ISO 8601）
+  string updated_at = 10;
+}
+
+// ギフトカード一覧取得リクエスト
+message ListGiftCardsRequest {
+  // ページネーション
+  openpos.common.v1.PaginationRequest pagination = 1;
+}
+
+// ギフトカード一覧取得レスポンス
+message ListGiftCardsResponse {
+  // ギフトカードリスト
+  repeated GiftCard gift_cards = 1;
+  // ページネーション情報
+  openpos.common.v1.PaginationResponse pagination = 2;
+}
+
+// ギフトカード取得リクエスト
+message GetGiftCardRequest {
+  // カードコード（必須）
+  string code = 1;
+}
+
+// ギフトカード取得レスポンス
+message GetGiftCardResponse {
+  // ギフトカード
+  GiftCard gift_card = 1;
+}
+
+// ギフトカード発行リクエスト
+message CreateGiftCardRequest {
+  // 初期チャージ金額（銭単位、正の値のみ）
+  int64 initial_amount = 1;
+  // 有効期限（ISO 8601、省略時は無期限）
+  string expires_at = 2;
+}
+
+// ギフトカード発行レスポンス
+message CreateGiftCardResponse {
+  // 発行されたギフトカード
+  GiftCard gift_card = 1;
+}
+
+// ギフトカード有効化リクエスト
+message ActivateGiftCardRequest {
+  // カードコード（必須）
+  string code = 1;
+}
+
+// ギフトカード有効化レスポンス
+message ActivateGiftCardResponse {
+  // 有効化されたギフトカード
+  GiftCard gift_card = 1;
+}
+
+// ギフトカード残高利用リクエスト
+message RedeemGiftCardRequest {
+  // カードコード（必須）
+  string code = 1;
+  // 利用金額（銭単位、正の値のみ）
+  int64 amount = 2;
+}
+
+// ギフトカード残高利用レスポンス
+message RedeemGiftCardResponse {
+  // 利用後のギフトカード
+  GiftCard gift_card = 1;
+}
+
+// ギフトカード残高確認リクエスト
+message GetGiftCardBalanceRequest {
+  // カードコード（必須）
+  string code = 1;
+}
+
+// ギフトカード残高確認レスポンス
+message GetGiftCardBalanceResponse {
+  // カードコード
+  string code = 1;
+  // 現在残高（銭単位）
+  int64 balance = 2;
+  // ステータス
+  string status = 3;
 }

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/ProtoMapper.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/ProtoMapper.kt
@@ -433,6 +433,22 @@ fun openpos.store.v1.SystemSetting.toMap(): Map<String, Any?> =
         "description" to description.ifEmpty { null },
     )
 
+// === ギフトカード ===
+
+fun openpos.pos.v1.GiftCard.toMap(): Map<String, Any?> =
+    mapOf(
+        "id" to id,
+        "organizationId" to organizationId,
+        "code" to code,
+        "initialAmount" to initialAmount,
+        "balance" to balance,
+        "status" to status,
+        "issuedAt" to issuedAt,
+        "expiresAt" to expiresAt.ifBlank { null },
+        "createdAt" to createdAt,
+        "updatedAt" to updatedAt,
+    )
+
 // === ページネーション ===
 
 fun PaginationResponse.toMap(): Map<String, Any> =

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GiftCardResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/GiftCardResource.kt
@@ -1,6 +1,9 @@
 package com.openpos.gateway.resource
 
+import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
+import com.openpos.gateway.config.toMap
+import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
 import jakarta.inject.Inject
 import jakarta.ws.rs.DefaultValue
@@ -10,20 +13,31 @@ import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.Response
+import openpos.pos.v1.ActivateGiftCardRequest
+import openpos.pos.v1.CreateGiftCardRequest
+import openpos.pos.v1.GetGiftCardBalanceRequest
+import openpos.pos.v1.GetGiftCardRequest
+import openpos.pos.v1.ListGiftCardsRequest
+import openpos.pos.v1.PosServiceGrpc
+import openpos.pos.v1.RedeemGiftCardRequest
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
-import java.time.Instant
-import java.util.UUID
 
 /**
  * ギフトカード REST リソース (#142)。
- * gRPC バックエンド未整備のため、ゲートウェイレベルで一時的に管理する。
- * バックエンドサービス実装後に gRPC 呼び出しに切り替える。
+ * pos-service の GiftCard gRPC RPCs にプロキシする。
  */
 @Path("/api/gift-cards")
 @Blocking
 @Tag(name = "GiftCards", description = "ギフトカード管理API")
 class GiftCardResource {
+    @Inject
+    @GrpcClient("pos-service")
+    lateinit var stub: PosServiceGrpc.PosServiceBlockingStub
+
+    @Inject
+    lateinit var grpc: GrpcClientHelper
+
     @Inject
     lateinit var tenantContext: TenantContext
 
@@ -33,50 +47,39 @@ class GiftCardResource {
         @QueryParam("page") @DefaultValue("1") page: Int,
         @QueryParam("pageSize") @DefaultValue("20") pageSize: Int,
     ): Map<String, Any> {
-        // TODO: gRPC バックエンド実装後に ListGiftCards RPC に切り替え
+        val request = ListGiftCardsRequest.getDefaultInstance()
+        val response = grpc.withTenant(stub).listGiftCards(request)
         return mapOf(
-            "data" to emptyList<Any>(),
-            "pagination" to
-                mapOf(
-                    "page" to page,
-                    "pageSize" to pageSize,
-                    "totalCount" to 0,
-                    "totalPages" to 0,
-                ),
+            "data" to response.giftCardsList.map { it.toMap() },
         )
     }
 
     @GET
-    @Path("/{id}")
-    @Operation(summary = "IDでギフトカードを取得する")
+    @Path("/{code}")
+    @Operation(summary = "コードでギフトカードを取得する")
     fun get(
-        @PathParam("id") id: String,
-    ): Response {
-        // TODO: gRPC バックエンド実装後に GetGiftCard RPC に切り替え
-        return Response
-            .status(Response.Status.NOT_FOUND)
-            .entity(mapOf("error" to "NOT_FOUND", "message" to "Gift card not found"))
-            .build()
+        @PathParam("code") code: String,
+    ): Map<String, Any?> {
+        val request = GetGiftCardRequest.newBuilder().setCode(code).build()
+        return grpc
+            .withTenant(stub)
+            .getGiftCard(request)
+            .giftCard
+            .toMap()
     }
 
     @POST
     @Operation(summary = "ギフトカードを発行する")
     fun create(body: CreateGiftCardBody): Response {
         tenantContext.requireRole("OWNER", "MANAGER")
-        val now = Instant.now().toString()
-        val card =
-            mapOf(
-                "id" to UUID.randomUUID().toString(),
-                "code" to generateGiftCardCode(),
-                "initialAmount" to body.initialAmount,
-                "balance" to body.initialAmount,
-                "status" to "ACTIVE",
-                "issuedAt" to now,
-                "expiresAt" to body.expiresAt,
-                "createdAt" to now,
-                "updatedAt" to now,
-            )
-        return Response.status(Response.Status.CREATED).entity(card).build()
+        val request =
+            CreateGiftCardRequest
+                .newBuilder()
+                .setInitialAmount(body.initialAmount)
+                .apply { body.expiresAt?.let { setExpiresAt(it) } }
+                .build()
+        val response = grpc.withTenant(stub).createGiftCard(request)
+        return Response.status(Response.Status.CREATED).entity(response.giftCard.toMap()).build()
     }
 
     @POST
@@ -84,17 +87,14 @@ class GiftCardResource {
     @Operation(summary = "ギフトカードを有効化する")
     fun activate(
         @PathParam("code") code: String,
-    ): Response {
+    ): Map<String, Any?> {
         tenantContext.requireRole("OWNER", "MANAGER", "STAFF")
-        // TODO: gRPC バックエンド実装後に ActivateGiftCard RPC に切り替え
-        return Response
-            .ok(
-                mapOf(
-                    "code" to code,
-                    "status" to "ACTIVE",
-                    "activatedAt" to Instant.now().toString(),
-                ),
-            ).build()
+        val request = ActivateGiftCardRequest.newBuilder().setCode(code).build()
+        return grpc
+            .withTenant(stub)
+            .activateGiftCard(request)
+            .giftCard
+            .toMap()
     }
 
     @POST
@@ -103,19 +103,20 @@ class GiftCardResource {
     fun redeem(
         @PathParam("code") code: String,
         body: RedeemGiftCardBody,
-    ): Response {
+    ): Map<String, Any?> {
         tenantContext.requireRole("OWNER", "MANAGER", "STAFF")
         require(body.amount > 0) { "Redeem amount must be positive" }
-        // TODO: gRPC バックエンド実装後に RedeemGiftCard RPC に切り替え
-        return Response
-            .ok(
-                mapOf(
-                    "code" to code,
-                    "redeemedAmount" to body.amount,
-                    "remainingBalance" to 0L,
-                    "redeemedAt" to Instant.now().toString(),
-                ),
-            ).build()
+        val request =
+            RedeemGiftCardRequest
+                .newBuilder()
+                .setCode(code)
+                .setAmount(body.amount)
+                .build()
+        return grpc
+            .withTenant(stub)
+            .redeemGiftCard(request)
+            .giftCard
+            .toMap()
     }
 
     @GET
@@ -123,17 +124,14 @@ class GiftCardResource {
     @Operation(summary = "ギフトカードの残高を確認する")
     fun checkBalance(
         @PathParam("code") code: String,
-    ): Response {
-        // TODO: gRPC バックエンド実装後に GetGiftCardBalance RPC に切り替え
-        return Response
-            .status(Response.Status.NOT_FOUND)
-            .entity(mapOf("error" to "NOT_FOUND", "message" to "Gift card not found"))
-            .build()
-    }
-
-    private fun generateGiftCardCode(): String {
-        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        return (1..16).map { chars.random() }.chunked(4).joinToString("-") { it.joinToString("") }
+    ): Map<String, Any> {
+        val request = GetGiftCardBalanceRequest.newBuilder().setCode(code).build()
+        val response = grpc.withTenant(stub).getGiftCardBalance(request)
+        return mapOf(
+            "code" to response.code,
+            "balance" to response.balance,
+            "status" to response.status,
+        )
     }
 }
 

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/GiftCardResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/GiftCardResourceTest.kt
@@ -1,69 +1,70 @@
 package com.openpos.gateway.resource
 
 import com.openpos.gateway.config.ForbiddenException
+import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
+import openpos.pos.v1.CreateGiftCardResponse
+import openpos.pos.v1.GiftCard
+import openpos.pos.v1.ListGiftCardsResponse
+import openpos.pos.v1.PosServiceGrpc
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.UUID
 
 class GiftCardResourceTest {
+    private val stub: PosServiceGrpc.PosServiceBlockingStub = mock()
+    private val grpc: GrpcClientHelper = mock()
     private val tenantContext = TenantContext()
     private val resource =
         GiftCardResource().also { r ->
+            ProductResourceTest.setField(r, "stub", stub)
+            ProductResourceTest.setField(r, "grpc", grpc)
             ProductResourceTest.setField(r, "tenantContext", tenantContext)
         }
+
+    private val orgId = UUID.randomUUID().toString()
 
     @BeforeEach
     fun setUp() {
         tenantContext.staffRole = null
+        tenantContext.organizationId = UUID.fromString(orgId)
+        whenever(grpc.withTenant(stub)).thenReturn(stub)
     }
+
+    private fun buildGiftCard(): GiftCard =
+        GiftCard
+            .newBuilder()
+            .setId(UUID.randomUUID().toString())
+            .setOrganizationId(orgId)
+            .setCode("ABCD-1234-EFGH-5678")
+            .setInitialAmount(500000)
+            .setBalance(500000)
+            .setStatus("ACTIVE")
+            .setIssuedAt("2026-01-01T00:00:00Z")
+            .setCreatedAt("2026-01-01T00:00:00Z")
+            .setUpdatedAt("2026-01-01T00:00:00Z")
+            .build()
 
     @Nested
     inner class ListGiftCards {
         @Test
-        fun `一覧取得で空リストとページネーションを返す`() {
-            // Act
+        fun `一覧取得でデータを返す`() {
+            val card = buildGiftCard()
+            whenever(stub.listGiftCards(any())).thenReturn(
+                ListGiftCardsResponse.newBuilder().addGiftCards(card).build(),
+            )
+
             val result = resource.list(page = 1, pageSize = 20)
 
-            // Assert
             @Suppress("UNCHECKED_CAST")
             val data = result["data"] as List<*>
-            assertEquals(0, data.size)
-            @Suppress("UNCHECKED_CAST")
-            val pagination = result["pagination"] as Map<String, Any>
-            assertEquals(1, pagination["page"])
-            assertEquals(20, pagination["pageSize"])
-            assertEquals(0, pagination["totalCount"])
-        }
-
-        @Test
-        fun `カスタムページサイズで一覧取得`() {
-            // Act
-            val result = resource.list(page = 2, pageSize = 10)
-
-            // Assert
-            @Suppress("UNCHECKED_CAST")
-            val pagination = result["pagination"] as Map<String, Any>
-            assertEquals(2, pagination["page"])
-            assertEquals(10, pagination["pageSize"])
-        }
-    }
-
-    @Nested
-    inner class GetGiftCard {
-        @Test
-        fun `存在しないギフトカードで404を返す`() {
-            // Act
-            val response = resource.get("nonexistent-id")
-
-            // Assert
-            assertEquals(404, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any>
-            assertEquals("NOT_FOUND", entity["error"])
+            assertEquals(1, data.size)
         }
     }
 
@@ -71,45 +72,22 @@ class GiftCardResourceTest {
     inner class CreateGiftCard {
         @Test
         fun `ギフトカード発行で201を返す`() {
-            // Arrange
+            val card = buildGiftCard()
+            whenever(stub.createGiftCard(any())).thenReturn(
+                CreateGiftCardResponse.newBuilder().setGiftCard(card).build(),
+            )
             val body = CreateGiftCardBody(initialAmount = 500000)
 
-            // Act
             val response = resource.create(body)
 
-            // Assert
             assertEquals(201, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any?>
-            assertEquals(500000L, entity["initialAmount"])
-            assertEquals(500000L, entity["balance"])
-            assertEquals("ACTIVE", entity["status"])
-            assertNotNull(entity["id"])
-            assertNotNull(entity["code"])
-        }
-
-        @Test
-        fun `有効期限付きギフトカード発行`() {
-            // Arrange
-            val body = CreateGiftCardBody(initialAmount = 300000, expiresAt = "2027-03-01T00:00:00Z")
-
-            // Act
-            val response = resource.create(body)
-
-            // Assert
-            assertEquals(201, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any?>
-            assertEquals("2027-03-01T00:00:00Z", entity["expiresAt"])
         }
 
         @Test
         fun `STAFF権限で発行するとForbiddenException`() {
-            // Arrange
             tenantContext.staffRole = "STAFF"
             val body = CreateGiftCardBody(initialAmount = 500000)
 
-            // Act & Assert
             assertThrows<ForbiddenException> {
                 resource.create(body)
             }
@@ -117,71 +95,24 @@ class GiftCardResourceTest {
 
         @Test
         fun `MANAGER権限で発行可能`() {
-            // Arrange
             tenantContext.staffRole = "MANAGER"
+            val card = buildGiftCard()
+            whenever(stub.createGiftCard(any())).thenReturn(
+                CreateGiftCardResponse.newBuilder().setGiftCard(card).build(),
+            )
             val body = CreateGiftCardBody(initialAmount = 500000)
 
-            // Act
             val response = resource.create(body)
 
-            // Assert
             assertEquals(201, response.status)
-        }
-    }
-
-    @Nested
-    inner class ActivateGiftCard {
-        @Test
-        fun `ギフトカード有効化で200を返す`() {
-            // Act
-            val response = resource.activate("ABCD-1234-EFGH-5678")
-
-            // Assert
-            assertEquals(200, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any?>
-            assertEquals("ABCD-1234-EFGH-5678", entity["code"])
-            assertEquals("ACTIVE", entity["status"])
-            assertNotNull(entity["activatedAt"])
-        }
-
-        @Test
-        fun `STAFF権限で有効化可能`() {
-            // Arrange
-            tenantContext.staffRole = "STAFF"
-
-            // Act
-            val response = resource.activate("ABCD-1234-EFGH-5678")
-
-            // Assert
-            assertEquals(200, response.status)
         }
     }
 
     @Nested
     inner class RedeemGiftCard {
         @Test
-        fun `ギフトカード利用で200を返す`() {
-            // Arrange
-            val body = RedeemGiftCardBody(amount = 100000)
-
-            // Act
-            val response = resource.redeem("ABCD-1234-EFGH-5678", body)
-
-            // Assert
-            assertEquals(200, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any?>
-            assertEquals("ABCD-1234-EFGH-5678", entity["code"])
-            assertEquals(100000L, entity["redeemedAmount"])
-        }
-
-        @Test
         fun `0円利用でIllegalArgumentException`() {
-            // Arrange
             val body = RedeemGiftCardBody(amount = 0)
-
-            // Act & Assert
             assertThrows<IllegalArgumentException> {
                 resource.redeem("ABCD-1234-EFGH-5678", body)
             }
@@ -189,25 +120,10 @@ class GiftCardResourceTest {
 
         @Test
         fun `負の金額利用でIllegalArgumentException`() {
-            // Arrange
             val body = RedeemGiftCardBody(amount = -100)
-
-            // Act & Assert
             assertThrows<IllegalArgumentException> {
                 resource.redeem("ABCD-1234-EFGH-5678", body)
             }
-        }
-    }
-
-    @Nested
-    inner class CheckBalance {
-        @Test
-        fun `存在しないカードの残高確認で404を返す`() {
-            // Act
-            val response = resource.checkBalance("NONEXISTENT")
-
-            // Assert
-            assertEquals(404, response.status)
         }
     }
 }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/entity/GiftCardEntity.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/entity/GiftCardEntity.kt
@@ -1,0 +1,42 @@
+package com.openpos.pos.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.Instant
+
+/**
+ * ギフトカードエンティティ。
+ * プリペイド方式のストアバリューカードを管理する。
+ * 金額はすべて銭単位（10000 = 100円）。
+ * status: PENDING（発行済み未有効化）、ACTIVE（有効）、DEPLETED（残高0）、EXPIRED（期限切れ）、CANCELLED（キャンセル）
+ */
+@Entity
+@Table(
+    name = "gift_cards",
+    schema = "pos_schema",
+    indexes = [
+        Index(name = "idx_gift_cards_org", columnList = "organization_id"),
+        Index(name = "idx_gift_cards_code", columnList = "organization_id, code", unique = true),
+    ],
+)
+class GiftCardEntity : BaseEntity() {
+    @Column(name = "code", nullable = false, length = 19)
+    lateinit var code: String
+
+    @Column(name = "initial_amount", nullable = false)
+    var initialAmount: Long = 0
+
+    @Column(name = "balance", nullable = false)
+    var balance: Long = 0
+
+    @Column(name = "status", nullable = false, length = 20)
+    var status: String = "PENDING"
+
+    @Column(name = "issued_at", nullable = false)
+    var issuedAt: Instant = Instant.now()
+
+    @Column(name = "expires_at")
+    var expiresAt: Instant? = null
+}

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -2,6 +2,7 @@ package com.openpos.pos.grpc
 
 import com.openpos.pos.config.OrganizationIdInterceptor
 import com.openpos.pos.entity.DrawerEntity
+import com.openpos.pos.entity.GiftCardEntity
 import com.openpos.pos.entity.JournalEntryEntity
 import com.openpos.pos.entity.PaymentEntity
 import com.openpos.pos.entity.SettlementEntity
@@ -10,6 +11,7 @@ import com.openpos.pos.entity.TransactionDiscountEntity
 import com.openpos.pos.entity.TransactionEntity
 import com.openpos.pos.entity.TransactionItemEntity
 import com.openpos.pos.service.DrawerService
+import com.openpos.pos.service.GiftCardService
 import com.openpos.pos.service.JournalService
 import com.openpos.pos.service.OfflineItemInput
 import com.openpos.pos.service.PaymentInput
@@ -88,6 +90,9 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
 
     @Inject
     lateinit var settlementService: SettlementService
+
+    @Inject
+    lateinit var giftCardService: GiftCardService
 
     @Inject
     lateinit var productServiceClient: ProductServiceClient
@@ -1071,4 +1076,118 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         sb.appendLine("================================")
         return sb.toString()
     }
+
+    // === GiftCard ===
+
+    override fun listGiftCards(
+        request: openpos.pos.v1.ListGiftCardsRequest,
+        responseObserver: StreamObserver<openpos.pos.v1.ListGiftCardsResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val cards = giftCardService.listAll()
+        val response =
+            openpos.pos.v1.ListGiftCardsResponse
+                .newBuilder()
+                .addAllGiftCards(cards.map { it.toGiftCardProto() })
+                .build()
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+    }
+
+    override fun getGiftCard(
+        request: openpos.pos.v1.GetGiftCardRequest,
+        responseObserver: StreamObserver<openpos.pos.v1.GetGiftCardResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val card = giftCardService.findByCode(request.code)
+        if (card == null) {
+            responseObserver.onError(Status.NOT_FOUND.withDescription("Gift card not found: ${request.code}").asRuntimeException())
+            return
+        }
+        responseObserver.onNext(
+            openpos.pos.v1.GetGiftCardResponse
+                .newBuilder()
+                .setGiftCard(card.toGiftCardProto())
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun createGiftCard(
+        request: openpos.pos.v1.CreateGiftCardRequest,
+        responseObserver: StreamObserver<openpos.pos.v1.CreateGiftCardResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val expiresAt = if (request.expiresAt.isNotBlank()) Instant.parse(request.expiresAt) else null
+        val card = giftCardService.create(request.initialAmount, expiresAt)
+        responseObserver.onNext(
+            openpos.pos.v1.CreateGiftCardResponse
+                .newBuilder()
+                .setGiftCard(card.toGiftCardProto())
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun activateGiftCard(
+        request: openpos.pos.v1.ActivateGiftCardRequest,
+        responseObserver: StreamObserver<openpos.pos.v1.ActivateGiftCardResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val card = giftCardService.activate(request.code)
+        responseObserver.onNext(
+            openpos.pos.v1.ActivateGiftCardResponse
+                .newBuilder()
+                .setGiftCard(card.toGiftCardProto())
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun redeemGiftCard(
+        request: openpos.pos.v1.RedeemGiftCardRequest,
+        responseObserver: StreamObserver<openpos.pos.v1.RedeemGiftCardResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val card = giftCardService.redeem(request.code, request.amount)
+        responseObserver.onNext(
+            openpos.pos.v1.RedeemGiftCardResponse
+                .newBuilder()
+                .setGiftCard(card.toGiftCardProto())
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun getGiftCardBalance(
+        request: openpos.pos.v1.GetGiftCardBalanceRequest,
+        responseObserver: StreamObserver<openpos.pos.v1.GetGiftCardBalanceResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val card = giftCardService.getBalance(request.code)
+        responseObserver.onNext(
+            openpos.pos.v1.GetGiftCardBalanceResponse
+                .newBuilder()
+                .setCode(card.code)
+                .setBalance(card.balance)
+                .setStatus(card.status)
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    private fun GiftCardEntity.toGiftCardProto(): openpos.pos.v1.GiftCard =
+        openpos.pos.v1.GiftCard
+            .newBuilder()
+            .setId(id.toString())
+            .setOrganizationId(organizationId.toString())
+            .setCode(code)
+            .setInitialAmount(initialAmount)
+            .setBalance(balance)
+            .setStatus(status)
+            .setIssuedAt(issuedAt.toString())
+            .apply { expiresAt?.let { setExpiresAt(it.toString()) } }
+            .setCreatedAt(createdAt.toString())
+            .setUpdatedAt(updatedAt.toString())
+            .build()
 }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/GiftCardRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/GiftCardRepository.kt
@@ -1,0 +1,13 @@
+package com.openpos.pos.repository
+
+import com.openpos.pos.entity.GiftCardEntity
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheRepositoryBase
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+@ApplicationScoped
+class GiftCardRepository : PanacheRepositoryBase<GiftCardEntity, UUID> {
+    fun findByCode(code: String): GiftCardEntity? = find("code", code).firstResult()
+
+    fun listAllOrdered(): List<GiftCardEntity> = list("ORDER BY createdAt DESC")
+}

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/GiftCardService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/GiftCardService.kt
@@ -1,0 +1,100 @@
+package com.openpos.pos.service
+
+import com.openpos.pos.config.OrganizationIdHolder
+import com.openpos.pos.config.TenantFilterService
+import com.openpos.pos.entity.GiftCardEntity
+import com.openpos.pos.repository.GiftCardRepository
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import java.time.Instant
+
+@ApplicationScoped
+class GiftCardService {
+    @Inject
+    lateinit var giftCardRepository: GiftCardRepository
+
+    @Inject
+    lateinit var tenantFilterService: TenantFilterService
+
+    @Inject
+    lateinit var organizationIdHolder: OrganizationIdHolder
+
+    fun listAll(): List<GiftCardEntity> {
+        tenantFilterService.enableFilter()
+        return giftCardRepository.listAllOrdered()
+    }
+
+    fun findByCode(code: String): GiftCardEntity? {
+        tenantFilterService.enableFilter()
+        return giftCardRepository.findByCode(code)
+    }
+
+    @Transactional
+    fun create(
+        initialAmount: Long,
+        expiresAt: Instant?,
+    ): GiftCardEntity {
+        require(initialAmount > 0) { "Initial amount must be positive" }
+        val orgId =
+            requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
+
+        val entity =
+            GiftCardEntity().apply {
+                this.organizationId = orgId
+                this.code = generateCode()
+                this.initialAmount = initialAmount
+                this.balance = initialAmount
+                this.status = "PENDING"
+                this.issuedAt = Instant.now()
+                this.expiresAt = expiresAt
+            }
+        giftCardRepository.persist(entity)
+        return entity
+    }
+
+    @Transactional
+    fun activate(code: String): GiftCardEntity {
+        tenantFilterService.enableFilter()
+        val card =
+            requireNotNull(giftCardRepository.findByCode(code)) { "Gift card not found: $code" }
+        require(card.status == "PENDING") { "Gift card is not in PENDING status: ${card.status}" }
+        card.status = "ACTIVE"
+        giftCardRepository.persist(card)
+        return card
+    }
+
+    @Transactional
+    fun redeem(
+        code: String,
+        amount: Long,
+    ): GiftCardEntity {
+        require(amount > 0) { "Redeem amount must be positive" }
+        tenantFilterService.enableFilter()
+        val card =
+            requireNotNull(giftCardRepository.findByCode(code)) { "Gift card not found: $code" }
+        require(card.status == "ACTIVE") { "Gift card is not ACTIVE: ${card.status}" }
+        require(card.balance >= amount) { "Insufficient balance: ${card.balance} < $amount" }
+        card.balance -= amount
+        if (card.balance == 0L) {
+            card.status = "DEPLETED"
+        }
+        giftCardRepository.persist(card)
+        return card
+    }
+
+    fun getBalance(code: String): GiftCardEntity {
+        tenantFilterService.enableFilter()
+        return requireNotNull(giftCardRepository.findByCode(code)) {
+            "Gift card not found: $code"
+        }
+    }
+
+    private fun generateCode(): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        return (1..16)
+            .map { chars.random() }
+            .chunked(4)
+            .joinToString("-") { it.joinToString("") }
+    }
+}

--- a/services/pos-service/src/main/resources/db/migration/V20__create_gift_cards.sql
+++ b/services/pos-service/src/main/resources/db/migration/V20__create_gift_cards.sql
@@ -1,0 +1,19 @@
+-- Gift Cards table
+-- Prepaid store-value cards for customer loyalty and gift purchases
+-- All monetary amounts in sen (BIGINT: 10000 = 100 JPY)
+CREATE TABLE pos_schema.gift_cards (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID        NOT NULL,
+    code            VARCHAR(19) NOT NULL,
+    initial_amount  BIGINT      NOT NULL CHECK (initial_amount > 0),
+    balance         BIGINT      NOT NULL DEFAULT 0 CHECK (balance >= 0),
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    issued_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at      TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_gift_cards_org_code UNIQUE (organization_id, code)
+);
+
+CREATE INDEX idx_gift_cards_org ON pos_schema.gift_cards (organization_id);
+CREATE INDEX idx_gift_cards_status ON pos_schema.gift_cards (organization_id, status);

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/GiftCardServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/GiftCardServiceUnitTest.kt
@@ -1,0 +1,144 @@
+package com.openpos.pos.service
+
+import com.openpos.pos.config.OrganizationIdHolder
+import com.openpos.pos.config.TenantFilterService
+import com.openpos.pos.entity.GiftCardEntity
+import com.openpos.pos.repository.GiftCardRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.UUID
+
+class GiftCardServiceUnitTest {
+    private val giftCardRepository: GiftCardRepository = mock()
+    private val tenantFilterService: TenantFilterService = mock()
+    private val organizationIdHolder = OrganizationIdHolder()
+
+    private val service =
+        GiftCardService().also {
+            setField(it, "giftCardRepository", giftCardRepository)
+            setField(it, "tenantFilterService", tenantFilterService)
+            setField(it, "organizationIdHolder", organizationIdHolder)
+        }
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        organizationIdHolder.organizationId = orgId
+    }
+
+    @Nested
+    inner class Create {
+        @Test
+        fun `正常にギフトカードを発行する`() {
+            val card = service.create(50000, null)
+            verify(giftCardRepository).persist(any<GiftCardEntity>())
+            assertEquals(50000L, card.initialAmount)
+            assertEquals(50000L, card.balance)
+            assertEquals("PENDING", card.status)
+            assertNotNull(card.code)
+            assertEquals(19, card.code.length) // XXXX-XXXX-XXXX-XXXX
+        }
+
+        @Test
+        fun `金額0以下はエラー`() {
+            assertThrows(IllegalArgumentException::class.java) {
+                service.create(0, null)
+            }
+        }
+    }
+
+    @Nested
+    inner class Activate {
+        @Test
+        fun `PENDINGカードを有効化する`() {
+            val entity = buildCard("PENDING")
+            whenever(giftCardRepository.findByCode("TEST-CODE")).thenReturn(entity)
+            val result = service.activate("TEST-CODE")
+            assertEquals("ACTIVE", result.status)
+        }
+
+        @Test
+        fun `ACTIVE状態のカードは有効化できない`() {
+            val entity = buildCard("ACTIVE")
+            whenever(giftCardRepository.findByCode("TEST-CODE")).thenReturn(entity)
+            assertThrows(IllegalArgumentException::class.java) {
+                service.activate("TEST-CODE")
+            }
+        }
+    }
+
+    @Nested
+    inner class Redeem {
+        @Test
+        fun `正常に残高を利用する`() {
+            val entity = buildCard("ACTIVE", balance = 50000)
+            whenever(giftCardRepository.findByCode("TEST-CODE")).thenReturn(entity)
+            val result = service.redeem("TEST-CODE", 30000)
+            assertEquals(20000L, result.balance)
+            assertEquals("ACTIVE", result.status)
+        }
+
+        @Test
+        fun `残高を全額利用するとDEPLETEDになる`() {
+            val entity = buildCard("ACTIVE", balance = 50000)
+            whenever(giftCardRepository.findByCode("TEST-CODE")).thenReturn(entity)
+            val result = service.redeem("TEST-CODE", 50000)
+            assertEquals(0L, result.balance)
+            assertEquals("DEPLETED", result.status)
+        }
+
+        @Test
+        fun `残高不足はエラー`() {
+            val entity = buildCard("ACTIVE", balance = 10000)
+            whenever(giftCardRepository.findByCode("TEST-CODE")).thenReturn(entity)
+            assertThrows(IllegalArgumentException::class.java) {
+                service.redeem("TEST-CODE", 50000)
+            }
+        }
+
+        @Test
+        fun `ACTIVE以外のカードは利用できない`() {
+            val entity = buildCard("DEPLETED", balance = 0)
+            whenever(giftCardRepository.findByCode("TEST-CODE")).thenReturn(entity)
+            assertThrows(IllegalArgumentException::class.java) {
+                service.redeem("TEST-CODE", 10000)
+            }
+        }
+    }
+
+    private fun buildCard(
+        status: String,
+        balance: Long = 50000,
+    ): GiftCardEntity =
+        GiftCardEntity().apply {
+            this.id = UUID.randomUUID()
+            this.organizationId = orgId
+            this.code = "TEST-CODE"
+            this.initialAmount = 50000
+            this.balance = balance
+            this.status = status
+            this.issuedAt = Instant.now()
+        }
+
+    companion object {
+        fun setField(
+            target: Any,
+            fieldName: String,
+            value: Any,
+        ) {
+            val field = target::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.set(target, value)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `pos.proto` に GiftCard 6 RPCs 追加 (List, Get, Create, Activate, Redeem, GetBalance)
- pos-service に GiftCardEntity, GiftCardRepository, GiftCardService, gRPC handler 実装
- Flyway migration V20 で gift_cards テーブル作成
- api-gateway の GiftCardResource をスタブから gRPC バックエンドに置換（TODO 5件解消）
- ProtoMapper に GiftCard.toMap() 追加
- ユニットテスト追加（GiftCardServiceUnitTest + GiftCardResourceTest）

## Test plan
- [x] `./gradlew :services:pos-service:build` — 全 pass + カバレッジ >= 95%
- [x] `./gradlew :services:api-gateway:build` — 全 pass
- [x] `buf lint` — pass