### PR TITLE
docs: add ER diagrams and sequence diagrams (Mermaid)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ This directory contains the project design, runbooks, product requirements, and 
 - [architecture/data-model.md](architecture/data-model.md): key entities and storage model
 - [architecture/event-driven.md](architecture/event-driven.md): messaging and event flow
 - [architecture/offline-strategy.md](architecture/offline-strategy.md): offline sync design
+- [architecture/sequence-diagrams.md](architecture/sequence-diagrams.md): key flow sequence diagrams (POS checkout, offline sync, PIN auth)
 
 ## Requirements and Planning
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -5,6 +5,49 @@
 
 ## store_schema
 
+```mermaid
+erDiagram
+    organizations ||--o{ stores : "has"
+    organizations ||--o{ terminals : "has"
+    organizations ||--o{ staff : "has"
+    stores ||--o{ terminals : "placed in"
+    stores ||--o{ staff : "works at"
+
+    organizations {
+        UUID id PK
+        VARCHAR name
+        VARCHAR business_type "RETAIL / RESTAURANT / OTHER"
+        VARCHAR invoice_number UK
+        VARCHAR plan
+        TIMESTAMPTZ deleted_at
+    }
+    stores {
+        UUID id PK
+        UUID organization_id FK
+        VARCHAR code UK
+        VARCHAR name
+        JSONB settings
+        BOOLEAN is_active
+    }
+    terminals {
+        UUID id PK
+        UUID organization_id FK
+        UUID store_id FK
+        VARCHAR terminal_code UK
+        TIMESTAMPTZ last_sync_at
+        BOOLEAN is_active
+    }
+    staff {
+        UUID id PK
+        UUID organization_id FK
+        UUID store_id FK
+        VARCHAR hydra_subject UK
+        VARCHAR name
+        VARCHAR role "OWNER / MANAGER / CASHIER"
+        VARCHAR pin_hash
+    }
+```
+
 ### organizations
 | カラム | 型 | 制約 |
 |--------|-----|------|
@@ -53,6 +96,59 @@
 | pin_locked_until | TIMESTAMPTZ | |
 
 ## product_schema
+
+```mermaid
+erDiagram
+    categories ||--o{ categories : "parent"
+    categories ||--o{ products : "contains"
+    tax_rates ||--o{ products : "applied to"
+    discounts ||--o{ coupons : "linked to"
+
+    categories {
+        UUID id PK
+        UUID organization_id
+        UUID parent_id FK "NULL = root"
+        VARCHAR name
+        VARCHAR color
+        INT display_order
+    }
+    tax_rates {
+        UUID id PK
+        UUID organization_id
+        VARCHAR name
+        DECIMAL rate
+        VARCHAR tax_type "STANDARD / REDUCED"
+        BOOLEAN is_active
+    }
+    products {
+        UUID id PK
+        UUID organization_id
+        UUID category_id FK
+        UUID tax_rate_id FK
+        VARCHAR name
+        VARCHAR barcode UK
+        VARCHAR sku UK
+        BIGINT price
+        BOOLEAN is_active
+    }
+    discounts {
+        UUID id PK
+        UUID organization_id
+        VARCHAR name
+        VARCHAR discount_type "PERCENTAGE / FIXED_AMOUNT"
+        BIGINT value
+        VARCHAR applies_to "TRANSACTION / PRODUCT"
+        BOOLEAN is_active
+    }
+    coupons {
+        UUID id PK
+        UUID organization_id
+        UUID discount_id FK
+        VARCHAR code UK
+        INT max_uses
+        INT used_count
+    }
+```
 
 ### categories
 | カラム | 型 | 制約 |
@@ -116,6 +212,64 @@
 | valid_until | TIMESTAMPTZ | |
 
 ## pos_schema
+
+```mermaid
+erDiagram
+    transactions ||--o{ transaction_items : "contains"
+    transactions ||--o{ payments : "paid by"
+    transactions ||--o{ transaction_tax_summaries : "tax breakdown"
+    transactions ||--o| receipts : "receipt"
+    transactions ||--o| transactions : "return of"
+
+    transactions {
+        UUID id PK
+        UUID organization_id
+        UUID store_id
+        UUID terminal_id
+        UUID staff_id
+        UUID client_id UK "idempotency key"
+        VARCHAR transaction_number UK
+        VARCHAR status "PENDING / COMPLETED / VOIDED / RETURNED"
+        BIGINT gross_amount
+        BIGINT discount_amount
+        BIGINT net_amount
+        BIGINT tax_amount
+        UUID original_transaction_id FK "return ref"
+    }
+    transaction_items {
+        UUID id PK
+        UUID transaction_id FK
+        UUID product_id
+        VARCHAR product_name "snapshot"
+        BIGINT unit_price "snapshot"
+        DECIMAL tax_rate "snapshot"
+        INT quantity
+        BIGINT subtotal
+        BIGINT discount_amount
+    }
+    payments {
+        UUID id PK
+        UUID transaction_id FK
+        VARCHAR payment_method "CASH / CREDIT_CARD / QR"
+        BIGINT amount
+        BIGINT received_amount
+        BIGINT change_amount
+    }
+    transaction_tax_summaries {
+        UUID id PK
+        UUID transaction_id FK
+        UUID tax_rate_id FK
+        DECIMAL tax_rate "snapshot"
+        BIGINT taxable_amount
+        BIGINT tax_amount
+    }
+    receipts {
+        UUID id PK
+        UUID transaction_id FK
+        TEXT pdf_url
+        TIMESTAMPTZ generated_at
+    }
+```
 
 ### transactions
 | カラム | 型 | 制約 |
@@ -183,6 +337,36 @@
 
 ## inventory_schema
 
+```mermaid
+erDiagram
+    stocks ||--o{ stock_movements : "tracked by"
+    purchase_orders {
+        UUID id PK
+        UUID organization_id
+        UUID store_id
+        VARCHAR status "DRAFT / ORDERED / RECEIVED / CANCELLED"
+        TIMESTAMPTZ ordered_at
+        TIMESTAMPTZ received_at
+    }
+    stocks {
+        UUID id PK
+        UUID organization_id
+        UUID store_id
+        UUID product_id
+        INT quantity
+        INT alert_threshold
+        BIGINT version "optimistic lock"
+    }
+    stock_movements {
+        UUID id PK
+        UUID organization_id
+        UUID stock_id FK
+        VARCHAR movement_type "SALE / RETURN / RECEIPT / ADJUSTMENT / TRANSFER"
+        INT quantity_delta
+        UUID reference_id "transaction ID etc."
+    }
+```
+
 ### stocks
 | カラム | 型 | 制約 |
 |--------|-----|------|
@@ -218,6 +402,42 @@
 | note | TEXT | |
 
 ## analytics_schema
+
+```mermaid
+erDiagram
+    daily_sales {
+        UUID id PK
+        UUID organization_id
+        UUID store_id
+        DATE date
+        BIGINT gross_amount
+        BIGINT net_amount
+        BIGINT tax_amount
+        INT transaction_count
+        BIGINT cash_amount
+        BIGINT card_amount
+        BIGINT qr_amount
+    }
+    product_sales {
+        UUID id PK
+        UUID organization_id
+        UUID store_id
+        UUID product_id
+        DATE date
+        INT quantity_sold
+        BIGINT gross_amount
+        BIGINT net_amount
+    }
+    hourly_sales {
+        UUID id PK
+        UUID organization_id
+        UUID store_id
+        DATE date
+        SMALLINT hour "0-23"
+        INT transaction_count
+        BIGINT net_amount
+    }
+```
 
 ### daily_sales
 | カラム | 型 | 制約 |

--- a/docs/architecture/sequence-diagrams.md
+++ b/docs/architecture/sequence-diagrams.md
@@ -1,0 +1,157 @@
+# シーケンス図
+
+主要フローの Mermaid シーケンス図。
+
+## POS 会計フロー
+
+POS端末からの取引確定の一連の流れ。pos-service が取引を記録し、RabbitMQ 経由で inventory-service（在庫減算）と analytics-service（集計更新）に非同期通知する。
+
+```mermaid
+sequenceDiagram
+    actor Cashier as レジ担当
+    participant POS as POS Terminal<br/>(React PWA)
+    participant GW as api-gateway
+    participant PS as pos-service
+    participant PD as product-service
+    participant INV as inventory-service
+    participant MQ as RabbitMQ
+    participant AN as analytics-service
+
+    Cashier->>POS: 商品スキャン / 数量入力
+    POS->>GW: GET /api/products/{barcode}
+    GW->>PD: gRPC GetProduct
+    PD-->>GW: Product (price, tax_rate)
+    GW-->>POS: 商品情報
+
+    Cashier->>POS: 会計確定
+    POS->>POS: client_id (UUID) 生成（冪等性キー）
+    POS->>GW: POST /api/transactions
+    GW->>PS: gRPC CreateTransaction
+
+    PS->>PS: 税額計算 (銭単位 BIGINT)
+    PS->>PS: Transaction + Items + Payment 保存
+    PS->>PS: Receipt PDF 生成
+    PS-->>GW: TransactionResponse
+    GW-->>POS: 201 Created
+
+    PS--)MQ: sale.completed
+
+    par 在庫更新
+        MQ--)INV: sale.completed
+        INV->>INV: 冪等性チェック (event_id)
+        INV->>INV: stock.quantity 減算 (楽観的ロック)
+        opt quantity <= alert_threshold
+            INV--)MQ: stock.low
+        end
+    and 売上集計
+        MQ--)AN: sale.completed
+        AN->>AN: 冪等性チェック (event_id)
+        AN->>AN: daily_sales / product_sales / hourly_sales UPSERT
+    end
+
+    POS->>Cashier: レシート表示
+```
+
+## オフライン同期フロー
+
+ネットワーク切断中は IndexedDB に取引を保存し、復帰時に Service Worker の Background Sync で自動送信する。`client_id` による冪等性でリトライが安全に行われる。
+
+```mermaid
+sequenceDiagram
+    actor Cashier as レジ担当
+    participant POS as POS Terminal<br/>(React PWA)
+    participant IDB as IndexedDB<br/>(Dexie.js)
+    participant SW as Service Worker
+    participant GW as api-gateway
+    participant PS as pos-service
+
+    Note over POS: ネットワーク切断
+
+    Cashier->>POS: 会計確定（オフライン）
+    POS->>POS: client_id (UUID) 生成
+    POS->>IDB: pendingTransactions に保存<br/>syncStatus = "pending"
+    POS->>Cashier: レシート表示（ローカル生成）
+
+    Note over POS: さらに取引が続く...
+    Cashier->>POS: 会計確定（オフライン）
+    POS->>IDB: pendingTransactions に保存
+
+    Note over POS,GW: ネットワーク復帰
+
+    POS->>POS: online イベント検知
+    POS->>SW: sync 登録 (tag: "sync-transactions")
+
+    SW->>IDB: syncStatus = "pending" を全件取得
+    loop 未同期トランザクションごと
+        SW->>GW: POST /api/sync/transactions
+        GW->>PS: gRPC CreateTransaction
+        PS->>PS: client_id で冪等性チェック
+        alt 新規取引
+            PS->>PS: Transaction 保存 + イベント発行
+            PS-->>GW: 201 Created (serverId)
+        else 重複 (client_id 既存)
+            PS-->>GW: 200 OK (既存の serverId)
+        end
+        GW-->>SW: レスポンス
+        alt 同期成功
+            SW->>IDB: pendingTransaction 削除
+        else 同期失敗
+            SW->>IDB: syncStatus = "failed"<br/>retryCount++
+            opt retryCount >= 5
+                SW->>IDB: syncStatus = "error"
+                SW->>POS: スタッフに手動確認を通知
+            end
+        end
+    end
+
+    par マスタデータ同期
+        SW->>GW: GET /api/sync/master?since={lastSyncAt}
+        GW-->>SW: 差分データ (products, categories, ...)
+        SW->>IDB: bulkPut で差分更新
+        SW->>IDB: syncMetadata.lastSyncAt 更新
+    end
+```
+
+## PIN 認証フロー
+
+POS端末のスタッフ認証。ORY Hydra の OAuth2/OIDC とは別に、端末上での簡易切り替えとして PIN コードを使用する。PIN ハッシュは store-service 側で検証し、成功時に JWT を発行する。
+
+```mermaid
+sequenceDiagram
+    actor Staff as スタッフ
+    participant POS as POS Terminal<br/>(React PWA)
+    participant GW as api-gateway
+    participant SS as store-service
+    participant DB as PostgreSQL<br/>(store_schema)
+
+    Staff->>POS: PIN 入力 (4-6桁)
+    POS->>GW: POST /api/auth/pin<br/>{terminal_id, pin}
+    GW->>SS: gRPC VerifyPin
+
+    SS->>DB: SELECT staff WHERE store_id = terminal.store_id
+    DB-->>SS: staff レコード
+
+    alt pin_locked_until > NOW()
+        SS-->>GW: FAILED_PRECONDITION<br/>"アカウントロック中"
+        GW-->>POS: 423 Locked
+        POS->>Staff: ロック中エラー表示
+    else PIN 照合
+        SS->>SS: bcrypt.verify(pin, pin_hash)
+        alt PIN 一致
+            SS->>DB: pin_failed_count = 0 に更新
+            SS->>SS: JWT 生成<br/>(sub, role, store_id, terminal_id)
+            SS-->>GW: VerifyPinResponse (token, staff)
+            GW-->>POS: 200 OK {token, staff}
+            POS->>POS: JWT をメモリ保持
+            POS->>Staff: ログイン成功 / レジ画面表示
+        else PIN 不一致
+            SS->>DB: pin_failed_count++ 更新
+            opt pin_failed_count >= 5
+                SS->>DB: pin_locked_until = NOW() + 15min
+            end
+            SS-->>GW: UNAUTHENTICATED<br/>"PIN が正しくありません"
+            GW-->>POS: 401 Unauthorized
+            POS->>Staff: 認証失敗<br/>残り試行回数表示
+        end
+    end
+```


### PR DESCRIPTION
## Summary

- 5スキーマ（store, product, pos, inventory, analytics）のMermaid ER図を `docs/architecture/data-model.md` に追加
- 主要3フローのMermaidシーケンス図を `docs/architecture/sequence-diagrams.md` に新規作成
  - POS会計フロー（商品スキャン → 取引確定 → RabbitMQ → 在庫/集計更新）
  - オフライン同期フロー（IndexedDB保存 → Service Worker Background Sync → 冪等同期）
  - PIN認証フロー（PIN検証 → bcrypt照合 → JWT発行 / ロックアウト）
- `docs/README.md` にシーケンス図へのリンクを追加

既存ドキュメントのテキスト内容は一切変更なし。Mermaidブロックの追加のみ。

Closes #1105

## Test plan

- [ ] GitHub上で `docs/architecture/data-model.md` を開き、5つのER図がレンダリングされることを確認
- [ ] GitHub上で `docs/architecture/sequence-diagrams.md` を開き、3つのシーケンス図がレンダリングされることを確認
- [ ] `docs/README.md` のリンクからシーケンス図に遷移できることを確認