### PR TITLE
fix(inventory-service): keep tenant context available outside request scope

### DIFF
--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/config/OrganizationIdHolder.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/config/OrganizationIdHolder.kt
@@ -1,13 +1,28 @@
 package com.openpos.inventory.config
 
-import jakarta.enterprise.context.RequestScoped
+import jakarta.enterprise.context.ApplicationScoped
 import java.util.UUID
 
 /**
- * リクエストスコープで organization_id を保持する CDI bean。
- * gRPC Interceptor から設定され、TenantFilterService で参照される。
+ * 現在の実行スレッドに紐づく organization_id を保持する。
+ * inventory-service では gRPC worker や RabbitMQ consumer からも参照されるため、
+ * RequestScoped ではなく thread-local で扱う。
  */
-@RequestScoped
+@ApplicationScoped
 class OrganizationIdHolder {
-    var organizationId: UUID? = null
+    private val currentOrganizationId = ThreadLocal<UUID?>()
+
+    var organizationId: UUID?
+        get() = currentOrganizationId.get()
+        set(value) {
+            if (value == null) {
+                currentOrganizationId.remove()
+            } else {
+                currentOrganizationId.set(value)
+            }
+        }
+
+    fun clear() {
+        currentOrganizationId.remove()
+    }
 }

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/config/OrganizationIdInterceptor.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/config/OrganizationIdInterceptor.kt
@@ -10,6 +10,7 @@ import io.grpc.ServerInterceptor
 import io.grpc.Status
 import io.quarkus.grpc.GlobalInterceptor
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import org.jboss.logging.Logger
 import java.util.UUID
 
@@ -23,6 +24,9 @@ import java.util.UUID
 @ApplicationScoped
 @GlobalInterceptor
 class OrganizationIdInterceptor : ServerInterceptor {
+    @Inject
+    lateinit var organizationIdHolder: OrganizationIdHolder
+
     companion object {
         private val LOG: Logger = Logger.getLogger(OrganizationIdInterceptor::class.java)
 
@@ -106,13 +110,15 @@ class OrganizationIdInterceptor : ServerInterceptor {
                 .withValue(ORGANIZATION_ID_CTX_KEY, orgId)
                 .withValue(REQUEST_ID_CTX_KEY, requestId)
         val delegate = Contexts.interceptCall(ctx, call, headers, next)
-        return MdcCleanupListener(delegate)
+        return MdcCleanupListener(delegate, organizationIdHolder)
     }
 
     private class MdcCleanupListener<ReqT>(
         delegate: ServerCall.Listener<ReqT>,
+        private val organizationIdHolder: OrganizationIdHolder,
     ) : SimpleForwardingServerCallListener<ReqT>(delegate) {
         private fun cleanupMdc() {
+            organizationIdHolder.clear()
             org.jboss.logging.MDC
                 .remove("requestId")
             org.jboss.logging.MDC

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/StockEventProcessor.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/StockEventProcessor.kt
@@ -22,16 +22,20 @@ class StockEventProcessor {
         payload: SaleCompletedPayload,
     ) {
         organizationIdHolder.organizationId = organizationId
-        val storeId = UUID.fromString(payload.storeId)
-        for (item in payload.items) {
-            stockService.adjustStock(
-                storeId = storeId,
-                productId = UUID.fromString(item.productId),
-                quantityChange = -item.quantity,
-                movementType = "SALE",
-                referenceId = payload.transactionId,
-                note = null,
-            )
+        try {
+            val storeId = UUID.fromString(payload.storeId)
+            for (item in payload.items) {
+                stockService.adjustStock(
+                    storeId = storeId,
+                    productId = UUID.fromString(item.productId),
+                    quantityChange = -item.quantity,
+                    movementType = "SALE",
+                    referenceId = payload.transactionId,
+                    note = null,
+                )
+            }
+        } finally {
+            organizationIdHolder.clear()
         }
     }
 
@@ -40,16 +44,20 @@ class StockEventProcessor {
         payload: SaleVoidedPayload,
     ) {
         organizationIdHolder.organizationId = organizationId
-        val storeId = UUID.fromString(payload.storeId)
-        for (item in payload.items) {
-            stockService.adjustStock(
-                storeId = storeId,
-                productId = UUID.fromString(item.productId),
-                quantityChange = item.quantity,
-                movementType = "RETURN",
-                referenceId = payload.voidTransactionId,
-                note = "Void of transaction ${payload.originalTransactionId}",
-            )
+        try {
+            val storeId = UUID.fromString(payload.storeId)
+            for (item in payload.items) {
+                stockService.adjustStock(
+                    storeId = storeId,
+                    productId = UUID.fromString(item.productId),
+                    quantityChange = item.quantity,
+                    movementType = "RETURN",
+                    referenceId = payload.voidTransactionId,
+                    note = "Void of transaction ${payload.originalTransactionId}",
+                )
+            }
+        } finally {
+            organizationIdHolder.clear()
         }
     }
 }

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/event/StockEventProcessorTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/event/StockEventProcessorTest.kt
@@ -1,11 +1,14 @@
 package com.openpos.inventory.event
 
+import com.openpos.inventory.config.OrganizationIdHolder
 import com.openpos.inventory.entity.StockEntity
 import com.openpos.inventory.service.StockService
 import io.quarkus.test.InjectMock
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -20,6 +23,9 @@ class StockEventProcessorTest {
     @Inject
     lateinit var stockEventProcessor: StockEventProcessor
 
+    @Inject
+    lateinit var organizationIdHolder: OrganizationIdHolder
+
     @InjectMock
     lateinit var stockService: StockService
 
@@ -27,6 +33,11 @@ class StockEventProcessorTest {
     private val storeId = UUID.randomUUID()
     private val productId1 = UUID.randomUUID()
     private val productId2 = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        organizationIdHolder.clear()
+    }
 
     @Test
     fun `processSaleCompleted decreases stock for each item`() {
@@ -68,6 +79,7 @@ class StockEventProcessorTest {
             referenceId = eq("txn-001"),
             note = eq(null),
         )
+        assertNull(organizationIdHolder.organizationId)
     }
 
     @Test
@@ -108,5 +120,6 @@ class StockEventProcessorTest {
             referenceId = eq("void-001"),
             note = eq("Void of transaction txn-001"),
         )
+        assertNull(organizationIdHolder.organizationId)
     }
 }

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/grpc/InventoryGrpcServiceContextTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/grpc/InventoryGrpcServiceContextTest.kt
@@ -1,0 +1,121 @@
+package com.openpos.inventory.grpc
+
+import com.openpos.inventory.config.OrganizationIdInterceptor
+import com.openpos.inventory.config.TenantFilterService
+import com.openpos.inventory.entity.StockEntity
+import com.openpos.inventory.entity.StockMovementEntity
+import com.openpos.inventory.event.StockLowEventPublisher
+import com.openpos.inventory.repository.StockMovementRepository
+import com.openpos.inventory.repository.StockRepository
+import io.grpc.Context
+import io.grpc.stub.StreamObserver
+import io.quarkus.arc.Arc
+import io.quarkus.grpc.GrpcService
+import io.quarkus.test.InjectMock
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import openpos.inventory.v1.AdjustStockRequest
+import openpos.inventory.v1.AdjustStockResponse
+import openpos.inventory.v1.MovementType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.UUID
+
+@QuarkusTest
+class InventoryGrpcServiceContextTest {
+    @Inject
+    @GrpcService
+    lateinit var grpcService: InventoryGrpcService
+
+    @InjectMock
+    lateinit var stockRepository: StockRepository
+
+    @InjectMock
+    lateinit var movementRepository: StockMovementRepository
+
+    @InjectMock
+    lateinit var tenantFilterService: TenantFilterService
+
+    @InjectMock
+    lateinit var stockLowEventPublisher: StockLowEventPublisher
+
+    private val orgId = UUID.randomUUID()
+    private val storeId = UUID.randomUUID()
+    private val productId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        doNothing().whenever(stockRepository).persist(any<StockEntity>())
+        doNothing().whenever(movementRepository).persist(any<StockMovementEntity>())
+        doNothing().whenever(tenantFilterService).enableFilter()
+        doNothing().whenever(stockLowEventPublisher).publish(any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `adjustStock works even when request context is inactive`() {
+        val existingStock =
+            StockEntity().apply {
+                id = UUID.randomUUID()
+                organizationId = orgId
+                storeId = this@InventoryGrpcServiceContextTest.storeId
+                productId = this@InventoryGrpcServiceContextTest.productId
+                quantity = 10
+                updatedAt = Instant.now()
+            }
+        whenever(stockRepository.findByStoreAndProductForUpdate(storeId, productId)).thenReturn(existingStock)
+
+        val request =
+            AdjustStockRequest
+                .newBuilder()
+                .setStoreId(storeId.toString())
+                .setProductId(productId.toString())
+                .setQuantityChange(5)
+                .setMovementType(MovementType.MOVEMENT_TYPE_RECEIPT)
+                .setReferenceId("po-001")
+                .setNote("restock")
+                .build()
+        val observer = CapturingObserver<AdjustStockResponse>()
+
+        val requestContext = Arc.container().requestContext()
+        if (requestContext.isActive) {
+            requestContext.terminate()
+        }
+
+        val grpcContext =
+            Context
+                .current()
+                .withValue(OrganizationIdInterceptor.ORGANIZATION_ID_CTX_KEY, orgId)
+        grpcContext.run(
+            Runnable {
+                grpcService.adjustStock(request, observer)
+            },
+        )
+
+        assertTrue(observer.completed)
+        assertEquals(15, observer.value!!.stock.quantity)
+        verify(stockRepository).persist(any<StockEntity>())
+        verify(movementRepository).persist(any<StockMovementEntity>())
+    }
+
+    private class CapturingObserver<T> : StreamObserver<T> {
+        var value: T? = null
+        var completed = false
+
+        override fun onNext(value: T) {
+            this.value = value
+        }
+
+        override fun onError(t: Throwable): Unit = throw AssertionError("Unexpected error", t)
+
+        override fun onCompleted() {
+            completed = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace inventory-service tenant holder request scope with thread-local application scope
- clear tenant context after gRPC calls and RabbitMQ event processing
- add regression coverage for event cleanup and gRPC adjustStock without an active request context

## Testing
- git diff --check
- ./gradlew :services:inventory-service:test --tests "com.openpos.inventory.grpc.InventoryGrpcServiceContextTest" --tests "com.openpos.inventory.event.StockEventProcessorTest"

## Notes
- Closes #1082
- While verifying clean seed, I found a separate local-demo first-write deadline problem and filed #1083 instead of mixing it into this PR
