### PR TITLE
fix(inventory): apply statusFilter when listing stock transfers without storeId

### DIFF
--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/grpc/InventoryGrpcService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/grpc/InventoryGrpcService.kt
@@ -625,7 +625,7 @@ class InventoryGrpcService : InventoryServiceGrpc.InventoryServiceImplBase() {
                     pageSize = pageSize,
                 )
             } else {
-                stockTransferService.list(page = page, pageSize = pageSize)
+                stockTransferService.list(status = statusFilter, page = page, pageSize = pageSize)
             }
         val totalPages = if (totalCount > 0) ((totalCount + pageSize - 1) / pageSize).toInt() else 0
         responseObserver.onNext(

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/repository/StockTransferRepository.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/repository/StockTransferRepository.kt
@@ -9,7 +9,25 @@ import java.util.UUID
 
 @ApplicationScoped
 class StockTransferRepository : PanacheRepositoryBase<StockTransferEntity, UUID> {
-    fun listPaginated(page: Page): List<StockTransferEntity> = findAll(Sort.descending("createdAt")).page(page).list()
+    fun listPaginated(
+        status: String?,
+        page: Page,
+    ): List<StockTransferEntity> {
+        val query =
+            if (status != null) {
+                find("status = ?1", Sort.descending("createdAt"), status)
+            } else {
+                findAll(Sort.descending("createdAt"))
+            }
+        return query.page(page).list()
+    }
+
+    fun countByStatus(status: String?): Long =
+        if (status != null) {
+            count("status = ?1", status)
+        } else {
+            count()
+        }
 
     fun listByStoreId(
         storeId: UUID,

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StockTransferService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StockTransferService.kt
@@ -48,12 +48,13 @@ class StockTransferService {
     }
 
     fun list(
+        status: String?,
         page: Int,
         pageSize: Int,
     ): Pair<List<StockTransferEntity>, Long> {
         tenantFilterService.enableFilter()
-        val items = stockTransferRepository.listPaginated(Page.of(page, pageSize))
-        val total = stockTransferRepository.count()
+        val items = stockTransferRepository.listPaginated(status, Page.of(page, pageSize))
+        val total = stockTransferRepository.countByStatus(status)
         return Pair(items, total)
     }
 

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StockTransferServiceTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StockTransferServiceTest.kt
@@ -104,7 +104,7 @@ class StockTransferServiceTest {
     @Nested
     inner class ListTransfers {
         @Test
-        fun `returns paginated results`() {
+        fun `returns paginated results without status filter`() {
             val items =
                 listOf(
                     StockTransferEntity().apply {
@@ -116,14 +116,39 @@ class StockTransferServiceTest {
                         status = "PENDING"
                     },
                 )
-            whenever(stockTransferRepository.listPaginated(any<Page>())).thenReturn(items)
-            whenever(stockTransferRepository.count()).thenReturn(1L)
+            whenever(stockTransferRepository.listPaginated(eq(null), any<Page>())).thenReturn(items)
+            whenever(stockTransferRepository.countByStatus(eq(null))).thenReturn(1L)
 
-            val (result, total) = service.list(0, 20)
+            val (result, total) = service.list(null, 0, 20)
 
             assertEquals(1, result.size)
             assertEquals(1L, total)
             verify(tenantFilterService).enableFilter()
+        }
+
+        @Test
+        fun `returns paginated results with status filter`() {
+            val items =
+                listOf(
+                    StockTransferEntity().apply {
+                        id = UUID.randomUUID()
+                        organizationId = orgId
+                        fromStoreId = UUID.randomUUID()
+                        toStoreId = UUID.randomUUID()
+                        this.items = "[]"
+                        status = "PENDING"
+                    },
+                )
+            whenever(stockTransferRepository.listPaginated(eq("PENDING"), any<Page>())).thenReturn(items)
+            whenever(stockTransferRepository.countByStatus(eq("PENDING"))).thenReturn(1L)
+
+            val (result, total) = service.list("PENDING", 0, 20)
+
+            assertEquals(1, result.size)
+            assertEquals(1L, total)
+            verify(tenantFilterService).enableFilter()
+            verify(stockTransferRepository).listPaginated(eq("PENDING"), any<Page>())
+            verify(stockTransferRepository).countByStatus(eq("PENDING"))
         }
     }
 


### PR DESCRIPTION
## Summary
- `ListStockTransfers` の `storeId` 未指定時に `statusFilter` が無視されるバグを修正
- `StockTransferRepository.listPaginated()` に `status` パラメータを追加し、ステータスによるフィルタクエリを実装
- `StockTransferService.list()` に `status` パラメータを伝播
- `InventoryGrpcService` の分岐で `statusFilter` を常に渡すよう修正

## Changes
- `StockTransferRepository`: `listPaginated(status, page)` と `countByStatus(status)` を追加
- `StockTransferService.list()`: `status: String?` パラメータを追加
- `InventoryGrpcService.listStockTransfers()`: else 分岐で `statusFilter` を渡す
- テスト: status フィルタありなし両方のケースを追加

## Test plan
- [x] `./gradlew :services:inventory-service:build` パス
- [x] `./gradlew :services:inventory-service:test --rerun` 全テストパス
- [ ] CI パス

Closes #1131