### PR TITLE
feat: implement StampCard gRPC backend in store-service

### DIFF
--- a/proto/openpos/store/v1/store.proto
+++ b/proto/openpos/store/v1/store.proto
@@ -57,6 +57,17 @@ service StoreService {
   rpc RecordConsent(RecordConsentRequest) returns (RecordConsentResponse);
   // データ処理同意を取得する
   rpc GetConsent(GetConsentRequest) returns (GetConsentResponse);
+
+  // === スタンプカード ===
+
+  // 顧客のスタンプカードを取得する
+  rpc GetStampCard(GetStampCardRequest) returns (GetStampCardResponse);
+  // スタンプカードを発行する
+  rpc IssueStampCard(IssueStampCardRequest) returns (IssueStampCardResponse);
+  // スタンプを追加する
+  rpc AddStamp(AddStampRequest) returns (AddStampResponse);
+  // スタンプ報酬を交換する
+  rpc RedeemStampReward(RedeemStampRewardRequest) returns (RedeemStampRewardResponse);
 }
 
 // スタッフロール
@@ -598,4 +609,83 @@ message GetConsentRequest {
 message GetConsentResponse {
   // 同意リスト
   repeated DataProcessingConsent consents = 1;
+}
+
+// === スタンプカード ===
+
+// スタンプカード
+// 顧客のポイントカード（スタンプ式ロイヤリティプログラム）
+message StampCard {
+  // スタンプカードID
+  string id = 1;
+  // 組織ID
+  string organization_id = 2;
+  // 顧客ID
+  string customer_id = 3;
+  // 現在のスタンプ数
+  int32 stamp_count = 4;
+  // 最大スタンプ数（報酬獲得に必要な数）
+  int32 max_stamps = 5;
+  // 報酬の説明
+  string reward_description = 6;
+  // ステータス（ACTIVE, COMPLETED, EXPIRED）
+  string status = 7;
+  // 発行日時（ISO 8601）
+  string issued_at = 8;
+  // 作成日時（ISO 8601）
+  string created_at = 9;
+  // 更新日時（ISO 8601）
+  string updated_at = 10;
+}
+
+// スタンプカード取得リクエスト
+message GetStampCardRequest {
+  // 顧客ID（必須）
+  string customer_id = 1;
+}
+
+// スタンプカード取得レスポンス
+message GetStampCardResponse {
+  // スタンプカード
+  StampCard stamp_card = 1;
+}
+
+// スタンプカード発行リクエスト
+message IssueStampCardRequest {
+  // 顧客ID（必須）
+  string customer_id = 1;
+  // 最大スタンプ数（デフォルト10）
+  int32 max_stamps = 2;
+  // 報酬の説明
+  string reward_description = 3;
+}
+
+// スタンプカード発行レスポンス
+message IssueStampCardResponse {
+  // 発行されたスタンプカード
+  StampCard stamp_card = 1;
+}
+
+// スタンプ追加リクエスト
+message AddStampRequest {
+  // 顧客ID（必須）
+  string customer_id = 1;
+}
+
+// スタンプ追加レスポンス
+message AddStampResponse {
+  // 更新後のスタンプカード
+  StampCard stamp_card = 1;
+}
+
+// スタンプ報酬交換リクエスト
+message RedeemStampRewardRequest {
+  // 顧客ID（必須）
+  string customer_id = 1;
+}
+
+// スタンプ報酬交換レスポンス
+message RedeemStampRewardResponse {
+  // リセット後のスタンプカード
+  StampCard stamp_card = 1;
 }

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/ProtoMapper.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/config/ProtoMapper.kt
@@ -460,6 +460,22 @@ fun openpos.pos.v1.GiftCard.toMap(): Map<String, Any?> =
         "updatedAt" to updatedAt,
     )
 
+// === スタンプカード ===
+
+fun openpos.store.v1.StampCard.toMap(): Map<String, Any?> =
+    mapOf(
+        "id" to id,
+        "organizationId" to organizationId,
+        "customerId" to customerId,
+        "stampCount" to stampCount,
+        "maxStamps" to maxStamps,
+        "rewardDescription" to rewardDescription.ifEmpty { null },
+        "status" to status,
+        "issuedAt" to issuedAt,
+        "createdAt" to createdAt,
+        "updatedAt" to updatedAt,
+    )
+
 // === ページネーション ===
 
 fun PaginationResponse.toMap(): Map<String, Any> =

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StampCardResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/StampCardResource.kt
@@ -1,6 +1,9 @@
 package com.openpos.gateway.resource
 
+import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
+import com.openpos.gateway.config.toMap
+import io.quarkus.grpc.GrpcClient
 import io.smallrye.common.annotation.Blocking
 import jakarta.inject.Inject
 import jakarta.ws.rs.GET
@@ -8,20 +11,29 @@ import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.core.Response
+import openpos.store.v1.AddStampRequest
+import openpos.store.v1.GetStampCardRequest
+import openpos.store.v1.IssueStampCardRequest
+import openpos.store.v1.RedeemStampRewardRequest
+import openpos.store.v1.StoreServiceGrpc
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
-import java.time.Instant
-import java.util.UUID
 
 /**
  * デジタルスタンプカード REST リソース（#222）。
- * gRPC バックエンド未整備のため、ゲートウェイレベルで一時的に管理する。
- * バックエンドサービス実装後に gRPC 呼び出しに切り替える。
+ * store-service の StampCard gRPC RPCs にプロキシする。
  */
 @Path("/api/stamp-cards")
 @Blocking
 @Tag(name = "StampCards", description = "スタンプカード管理API")
 class StampCardResource {
+    @Inject
+    @GrpcClient("store-service")
+    lateinit var stub: StoreServiceGrpc.StoreServiceBlockingStub
+
+    @Inject
+    lateinit var grpc: GrpcClientHelper
+
     @Inject
     lateinit var tenantContext: TenantContext
 
@@ -30,32 +42,28 @@ class StampCardResource {
     @Operation(summary = "顧客のスタンプカードを取得する")
     fun get(
         @PathParam("customerId") customerId: String,
-    ): Response {
-        // TODO: gRPC バックエンド実装後に GetStampCard RPC に切り替え
-        return Response
-            .status(Response.Status.NOT_FOUND)
-            .entity(mapOf("error" to "NOT_FOUND", "message" to "Stamp card not found for customer"))
-            .build()
+    ): Map<String, Any?> {
+        val request = GetStampCardRequest.newBuilder().setCustomerId(customerId).build()
+        return grpc
+            .withTenant(stub)
+            .getStampCard(request)
+            .stampCard
+            .toMap()
     }
 
     @POST
     @Operation(summary = "スタンプカードを発行する")
     fun issue(body: IssueStampCardBody): Response {
         tenantContext.requireRole("OWNER", "MANAGER", "STAFF")
-        val now = Instant.now().toString()
-        val card =
-            mapOf(
-                "id" to UUID.randomUUID().toString(),
-                "customerId" to body.customerId,
-                "stampCount" to 0,
-                "maxStamps" to body.maxStamps,
-                "rewardDescription" to body.rewardDescription,
-                "status" to "ACTIVE",
-                "issuedAt" to now,
-                "createdAt" to now,
-                "updatedAt" to now,
-            )
-        return Response.status(Response.Status.CREATED).entity(card).build()
+        val request =
+            IssueStampCardRequest
+                .newBuilder()
+                .setCustomerId(body.customerId)
+                .setMaxStamps(body.maxStamps)
+                .apply { body.rewardDescription?.let { setRewardDescription(it) } }
+                .build()
+        val response = grpc.withTenant(stub).issueStampCard(request)
+        return Response.status(Response.Status.CREATED).entity(response.stampCard.toMap()).build()
     }
 
     @POST
@@ -63,18 +71,14 @@ class StampCardResource {
     @Operation(summary = "スタンプを追加する")
     fun addStamp(
         @PathParam("customerId") customerId: String,
-    ): Response {
+    ): Map<String, Any?> {
         tenantContext.requireRole("OWNER", "MANAGER", "STAFF")
-        // TODO: gRPC バックエンド実装後に AddStamp RPC に切り替え
-        val now = Instant.now().toString()
-        return Response
-            .ok(
-                mapOf(
-                    "customerId" to customerId,
-                    "stampCount" to 1,
-                    "stampedAt" to now,
-                ),
-            ).build()
+        val request = AddStampRequest.newBuilder().setCustomerId(customerId).build()
+        return grpc
+            .withTenant(stub)
+            .addStamp(request)
+            .stampCard
+            .toMap()
     }
 
     @POST
@@ -82,19 +86,14 @@ class StampCardResource {
     @Operation(summary = "スタンプ報酬を交換する")
     fun redeemReward(
         @PathParam("customerId") customerId: String,
-    ): Response {
+    ): Map<String, Any?> {
         tenantContext.requireRole("OWNER", "MANAGER", "STAFF")
-        // TODO: gRPC バックエンド実装後に RedeemStampReward RPC に切り替え
-        val now = Instant.now().toString()
-        return Response
-            .ok(
-                mapOf(
-                    "customerId" to customerId,
-                    "redeemed" to true,
-                    "stampCount" to 0,
-                    "redeemedAt" to now,
-                ),
-            ).build()
+        val request = RedeemStampRewardRequest.newBuilder().setCustomerId(customerId).build()
+        return grpc
+            .withTenant(stub)
+            .redeemStampReward(request)
+            .stampCard
+            .toMap()
     }
 }
 

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/StampCardResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/StampCardResourceTest.kt
@@ -1,153 +1,96 @@
 package com.openpos.gateway.resource
 
 import com.openpos.gateway.config.ForbiddenException
+import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
+import openpos.store.v1.IssueStampCardResponse
+import openpos.store.v1.StampCard
+import openpos.store.v1.StoreServiceGrpc
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.UUID
 
 class StampCardResourceTest {
+    private val stub: StoreServiceGrpc.StoreServiceBlockingStub = mock()
+    private val grpc: GrpcClientHelper = mock()
     private val tenantContext = TenantContext()
     private val resource =
         StampCardResource().also { r ->
+            ProductResourceTest.setField(r, "stub", stub)
+            ProductResourceTest.setField(r, "grpc", grpc)
             ProductResourceTest.setField(r, "tenantContext", tenantContext)
         }
+
+    private val orgId = UUID.randomUUID().toString()
+    private val customerId = UUID.randomUUID().toString()
 
     @BeforeEach
     fun setUp() {
         tenantContext.staffRole = null
+        tenantContext.organizationId = UUID.fromString(orgId)
+        whenever(grpc.withTenant(stub)).thenReturn(stub)
     }
 
-    @Nested
-    inner class GetStampCard {
-        @Test
-        fun `存在しないスタンプカードで404を返す`() {
-            // Act
-            val response = resource.get("customer-123")
-
-            // Assert
-            assertEquals(404, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any>
-            assertEquals("NOT_FOUND", entity["error"])
-        }
-    }
+    private fun buildStampCard(): StampCard =
+        StampCard
+            .newBuilder()
+            .setId(UUID.randomUUID().toString())
+            .setOrganizationId(orgId)
+            .setCustomerId(customerId)
+            .setStampCount(0)
+            .setMaxStamps(10)
+            .setStatus("ACTIVE")
+            .setIssuedAt("2026-01-01T00:00:00Z")
+            .setCreatedAt("2026-01-01T00:00:00Z")
+            .setUpdatedAt("2026-01-01T00:00:00Z")
+            .build()
 
     @Nested
     inner class IssueStampCard {
         @Test
         fun `スタンプカード発行で201を返す`() {
-            // Arrange
-            val body = IssueStampCardBody(customerId = "customer-123", maxStamps = 10)
+            val card = buildStampCard()
+            whenever(stub.issueStampCard(any())).thenReturn(
+                IssueStampCardResponse.newBuilder().setStampCard(card).build(),
+            )
+            val body = IssueStampCardBody(customerId = customerId, maxStamps = 10)
 
-            // Act
             val response = resource.issue(body)
 
-            // Assert
             assertEquals(201, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any?>
-            assertEquals("customer-123", entity["customerId"])
-            assertEquals(0, entity["stampCount"])
-            assertEquals(10, entity["maxStamps"])
-            assertEquals("ACTIVE", entity["status"])
-            assertNotNull(entity["id"])
         }
 
         @Test
-        fun `報酬説明付きスタンプカード発行`() {
-            // Arrange
-            val body =
-                IssueStampCardBody(
-                    customerId = "customer-456",
-                    maxStamps = 5,
-                    rewardDescription = "ドリンク1杯無料",
-                )
+        fun `認証なし（dev）で発行可能`() {
+            val card = buildStampCard()
+            whenever(stub.issueStampCard(any())).thenReturn(
+                IssueStampCardResponse.newBuilder().setStampCard(card).build(),
+            )
+            tenantContext.staffRole = null
+            val body = IssueStampCardBody(customerId = customerId)
 
-            // Act
             val response = resource.issue(body)
 
-            // Assert
-            assertEquals(201, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any?>
-            assertEquals("ドリンク1杯無料", entity["rewardDescription"])
-            assertEquals(5, entity["maxStamps"])
-        }
-
-        @Test
-        fun `STAFF権限で発行可能`() {
-            // Arrange
-            tenantContext.staffRole = "STAFF"
-            val body = IssueStampCardBody(customerId = "customer-123")
-
-            // Act
-            val response = resource.issue(body)
-
-            // Assert
             assertEquals(201, response.status)
         }
     }
 
     @Nested
-    inner class AddStamp {
+    inner class RoleCheck {
         @Test
-        fun `スタンプ追加で200を返す`() {
-            // Act
-            val response = resource.addStamp("customer-123")
+        fun `VIEWER権限で発行するとForbiddenException`() {
+            tenantContext.staffRole = "VIEWER"
+            val body = IssueStampCardBody(customerId = customerId)
 
-            // Assert
-            assertEquals(200, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any?>
-            assertEquals("customer-123", entity["customerId"])
-            assertEquals(1, entity["stampCount"])
-            assertNotNull(entity["stampedAt"])
-        }
-
-        @Test
-        fun `STAFF権限でスタンプ追加可能`() {
-            // Arrange
-            tenantContext.staffRole = "STAFF"
-
-            // Act
-            val response = resource.addStamp("customer-123")
-
-            // Assert
-            assertEquals(200, response.status)
-        }
-    }
-
-    @Nested
-    inner class RedeemReward {
-        @Test
-        fun `スタンプ報酬交換で200を返す`() {
-            // Act
-            val response = resource.redeemReward("customer-123")
-
-            // Assert
-            assertEquals(200, response.status)
-            @Suppress("UNCHECKED_CAST")
-            val entity = response.entity as Map<String, Any?>
-            assertEquals("customer-123", entity["customerId"])
-            assertEquals(true, entity["redeemed"])
-            assertEquals(0, entity["stampCount"])
-            assertNotNull(entity["redeemedAt"])
-        }
-
-        @Test
-        fun `STAFF権限で報酬交換可能`() {
-            // Arrange
-            tenantContext.staffRole = "STAFF"
-
-            // Act
-            val response = resource.redeemReward("customer-123")
-
-            // Assert
-            assertEquals(200, response.status)
+            assertThrows<ForbiddenException> {
+                resource.issue(body)
+            }
         }
     }
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/entity/StampCardEntity.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/entity/StampCardEntity.kt
@@ -1,0 +1,42 @@
+package com.openpos.store.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * スタンプカードエンティティ。
+ * 顧客ロイヤリティプログラムのスタンプ式カード。
+ * status: ACTIVE（利用中）、COMPLETED（最大到達・報酬交換待ち）、EXPIRED（期限切れ）
+ */
+@Entity
+@Table(
+    name = "stamp_cards",
+    schema = "store_schema",
+    indexes = [
+        Index(name = "idx_stamp_cards_org", columnList = "organization_id"),
+        Index(name = "idx_stamp_cards_customer", columnList = "organization_id, customer_id"),
+    ],
+)
+class StampCardEntity : BaseEntity() {
+    @Column(name = "customer_id", nullable = false)
+    lateinit var customerId: UUID
+
+    @Column(name = "stamp_count", nullable = false)
+    var stampCount: Int = 0
+
+    @Column(name = "max_stamps", nullable = false)
+    var maxStamps: Int = 10
+
+    @Column(name = "reward_description")
+    var rewardDescription: String? = null
+
+    @Column(name = "status", nullable = false, length = 20)
+    var status: String = "ACTIVE"
+
+    @Column(name = "issued_at", nullable = false)
+    var issuedAt: Instant = Instant.now()
+}

--- a/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
@@ -6,12 +6,14 @@ import com.openpos.store.config.DataMaskingUtil
 import com.openpos.store.entity.DataProcessingConsentEntity
 import com.openpos.store.entity.OrganizationEntity
 import com.openpos.store.entity.StaffEntity
+import com.openpos.store.entity.StampCardEntity
 import com.openpos.store.entity.StoreEntity
 import com.openpos.store.entity.TerminalEntity
 import com.openpos.store.service.AuditLogService
 import com.openpos.store.service.GdprService
 import com.openpos.store.service.OrganizationService
 import com.openpos.store.service.StaffService
+import com.openpos.store.service.StampCardService
 import com.openpos.store.service.StoreService
 import com.openpos.store.service.TerminalService
 import io.grpc.Status
@@ -92,6 +94,9 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
 
     @Inject
     lateinit var gdprService: GdprService
+
+    @Inject
+    lateinit var stampCardService: StampCardService
 
     @Inject
     lateinit var tenantHelper: GrpcTenantHelper
@@ -695,4 +700,92 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
             "CASHIER" -> StaffRole.STAFF_ROLE_CASHIER
             else -> StaffRole.STAFF_ROLE_UNSPECIFIED
         }
+
+    // === StampCard ===
+
+    override fun getStampCard(
+        request: openpos.store.v1.GetStampCardRequest,
+        responseObserver: io.grpc.stub.StreamObserver<openpos.store.v1.GetStampCardResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val card = stampCardService.getByCustomerId(java.util.UUID.fromString(request.customerId))
+        if (card == null) {
+            responseObserver.onError(
+                Status.NOT_FOUND.withDescription("Stamp card not found for customer: ${request.customerId}").asRuntimeException(),
+            )
+            return
+        }
+        responseObserver.onNext(
+            openpos.store.v1.GetStampCardResponse
+                .newBuilder()
+                .setStampCard(card.toStampCardProto())
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun issueStampCard(
+        request: openpos.store.v1.IssueStampCardRequest,
+        responseObserver: io.grpc.stub.StreamObserver<openpos.store.v1.IssueStampCardResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val card =
+            stampCardService.issue(
+                customerId = java.util.UUID.fromString(request.customerId),
+                maxStamps = if (request.maxStamps > 0) request.maxStamps else 10,
+                rewardDescription = request.rewardDescription.ifBlank { null },
+            )
+        responseObserver.onNext(
+            openpos.store.v1.IssueStampCardResponse
+                .newBuilder()
+                .setStampCard(card.toStampCardProto())
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun addStamp(
+        request: openpos.store.v1.AddStampRequest,
+        responseObserver: io.grpc.stub.StreamObserver<openpos.store.v1.AddStampResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val card = stampCardService.addStamp(java.util.UUID.fromString(request.customerId))
+        responseObserver.onNext(
+            openpos.store.v1.AddStampResponse
+                .newBuilder()
+                .setStampCard(card.toStampCardProto())
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun redeemStampReward(
+        request: openpos.store.v1.RedeemStampRewardRequest,
+        responseObserver: io.grpc.stub.StreamObserver<openpos.store.v1.RedeemStampRewardResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val card = stampCardService.redeemReward(java.util.UUID.fromString(request.customerId))
+        responseObserver.onNext(
+            openpos.store.v1.RedeemStampRewardResponse
+                .newBuilder()
+                .setStampCard(card.toStampCardProto())
+                .build(),
+        )
+        responseObserver.onCompleted()
+    }
+
+    private fun StampCardEntity.toStampCardProto(): openpos.store.v1.StampCard =
+        openpos.store.v1.StampCard
+            .newBuilder()
+            .setId(id.toString())
+            .setOrganizationId(organizationId.toString())
+            .setCustomerId(customerId.toString())
+            .setStampCount(stampCount)
+            .setMaxStamps(maxStamps)
+            .apply { rewardDescription?.let { setRewardDescription(it) } }
+            .setStatus(status)
+            .setIssuedAt(issuedAt.toString())
+            .setCreatedAt(createdAt.toString())
+            .setUpdatedAt(updatedAt.toString())
+            .build()
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/repository/StampCardRepository.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/repository/StampCardRepository.kt
@@ -1,0 +1,13 @@
+package com.openpos.store.repository
+
+import com.openpos.store.entity.StampCardEntity
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheRepositoryBase
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+@ApplicationScoped
+class StampCardRepository : PanacheRepositoryBase<StampCardEntity, UUID> {
+    fun findActiveByCustomerId(customerId: UUID): StampCardEntity? = find("customerId = ?1 AND status = 'ACTIVE'", customerId).firstResult()
+
+    fun findByCustomerId(customerId: UUID): StampCardEntity? = find("customerId = ?1 ORDER BY createdAt DESC", customerId).firstResult()
+}

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/StampCardService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/StampCardService.kt
@@ -1,0 +1,84 @@
+package com.openpos.store.service
+
+import com.openpos.store.config.OrganizationIdHolder
+import com.openpos.store.config.TenantFilterService
+import com.openpos.store.entity.StampCardEntity
+import com.openpos.store.repository.StampCardRepository
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@ApplicationScoped
+class StampCardService {
+    @Inject
+    lateinit var stampCardRepository: StampCardRepository
+
+    @Inject
+    lateinit var tenantFilterService: TenantFilterService
+
+    @Inject
+    lateinit var organizationIdHolder: OrganizationIdHolder
+
+    fun getByCustomerId(customerId: UUID): StampCardEntity? {
+        tenantFilterService.enableFilter()
+        return stampCardRepository.findByCustomerId(customerId)
+    }
+
+    @Transactional
+    fun issue(
+        customerId: UUID,
+        maxStamps: Int,
+        rewardDescription: String?,
+    ): StampCardEntity {
+        val orgId =
+            requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
+        val effectiveMaxStamps = if (maxStamps > 0) maxStamps else 10
+
+        val entity =
+            StampCardEntity().apply {
+                this.organizationId = orgId
+                this.customerId = customerId
+                this.stampCount = 0
+                this.maxStamps = effectiveMaxStamps
+                this.rewardDescription = rewardDescription
+                this.status = "ACTIVE"
+                this.issuedAt = Instant.now()
+            }
+        stampCardRepository.persist(entity)
+        return entity
+    }
+
+    @Transactional
+    fun addStamp(customerId: UUID): StampCardEntity {
+        tenantFilterService.enableFilter()
+        val card =
+            requireNotNull(stampCardRepository.findActiveByCustomerId(customerId)) {
+                "Active stamp card not found for customer: $customerId"
+            }
+        require(card.status == "ACTIVE") { "Stamp card is not ACTIVE: ${card.status}" }
+        card.stampCount += 1
+        if (card.stampCount >= card.maxStamps) {
+            card.status = "COMPLETED"
+        }
+        stampCardRepository.persist(card)
+        return card
+    }
+
+    @Transactional
+    fun redeemReward(customerId: UUID): StampCardEntity {
+        tenantFilterService.enableFilter()
+        val card =
+            requireNotNull(stampCardRepository.findByCustomerId(customerId)) {
+                "Stamp card not found for customer: $customerId"
+            }
+        require(card.status == "COMPLETED") {
+            "Stamp card is not COMPLETED (stamps: ${card.stampCount}/${card.maxStamps})"
+        }
+        card.stampCount = 0
+        card.status = "ACTIVE"
+        stampCardRepository.persist(card)
+        return card
+    }
+}

--- a/services/store-service/src/main/resources/db/migration/V10__create_stamp_cards.sql
+++ b/services/store-service/src/main/resources/db/migration/V10__create_stamp_cards.sql
@@ -1,0 +1,17 @@
+-- Stamp Cards table
+-- Customer loyalty stamp cards for reward programs
+CREATE TABLE store_schema.stamp_cards (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     UUID        NOT NULL,
+    customer_id         UUID        NOT NULL,
+    stamp_count         INT         NOT NULL DEFAULT 0 CHECK (stamp_count >= 0),
+    max_stamps          INT         NOT NULL DEFAULT 10 CHECK (max_stamps > 0),
+    reward_description  TEXT,
+    status              VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    issued_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_stamp_cards_org ON store_schema.stamp_cards (organization_id);
+CREATE INDEX idx_stamp_cards_customer ON store_schema.stamp_cards (organization_id, customer_id);

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/StampCardServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/StampCardServiceUnitTest.kt
@@ -1,0 +1,134 @@
+package com.openpos.store.service
+
+import com.openpos.store.config.OrganizationIdHolder
+import com.openpos.store.config.TenantFilterService
+import com.openpos.store.entity.StampCardEntity
+import com.openpos.store.repository.StampCardRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.UUID
+
+class StampCardServiceUnitTest {
+    private val stampCardRepository: StampCardRepository = mock()
+    private val tenantFilterService: TenantFilterService = mock()
+    private val organizationIdHolder = OrganizationIdHolder()
+
+    private val service =
+        StampCardService().also {
+            setField(it, "stampCardRepository", stampCardRepository)
+            setField(it, "tenantFilterService", tenantFilterService)
+            setField(it, "organizationIdHolder", organizationIdHolder)
+        }
+
+    private val orgId = UUID.randomUUID()
+    private val customerId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        organizationIdHolder.organizationId = orgId
+    }
+
+    @Nested
+    inner class Issue {
+        @Test
+        fun `正常にスタンプカードを発行する`() {
+            val card = service.issue(customerId, 10, "ドリンク1杯無料")
+            verify(stampCardRepository).persist(any<StampCardEntity>())
+            assertEquals(0, card.stampCount)
+            assertEquals(10, card.maxStamps)
+            assertEquals("ドリンク1杯無料", card.rewardDescription)
+            assertEquals("ACTIVE", card.status)
+        }
+
+        @Test
+        fun `maxStamps 0以下はデフォルト10になる`() {
+            val card = service.issue(customerId, 0, null)
+            assertEquals(10, card.maxStamps)
+        }
+    }
+
+    @Nested
+    inner class AddStamp {
+        @Test
+        fun `スタンプを追加する`() {
+            val entity = buildCard(stampCount = 3, maxStamps = 10)
+            whenever(stampCardRepository.findActiveByCustomerId(customerId)).thenReturn(entity)
+            val result = service.addStamp(customerId)
+            assertEquals(4, result.stampCount)
+            assertEquals("ACTIVE", result.status)
+        }
+
+        @Test
+        fun `最大到達でCOMPLETEDになる`() {
+            val entity = buildCard(stampCount = 9, maxStamps = 10)
+            whenever(stampCardRepository.findActiveByCustomerId(customerId)).thenReturn(entity)
+            val result = service.addStamp(customerId)
+            assertEquals(10, result.stampCount)
+            assertEquals("COMPLETED", result.status)
+        }
+
+        @Test
+        fun `アクティブカードがなければエラー`() {
+            whenever(stampCardRepository.findActiveByCustomerId(customerId)).thenReturn(null)
+            assertThrows(IllegalArgumentException::class.java) {
+                service.addStamp(customerId)
+            }
+        }
+    }
+
+    @Nested
+    inner class RedeemReward {
+        @Test
+        fun `報酬交換でリセットされる`() {
+            val entity = buildCard(stampCount = 10, maxStamps = 10, status = "COMPLETED")
+            whenever(stampCardRepository.findByCustomerId(customerId)).thenReturn(entity)
+            val result = service.redeemReward(customerId)
+            assertEquals(0, result.stampCount)
+            assertEquals("ACTIVE", result.status)
+        }
+
+        @Test
+        fun `COMPLETED以外では交換できない`() {
+            val entity = buildCard(stampCount = 5, maxStamps = 10)
+            whenever(stampCardRepository.findByCustomerId(customerId)).thenReturn(entity)
+            assertThrows(IllegalArgumentException::class.java) {
+                service.redeemReward(customerId)
+            }
+        }
+    }
+
+    private fun buildCard(
+        stampCount: Int = 0,
+        maxStamps: Int = 10,
+        status: String = "ACTIVE",
+    ): StampCardEntity =
+        StampCardEntity().apply {
+            this.id = UUID.randomUUID()
+            this.organizationId = orgId
+            this.customerId = this@StampCardServiceUnitTest.customerId
+            this.stampCount = stampCount
+            this.maxStamps = maxStamps
+            this.status = status
+            this.issuedAt = Instant.now()
+        }
+
+    companion object {
+        fun setField(
+            target: Any,
+            fieldName: String,
+            value: Any,
+        ) {
+            val field = target::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.set(target, value)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `store.proto` に StampCard 4 RPCs 追加 (GetStampCard, IssueStampCard, AddStamp, RedeemStampReward)
- store-service に StampCardEntity, StampCardRepository, StampCardService, gRPC handler 実装
- Flyway migration V10 で stamp_cards テーブル作成
- api-gateway の StampCardResource をスタブから gRPC バックエンドに置換（TODO 3件解消）
- ProtoMapper に StampCard.toMap() 追加
- ユニットテスト追加（StampCardServiceUnitTest + StampCardResourceTest）

## Test plan
- [x] `./gradlew :services:store-service:build` — 全 pass + カバレッジ検証
- [x] `./gradlew :services:api-gateway:build` — 全 pass
- [x] `buf lint` — pass