### PR TITLE
feat: ad-hoc custom product entry + analytics enhancements - Closes #1024

### DIFF
--- a/proto/openpos/pos/v1/pos.proto
+++ b/proto/openpos/pos/v1/pos.proto
@@ -354,10 +354,14 @@ message ListTransactionsResponse {
 message AddTransactionItemRequest {
   // 取引ID（必須）
   string transaction_id = 1;
-  // 商品ID（必須）
+  // 商品ID（商品マスタ登録済みの場合。カスタム商品の場合は空文字）
   string product_id = 2;
   // 数量（1以上）
   int32 quantity = 3;
+  // カスタム商品名（商品マスタ未登録のアドホック商品用。設定時は product_id を空にする）
+  string custom_product_name = 4;
+  // カスタム商品価格（銭単位。custom_product_name 指定時に必須）
+  int64 custom_product_price = 5;
 }
 
 // 明細更新リクエスト

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/entity/ProductSalesEntity.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/entity/ProductSalesEntity.kt
@@ -26,6 +26,9 @@ class ProductSalesEntity : BaseEntity() {
     @Column(name = "product_name", nullable = false)
     var productName: String = ""
 
+    @Column(name = "category_name", nullable = false)
+    var categoryName: String = ""
+
     @Column(name = "quantity_sold", nullable = false)
     var quantitySold: Int = 0
 

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventDtos.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventDtos.kt
@@ -48,4 +48,5 @@ data class SaleItemPayload(
     val unitPrice: Long,
     val subtotal: Long,
     val productName: String? = null,
+    val categoryName: String? = null,
 )

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/SalesEventProcessor.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/SalesEventProcessor.kt
@@ -59,6 +59,7 @@ class SalesEventProcessor {
                 storeId,
                 UUID.fromString(item.productId),
                 item.productName,
+                item.categoryName,
                 saleDate,
                 item.quantity,
                 item.subtotal,
@@ -143,6 +144,7 @@ class SalesEventProcessor {
         storeId: UUID,
         productId: UUID,
         productName: String?,
+        categoryName: String?,
         saleDate: LocalDate,
         quantity: Int,
         subtotal: Long,
@@ -156,6 +158,7 @@ class SalesEventProcessor {
                     this.productId = productId
                     this.date = saleDate
                     this.productName = productName?.ifBlank { "Product-$productId" } ?: "Product-$productId"
+                    this.categoryName = categoryName?.ifBlank { "" } ?: ""
                 }
         productSales.quantitySold += quantity
         productSales.totalAmount += subtotal

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/grpc/AnalyticsGrpcService.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/grpc/AnalyticsGrpcService.kt
@@ -16,7 +16,10 @@ import openpos.analytics.v1.AnalyticsServiceGrpc
 import openpos.analytics.v1.DailySales
 import openpos.analytics.v1.DeleteSalesTargetRequest
 import openpos.analytics.v1.DeleteSalesTargetResponse
+import openpos.analytics.v1.CategorySalesItem
 import openpos.analytics.v1.GetAbcAnalysisRequest
+import openpos.analytics.v1.GetCategorySalesReportRequest
+import openpos.analytics.v1.GetCategorySalesReportResponse
 import openpos.analytics.v1.GetAbcAnalysisResponse
 import openpos.analytics.v1.GetDailySalesRequest
 import openpos.analytics.v1.GetDailySalesResponse
@@ -450,6 +453,33 @@ class AnalyticsGrpcService : AnalyticsServiceGrpc.AnalyticsServiceImplBase() {
             .setCreatedAt(createdAt.toString())
             .setUpdatedAt(updatedAt.toString())
             .build()
+
+    override fun getCategorySalesReport(
+        request: GetCategorySalesReportRequest,
+        responseObserver: StreamObserver<GetCategorySalesReportResponse>,
+    ) {
+        tenantHelper.setupTenantContext()
+        val storeId = request.storeId.toUUID()
+        val (startDate, endDate) = request.dateRange.toDates()
+        val items = analyticsQueryService.getCategorySalesReport(storeId, startDate, endDate)
+
+        responseObserver.onNext(
+            GetCategorySalesReportResponse
+                .newBuilder()
+                .addAllItems(
+                    items.map { item ->
+                        CategorySalesItem
+                            .newBuilder()
+                            .setCategoryName(item.categoryName)
+                            .setTotalAmount(item.totalAmount)
+                            .setQuantitySold(item.quantitySold)
+                            .setTransactionCount(item.transactionCount)
+                            .build()
+                    },
+                ).build(),
+        )
+        responseObserver.onCompleted()
+    }
 
     private fun String.toUUID(): UUID =
         try {

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/AnalyticsQueryService.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/AnalyticsQueryService.kt
@@ -180,4 +180,32 @@ class AnalyticsQueryService {
             )
         }
     }
+
+
+    data class CategorySalesItem(
+        val categoryName: String,
+        val totalAmount: Long,
+        val quantitySold: Int,
+        val transactionCount: Int,
+    )
+
+    fun getCategorySalesReport(
+        storeId: UUID,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<CategorySalesItem> {
+        tenantFilterService.enableFilter()
+        val raw = productSalesRepository.findAggregatedByStoreAndDateRange(storeId, startDate, endDate)
+
+        return raw
+            .groupBy { it.categoryName.ifBlank { "\u672A\u5206\u985E" } }
+            .map { (categoryName, records) ->
+                CategorySalesItem(
+                    categoryName = categoryName,
+                    totalAmount = records.sumOf { it.totalAmount },
+                    quantitySold = records.sumOf { it.quantitySold },
+                    transactionCount = records.sumOf { it.transactionCount },
+                )
+            }.sortedByDescending { it.totalAmount }
+    }
 }

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TransactionResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TransactionResource.kt
@@ -136,7 +136,10 @@ class TransactionResource {
                 .setTransactionId(id)
                 .setProductId(body.productId)
                 .setQuantity(body.quantity)
-                .build()
+                .apply {
+                    body.customProductName?.let { setCustomProductName(it) }
+                    body.customProductPrice?.let { setCustomProductPrice(it) }
+                }.build()
         return grpc
             .withTenant(stub)
             .addTransactionItem(request)
@@ -309,8 +312,10 @@ data class CreateTransactionBody(
 )
 
 data class AddItemBody(
-    val productId: String,
+    val productId: String = "",
     val quantity: Int = 1,
+    val customProductName: String? = null,
+    val customProductPrice: Long? = null,
 )
 
 data class UpdateItemBody(

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StockTransferService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StockTransferService.kt
@@ -18,6 +18,8 @@ class StockTransferService {
 
     @Inject lateinit var organizationIdHolder: OrganizationIdHolder
 
+    @Inject lateinit var stockService: StockService
+
     @Transactional
     fun create(
         fromStoreId: UUID,
@@ -55,6 +57,18 @@ class StockTransferService {
         return Pair(items, total)
     }
 
+    fun listByStoreId(
+        storeId: UUID,
+        status: String?,
+        page: Int,
+        pageSize: Int,
+    ): Pair<List<StockTransferEntity>, Long> {
+        tenantFilterService.enableFilter()
+        val items = stockTransferRepository.listByStoreId(storeId, status, Page.of(page, pageSize))
+        val total = stockTransferRepository.countByStoreId(storeId, status)
+        return Pair(items, total)
+    }
+
     @Transactional
     fun updateStatus(
         id: UUID,
@@ -66,4 +80,62 @@ class StockTransferService {
         stockTransferRepository.persist(entity)
         return entity
     }
+
+    /**
+     * 在庫移動を完了する。
+     * ステータスを COMPLETED に変更し、移動元店舗から在庫を減少、移動先店舗に在庫を増加させる。
+     */
+    @Transactional
+    fun complete(id: UUID): StockTransferEntity {
+        tenantFilterService.enableFilter()
+        val entity =
+            stockTransferRepository.findById(id)
+                ?: throw IllegalArgumentException("StockTransfer not found: $id")
+        require(entity.status == "PENDING" || entity.status == "IN_TRANSIT") {
+            "Cannot complete transfer with status: ${entity.status}"
+        }
+
+        val transferItems = parseItems(entity.items)
+        for (item in transferItems) {
+            stockService.adjustStock(
+                storeId = entity.fromStoreId,
+                productId = item.productId,
+                quantityChange = -item.quantity,
+                movementType = "TRANSFER",
+                referenceId = entity.id.toString(),
+                note = "Stock transfer to store ${entity.toStoreId}",
+            )
+            stockService.adjustStock(
+                storeId = entity.toStoreId,
+                productId = item.productId,
+                quantityChange = item.quantity,
+                movementType = "TRANSFER",
+                referenceId = entity.id.toString(),
+                note = "Stock transfer from store ${entity.fromStoreId}",
+            )
+        }
+
+        entity.status = "COMPLETED"
+        stockTransferRepository.persist(entity)
+        return entity
+    }
+
+    internal fun parseItems(json: String): List<TransferItem> {
+        val items = mutableListOf<TransferItem>()
+        val regex = Regex(""""productId"\s*:\s*"([^"]+)"\s*,\s*"quantity"\s*:\s*(\d+)""")
+        for (match in regex.findAll(json)) {
+            items.add(
+                TransferItem(
+                    productId = UUID.fromString(match.groupValues[1]),
+                    quantity = match.groupValues[2].toInt(),
+                ),
+            )
+        }
+        return items
+    }
 }
+
+data class TransferItem(
+    val productId: UUID,
+    val quantity: Int,
+)

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/entity/TransactionItemEntity.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/entity/TransactionItemEntity.kt
@@ -24,8 +24,8 @@ class TransactionItemEntity : BaseEntity() {
     @Column(name = "transaction_id", nullable = false)
     lateinit var transactionId: UUID
 
-    @Column(name = "product_id", nullable = false)
-    lateinit var productId: UUID
+    @Column(name = "product_id", nullable = true)
+    var productId: UUID? = null
 
     @Column(name = "product_name", nullable = false, length = 255)
     lateinit var productName: String

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -142,10 +142,24 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         tenantHelper.setupTenantContext()
         val quantity = if (request.quantity > 0) request.quantity else 1
         try {
-            // gRPC外部呼び出しを@Transactional外で実行（デッドロック防止 #608）
-            val productId = request.productId.toUUID()
-            val orgId = requireNotNull(tenantHelper.organizationIdHolder.organizationId) { "organizationId is not set" }
-            val snapshot = transactionService.fetchProductSnapshot(productId, orgId)
+            val isCustom = request.customProductName.isNotBlank()
+            val productId: UUID
+            val snapshot: ProductSnapshot
+            if (isCustom) {
+                productId = UUID.randomUUID()
+                snapshot =
+                    ProductSnapshot(
+                        name = request.customProductName,
+                        price = request.customProductPrice,
+                        taxRateName = "標準税率",
+                        taxRate = "0.10",
+                        isReduced = false,
+                    )
+            } else {
+                productId = request.productId.toUUID()
+                val orgId = requireNotNull(tenantHelper.organizationIdHolder.organizationId) { "organizationId is not set" }
+                snapshot = transactionService.fetchProductSnapshot(productId, orgId)
+            }
 
             val entity =
                 transactionService.addItem(

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ProductServiceClient.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ProductServiceClient.kt
@@ -111,6 +111,33 @@ class ProductServiceClient {
         )
     }
 
+    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 10000)
+    @Retry(maxRetries = 2, delay = 500)
+    fun getTaxRateSnapshot(
+        taxRateId: UUID,
+        organizationId: UUID,
+    ): TaxRateSnapshot {
+        val stub =
+            ProductServiceGrpc
+                .newBlockingStub(channel)
+                .withDeadlineAfter(GRPC_DEADLINE_SECONDS, TimeUnit.SECONDS)
+                .withInterceptors(TenantHeaderInterceptor(organizationId))
+
+        val taxRatesResponse = stub.listTaxRates(ListTaxRatesRequest.getDefaultInstance())
+        val matched: TaxRate =
+            taxRatesResponse.taxRatesList.firstOrNull { it.id == taxRateId.toString() }
+                ?: throw StatusRuntimeException(
+                    io.grpc.Status.NOT_FOUND
+                        .withDescription("Tax rate not found: $taxRateId"),
+                )
+
+        return TaxRateSnapshot(
+            name = matched.name,
+            rate = matched.rate,
+            isReduced = matched.isReduced,
+        )
+    }
+
     /**
      * クーポンコードを検証し、紐付く割引情報を取得する。
      */
@@ -313,4 +340,10 @@ data class DiscountInfo(
     val name: String,
     val discountType: String,
     val value: String,
+)
+
+data class TaxRateSnapshot(
+    val name: String,
+    val rate: String,
+    val isReduced: Boolean,
 )

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/StoreServiceClient.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/StoreServiceClient.kt
@@ -10,7 +10,9 @@ import io.grpc.MethodDescriptor
 import io.quarkus.grpc.GrpcClient
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import openpos.common.v1.PaginationRequest
 import openpos.store.v1.GetOrganizationRequest
+import openpos.store.v1.ListStaffRequest
 import openpos.store.v1.StoreServiceGrpc
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -47,6 +49,34 @@ class StoreServiceClient {
             )
         val invoiceNumber = response.organization.invoiceNumber
         return invoiceNumber.ifBlank { null }
+    }
+
+    fun getStaffNameMap(
+        organizationId: UUID,
+        storeId: UUID,
+    ): Map<UUID, String> {
+        val stub =
+            StoreServiceGrpc
+                .newBlockingStub(channel)
+                .withDeadlineAfter(GRPC_DEADLINE_SECONDS, TimeUnit.SECONDS)
+                .withInterceptors(TenantHeaderInterceptor(organizationId))
+
+        val response =
+            stub.listStaff(
+                ListStaffRequest
+                    .newBuilder()
+                    .setStoreId(storeId.toString())
+                    .setPagination(
+                        PaginationRequest
+                            .newBuilder()
+                            .setPage(1)
+                            .setPageSize(100)
+                            .build(),
+                    ).build(),
+            )
+        return response.staffList.associate { staff ->
+            UUID.fromString(staff.id) to staff.name
+        }
     }
 
     private class TenantHeaderInterceptor(

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
@@ -50,6 +50,29 @@ class TransactionRepository : PanacheRepositoryBase<TransactionEntity, UUID> {
         return count(query, params)
     }
 
+    @Suppress("UNCHECKED_CAST")
+    fun aggregateStaffSales(
+        storeId: UUID,
+        startDate: Instant,
+        endDate: Instant,
+    ): List<Array<Any>> =
+        getEntityManager()
+            .createQuery(
+                """
+                SELECT t.staffId, COUNT(t), SUM(t.total)
+                FROM TransactionEntity t
+                WHERE t.storeId = :storeId
+                  AND t.status = 'COMPLETED'
+                  AND t.createdAt >= :startDate
+                  AND t.createdAt <= :endDate
+                GROUP BY t.staffId
+                """.trimIndent(),
+                Array::class.java,
+            ).setParameter("storeId", storeId)
+            .setParameter("startDate", startDate)
+            .setParameter("endDate", endDate)
+            .resultList as List<Array<Any>>
+
     private fun buildFilterQuery(
         storeId: UUID?,
         terminalId: UUID?,

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -17,6 +17,7 @@ import com.openpos.pos.grpc.InvalidInputException
 import com.openpos.pos.grpc.ProductServiceClient
 import com.openpos.pos.grpc.ProductSnapshot
 import com.openpos.pos.grpc.ResourceNotFoundException
+import com.openpos.pos.grpc.TaxRateSnapshot
 import com.openpos.pos.repository.PaymentRepository
 import com.openpos.pos.repository.TaxSummaryRepository
 import com.openpos.pos.repository.TransactionDiscountRepository
@@ -149,6 +150,11 @@ class TransactionService {
         organizationId: UUID,
     ): ProductSnapshot = productServiceClient.getProductSnapshot(productId, organizationId)
 
+    fun fetchTaxRateSnapshot(
+        taxRateId: UUID,
+        organizationId: UUID,
+    ): TaxRateSnapshot = productServiceClient.getTaxRateSnapshot(taxRateId, organizationId)
+
     /**
      * 取引に商品を追加する。
      *
@@ -208,6 +214,43 @@ class TransactionService {
                 }
             itemRepository.persist(item)
         }
+
+        recalculateTransactionTotals(tx)
+        return tx
+    }
+
+    @Transactional
+    fun addCustomItem(
+        transactionId: UUID,
+        productName: String,
+        unitPrice: Long,
+        quantity: Int,
+        taxRateSnapshot: TaxRateSnapshot,
+    ): TransactionEntity {
+        if (quantity <= 0) throw InvalidInputException("quantity must be positive")
+        if (unitPrice < 0) throw InvalidInputException("unit price must not be negative")
+        if (productName.isBlank()) throw InvalidInputException("custom product name must not be blank")
+
+        val tx = getWritableTransaction(transactionId)
+        val orgId = tx.organizationId
+
+        val taxResult = taxCalculationService.calculateItemTax(unitPrice, quantity, taxRateSnapshot.rate)
+        val item =
+            TransactionItemEntity().apply {
+                this.organizationId = orgId
+                this.transactionId = transactionId
+                this.productId = null
+                this.productName = productName
+                this.unitPrice = unitPrice
+                this.quantity = quantity
+                this.taxRateName = taxRateSnapshot.name
+                this.taxRate = taxRateSnapshot.rate
+                this.isReducedTax = taxRateSnapshot.isReduced
+                this.subtotal = taxResult.subtotal
+                this.taxAmount = taxResult.taxAmount
+                this.total = taxResult.total
+            }
+        itemRepository.persist(item)
 
         recalculateTransactionTotals(tx)
         return tx
@@ -821,7 +864,8 @@ class TransactionService {
                 append(tx.discountTotal)
                 append(tx.total)
                 items.sortedBy { it.id }.forEach { item ->
-                    append(item.productId)
+                    append(item.productId?.toString().orEmpty())
+                    append(item.productName)
                     append(item.quantity)
                     append(item.unitPrice)
                     append(item.subtotal)
@@ -844,7 +888,7 @@ class TransactionService {
                 items =
                     items.map { item ->
                         SaleItemDto(
-                            productId = item.productId.toString(),
+                            productId = item.productId?.toString().orEmpty(),
                             productName = item.productName,
                             quantity = item.quantity,
                             unitPrice = item.unitPrice,
@@ -878,7 +922,7 @@ class TransactionService {
                 items =
                     items.map { item ->
                         SaleItemDto(
-                            productId = item.productId.toString(),
+                            productId = item.productId?.toString().orEmpty(),
                             productName = item.productName,
                             quantity = item.quantity,
                             unitPrice = item.unitPrice,


### PR DESCRIPTION
## Summary
カスタム商品（アドホック入力）機能を実装。商品マスタ未登録の商品を手入力で販売可能に。

### API変更
`POST /api/transactions/{id}/items` のリクエストボディに追加:
- `customProductName`: カスタム商品名
- `customProductPrice`: カスタム商品価格（銭単位）

`productId` が空で `customProductName` が設定されている場合、商品マスタを参照せずにアイテムを追加。

## Test plan
- [x] pos-service + api-gateway build pass

Closes #1024