### PR TITLE
docs(readme): fix Quarkus version mismatch (3.32 → 3.34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pnpm demo:assets
 
 | カテゴリ | 技術 |
 | --- | --- |
-| バックエンド | Kotlin 2.3 / Quarkus 3.32 / GraalVM CE 21 / Gradle 9 |
+| バックエンド | Kotlin 2.3 / Quarkus 3.34 / GraalVM CE 21 / Gradle 9.4 |
 | フロントエンド | React 19 / TypeScript / Vite 7 / Tailwind CSS + shadcn/ui |
 | データベース | PostgreSQL 17（スキーマ分離、Flyway マイグレーション） |
 | キャッシュ | Redis 7（Lettuce、cache-aside パターン） |


### PR DESCRIPTION
## Summary
- Quarkus 3.32 → 3.34 (actual: 3.34.1 in libs.versions.toml)
- Gradle 9 → 9.4 (actual: 9.4.1 in gradle-wrapper.properties)

Closes #1104