### PR TITLE
build: prune stale Quarkus runner jars (#1076)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.Delete
+
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.allopen) apply false
@@ -28,11 +30,25 @@ subprojects {
         }
 
         afterEvaluate {
+            val deleteStaleRunnerJars =
+                tasks.register<Delete>("deleteStaleRunnerJars") {
+                    delete(
+                        fileTree(layout.buildDirectory) {
+                            include("${project.name}-*-runner.jar")
+                            exclude("${project.name}-${project.version}-runner.jar")
+                        },
+                    )
+                }
+
             dependencies {
                 "implementation"(rootProject.libs.quarkus.logging.json)
                 "testImplementation"(rootProject.libs.testcontainers)
                 "testImplementation"(rootProject.libs.testcontainers.postgresql)
                 "testImplementation"(rootProject.libs.testcontainers.junit.jupiter)
+            }
+
+            tasks.matching { it.name == "quarkusBuild" }.configureEach {
+                dependsOn(deleteStaleRunnerJars)
             }
 
             apply(plugin = "jacoco")


### PR DESCRIPTION
## Summary
- delete stale service runner jars whose version no longer matches the current project version
- make quarkusBuild depend on that cleanup so branch switches and version bumps stop leaving misleading runner artifacts behind
- keep the current runner jar untouched so incremental quarkusBuild stays fast while old jars disappear

## Verification
- git diff --check
- /bin/zsh -lc 'PATH="/opt/homebrew/bin:/opt/homebrew/opt/openjdk@21/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Users/nakayamaryuuukei/.codex/tmp/arg0/codex-arg0xLeG1O:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/nakayamaryuuukei/go/bin:/Users/nakayamaryuuukei/.local/bin:/opt/homebrew/opt/postgresql@17/bin:/Users/nakayamaryuuukei/.vscode/extensions/vscjava.vscode-java-debug-0.58.5/bundled/scripts/noConfigScripts" JAVA_HOME="/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home" GRADLE_USER_HOME="/Users/nakayamaryuuukei/work/private-code/open-pos/.gradle-home" ./gradlew :services:pos-service:quarkusBuild -Dquarkus.package.jar.type=uber-jar'
- ls services/pos-service/build | rg 'runner.jar|quarkus-artifact.properties'
- jar tf services/pos-service/build/pos-service-1.0.0-runner.jar | rg 'db/migration/'

Closes #1076