### PR TITLE
fix(ci): make E2E informational, require local execution

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -187,10 +187,16 @@ pnpm -r typecheck       # 型チェック
 pnpm -r lint            # ESLint
 pnpm -r run test        # ユニット/機能テスト
 pnpm -r build           # ビルド確認
+
+# E2E テスト（必須 — CI では informational のためローカルで必ず実行）
+# GitHub Free ランナーでは Docker ビルドがタイムアウトするため、CI の required check から除外している。
+# PR 作成前にローカルで pass を確認すること。
+make docker-demo && pnpm --filter e2e test
 ```
 
 - 失敗したら PR を作成せず、原因を修正してから再実行
 - `make verify` で Proto 以外の基本チェックをまとめて実行可能
+- `make verify-full` で E2E 含む全チェックをまとめて実行可能
 
 ### 必須手順
 1. ブランチ作成 → コミット → push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,10 @@ jobs:
           path: apps/*/coverage/
         if: ${{ !cancelled() }}
 
+  # E2E is informational (not required for merge).
+  # Reason: GitHub Free runners cannot reliably complete the full Docker build
+  # within the 45-min timeout. E2E MUST be run locally before creating a PR.
+  # See CLAUDE.md "PR 作成前のローカル CI 検証" for the required local command.
   e2e:
     name: E2E Test (Playwright)
     needs: [changes]
@@ -226,13 +230,14 @@ jobs:
   ci-success:
     name: CI Success
     if: always()
-    needs: [changes, proto-lint, backend, frontend, e2e]
+    # E2E is excluded from required checks — see comment above the e2e job.
+    needs: [changes, proto-lint, backend, frontend]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Verify all jobs passed or were skipped
         run: |
-          results=("${{ needs.changes.result }}" "${{ needs.proto-lint.result }}" "${{ needs.backend.result }}" "${{ needs.frontend.result }}" "${{ needs.e2e.result }}")
+          results=("${{ needs.changes.result }}" "${{ needs.proto-lint.result }}" "${{ needs.backend.result }}" "${{ needs.frontend.result }}")
           for r in "${results[@]}"; do
             if [[ "$r" != "success" && "$r" != "skipped" ]]; then
               echo "::error::Job failed with result: $r"
@@ -261,6 +266,5 @@ jobs:
           | proto-lint | \`${{ needs.proto-lint.result }}\` |
           | backend | \`${{ needs.backend.result }}\` |
           | frontend | \`${{ needs.frontend.result }}\` |
-          | e2e | \`${{ needs.e2e.result }}\` |
 
           [ワークフロー実行を確認](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"


### PR DESCRIPTION
## Summary
- CI の E2E Test を required check から除外（informational に変更）
- 理由: GitHub Free ランナーで Docker ビルドが45分タイムアウトに到達し、コード無関係の失敗が頻発
- CLAUDE.md に E2E ローカル実行必須を明記

## Changes
- `.github/workflows/ci.yml`: ci-success の needs から e2e を除外、理由をコメント記載
- `.claude/CLAUDE.md`: PR 作成前チェックリストに E2E 実行を追加

## Test plan
- [x] CI ワークフロー構文検証