### PR TITLE
docs: add CodeQL, version, coverage, and test count badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![Security](https://github.com/akaitigo/open-pos/actions/workflows/security.yml/badge.svg)](https://github.com/akaitigo/open-pos/actions/workflows/security.yml)
 [![Release Drafter](https://github.com/akaitigo/open-pos/actions/workflows/release-drafter.yml/badge.svg)](https://github.com/akaitigo/open-pos/actions/workflows/release-drafter.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![CodeQL](https://github.com/akaitigo/open-pos/actions/workflows/codeql.yml/badge.svg)](https://github.com/akaitigo/open-pos/actions/workflows/codeql.yml)
+[![GitHub release](https://img.shields.io/github/v/release/akaitigo/open-pos)](https://github.com/akaitigo/open-pos/releases/latest)
+[![Coverage](https://img.shields.io/badge/coverage-95%25+-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-1800+-blue)]()
 
 Production-ready な汎用 POS（Point of Sale）システム。マルチテナント・オフライン対応のマイクロサービスアーキテクチャ。
 


### PR DESCRIPTION
## Summary
- CodeQL、バージョン、カバレッジ（95%+）、テスト数（1800+）のバッジを README に追加
- 既存バッジ（CI, Security, Release Drafter, License）の直後に配置
- テストカバレッジとテスト数は外部サービス不要の静的バッジで対応

Closes #1107