### PR TITLE
fix: harden analytics event consumers (#1074)

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumer.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumer.kt
@@ -11,7 +11,9 @@ import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.eclipse.microprofile.reactive.messaging.Message
 import org.eclipse.microprofile.reactive.messaging.Metadata
 import org.jboss.logging.Logger
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.CompletionStage
+import io.vertx.core.json.JsonObject
 
 /**
  * analytics-service の Dead Letter Queue コンシューマー。
@@ -44,9 +46,9 @@ class DeadLetterQueueConsumer {
     }
 
     @Incoming("dlq-analytics-sale-completed")
-    fun onDlqSaleCompleted(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
+    fun onDlqSaleCompleted(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = message.payload
+            val body = payloadAsString(message.payload)
             handleDeadLetter(body, "analytics.sale-completed") { retryMessage, delayMs ->
                 val metadata =
                     OutgoingRabbitMQMetadata
@@ -64,9 +66,9 @@ class DeadLetterQueueConsumer {
         }
 
     @Incoming("dlq-analytics-sale-voided")
-    fun onDlqSaleVoided(message: IncomingRabbitMQMessage<String>): CompletionStage<Void> =
+    fun onDlqSaleVoided(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = message.payload
+            val body = payloadAsString(message.payload)
             handleDeadLetter(body, "analytics.sale-voided") { retryMessage, delayMs ->
                 val metadata =
                     OutgoingRabbitMQMetadata
@@ -81,6 +83,15 @@ class DeadLetterQueueConsumer {
         } catch (e: Exception) {
             log.errorf(e, "Failed to process DLQ analytics sale-voided message, sending nack")
             message.nack(e)
+        }
+
+    private fun payloadAsString(payload: Any?): String =
+        when (payload) {
+            null -> throw IllegalArgumentException("RabbitMQ payload is null")
+            is String -> payload
+            is ByteArray -> String(payload, StandardCharsets.UTF_8)
+            is JsonObject -> payload.encode()
+            else -> objectMapper.writeValueAsString(payload)
         }
 
     private fun handleDeadLetter(

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventConsumer.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventConsumer.kt
@@ -2,12 +2,15 @@ package com.openpos.analytics.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.smallrye.common.annotation.Blocking
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.jboss.logging.Logger
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 import java.util.concurrent.CompletionStage
+import io.vertx.core.json.JsonObject
 
 /**
  * RabbitMQ からイベントを受信し、冪等ハンドラー経由で処理する。
@@ -27,10 +30,11 @@ class EventConsumer {
 
     private val log = Logger.getLogger(EventConsumer::class.java)
 
+    @Blocking
     @Incoming("sale-completed-events")
     fun onSaleCompleted(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = message.payload.toString()
+            val body = payloadAsString(message.payload)
             val envelope = objectMapper.readValue(body, EventEnvelopeDto::class.java)
             val eventId = UUID.fromString(envelope.eventId)
 
@@ -47,10 +51,11 @@ class EventConsumer {
             message.nack(e)
         }
 
+    @Blocking
     @Incoming("sale-voided-events")
     fun onSaleVoided(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = message.payload.toString()
+            val body = payloadAsString(message.payload)
             val envelope = objectMapper.readValue(body, EventEnvelopeDto::class.java)
             val eventId = UUID.fromString(envelope.eventId)
 
@@ -65,5 +70,14 @@ class EventConsumer {
         } catch (e: Exception) {
             log.errorf(e, "Failed to process sale-voided event, sending nack")
             message.nack(e)
+        }
+
+    private fun payloadAsString(payload: Any?): String =
+        when (payload) {
+            null -> throw IllegalArgumentException("RabbitMQ payload is null")
+            is String -> payload
+            is ByteArray -> String(payload, StandardCharsets.UTF_8)
+            is JsonObject -> payload.encode()
+            else -> objectMapper.writeValueAsString(payload)
         }
 }

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumerTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/DeadLetterQueueConsumerTest.kt
@@ -3,6 +3,7 @@ package com.openpos.analytics.event
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
 import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata
+import io.vertx.core.json.JsonObject
 import org.eclipse.microprofile.reactive.messaging.Emitter
 import org.eclipse.microprofile.reactive.messaging.Message
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -38,8 +39,8 @@ class DeadLetterQueueConsumerTest {
         }
 
     @Suppress("UNCHECKED_CAST")
-    private fun mockMessage(body: String): IncomingRabbitMQMessage<String> {
-        val message = mock<IncomingRabbitMQMessage<String>>()
+    private fun mockMessage(body: Any): IncomingRabbitMQMessage<*> {
+        val message = mock<IncomingRabbitMQMessage<Any>>()
         whenever(message.payload).thenReturn(body)
         whenever(message.ack()).thenReturn(CompletableFuture.completedFuture(null))
         whenever(message.nack(any<Throwable>())).thenReturn(CompletableFuture.completedFuture(null))
@@ -103,6 +104,24 @@ class DeadLetterQueueConsumerTest {
         }
 
         @Test
+        fun `JsonObjectペイロードでもリトライできる`() {
+            // Arrange
+            val body = JsonObject(buildMessageBody(retryCount = 0))
+            val message = mockMessage(body)
+
+            // Act
+            consumer.onDlqSaleCompleted(message)
+
+            // Assert
+            val captor = argumentCaptor<Message<String>>()
+            verify(saleCompletedRetryEmitter).send(captor.capture())
+
+            val sentBody = objectMapper.readValue(captor.firstValue.payload, Map::class.java)
+            assertTrue(sentBody["retryCount"] == 1)
+            verify(message).ack()
+        }
+
+        @Test
         fun `最大リトライ回数到達後は再送しない`() {
             // Arrange
             val body = buildMessageBody(retryCount = 3)
@@ -147,6 +166,20 @@ class DeadLetterQueueConsumerTest {
         fun `初回リトライ時はsaleVoidedRetryEmitterにメッセージTTL付きで再送する`() {
             // Arrange
             val body = buildMessageBody(retryCount = 0)
+            val message = mockMessage(body)
+
+            // Act
+            consumer.onDlqSaleVoided(message)
+
+            // Assert
+            verify(saleVoidedRetryEmitter).send(any<Message<String>>())
+            verify(message).ack()
+        }
+
+        @Test
+        fun `JsonObjectペイロードでもsaleVoidedRetryEmitterに再送する`() {
+            // Arrange
+            val body = JsonObject(buildMessageBody(retryCount = 0))
             val message = mockMessage(body)
 
             // Act

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/EventConsumerTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/event/EventConsumerTest.kt
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.smallrye.common.annotation.Blocking
 import io.vertx.core.json.JsonObject
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -14,6 +16,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.lang.reflect.Method
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
@@ -155,6 +158,17 @@ class EventConsumerTest {
     @Nested
     inner class OnSaleCompleted {
         @Test
+        fun `onSaleCompletedはblockingで実行される`() {
+            val method: Method =
+                EventConsumer::class.java.getDeclaredMethod(
+                    "onSaleCompleted",
+                    IncomingRabbitMQMessage::class.java,
+                )
+
+            assertTrue(method.isAnnotationPresent(Blocking::class.java))
+        }
+
+        @Test
         fun `正常なJSONでprocessSaleCompletedが呼ばれる`() {
             // Arrange
             val json = buildSaleCompletedJson()
@@ -201,6 +215,17 @@ class EventConsumerTest {
 
     @Nested
     inner class OnSaleVoided {
+        @Test
+        fun `onSaleVoidedはblockingで実行される`() {
+            val method: Method =
+                EventConsumer::class.java.getDeclaredMethod(
+                    "onSaleVoided",
+                    IncomingRabbitMQMessage::class.java,
+                )
+
+            assertTrue(method.isAnnotationPresent(Blocking::class.java))
+        }
+
         @Test
         fun `正常なJSONでprocessSaleVoidedが呼ばれる`() {
             // Arrange


### PR DESCRIPTION
## Summary
- move analytics event consumption off the IO thread with @Blocking on the sale event handlers
- accept non-String RabbitMQ payloads in the analytics DLQ consumer and normalize them before retry handling
- add regression tests for the blocking annotations and JsonObject DLQ payloads

## Verification
- git diff --check
- /bin/zsh -lc 'PATH="/opt/homebrew/bin:/opt/homebrew/opt/openjdk@21/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Users/nakayamaryuuukei/.codex/tmp/arg0/codex-arg0xLeG1O:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/nakayamaryuuukei/go/bin:/Users/nakayamaryuuukei/.local/bin:/opt/homebrew/opt/postgresql@17/bin:/Users/nakayamaryuuukei/.vscode/extensions/vscjava.vscode-java-debug-0.58.5/bundled/scripts/noConfigScripts" JAVA_HOME="/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home" GRADLE_USER_HOME="/Users/nakayamaryuuukei/work/private-code/open-pos/.gradle-home" ./gradlew :services:analytics-service:test --tests "com.openpos.analytics.event.EventConsumerTest" --tests "com.openpos.analytics.event.DeadLetterQueueConsumerTest"'

Closes #1074