### PR TITLE
fix(pos): staff sales report completedAt filter & inactive discount reasons

### DIFF
--- a/proto/openpos/pos/v1/pos.proto
+++ b/proto/openpos/pos/v1/pos.proto
@@ -840,7 +840,10 @@ message DiscountReason {
   string updated_at = 7;
 }
 
-message ListDiscountReasonsRequest {}
+message ListDiscountReasonsRequest {
+  // When true, include inactive (disabled) discount reasons in the response.
+  bool include_inactive = 1;
+}
 
 message ListDiscountReasonsResponse {
   repeated DiscountReason discount_reasons = 1;

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -1266,7 +1266,12 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContext()
         try {
-            val reasons = discountReasonService.listActive()
+            val reasons =
+                if (request.includeInactive) {
+                    discountReasonService.listAll()
+                } else {
+                    discountReasonService.listActive()
+                }
             responseObserver.onNext(
                 openpos.pos.v1.ListDiscountReasonsResponse
                     .newBuilder()

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/DiscountReasonRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/DiscountReasonRepository.kt
@@ -9,5 +9,7 @@ import java.util.UUID
 class DiscountReasonRepository : PanacheRepositoryBase<DiscountReasonEntity, UUID> {
     fun findActive(): List<DiscountReasonEntity> = list("isActive = true")
 
+    fun findAllOrdered(): List<DiscountReasonEntity> = list("ORDER BY createdAt DESC")
+
     fun findByCode(code: String): DiscountReasonEntity? = find("code = ?1", code).firstResult()
 }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
@@ -78,8 +78,8 @@ class TransactionRepository : PanacheRepositoryBase<TransactionEntity, UUID> {
                 FROM TransactionEntity t
                 WHERE t.storeId = :storeId
                   AND t.status = 'COMPLETED'
-                  AND t.createdAt >= :startDate
-                  AND t.createdAt <= :endDate
+                  AND t.completedAt >= :startDate
+                  AND t.completedAt <= :endDate
                 GROUP BY t.staffId
                 """.trimIndent(),
                 Array::class.java,

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/DiscountReasonService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/DiscountReasonService.kt
@@ -29,6 +29,11 @@ class DiscountReasonService {
         return discountReasonRepository.findActive()
     }
 
+    fun listAll(): List<DiscountReasonEntity> {
+        tenantFilterService.enableFilter()
+        return discountReasonRepository.findAllOrdered()
+    }
+
     @Transactional
     fun create(
         code: String,

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceTest.kt
@@ -95,4 +95,33 @@ class DiscountReasonServiceTest {
         assertEquals(1, result.size)
         assertEquals("PROMO", result[0].code)
     }
+
+    @Test
+    fun `listAll should return all reasons including inactive`() {
+        val active =
+            DiscountReasonEntity().apply {
+                id = UUID.randomUUID()
+                organizationId = testOrgId
+                code = "PROMO"
+                description = "キャンペーン"
+                isActive = true
+            }
+        val inactive =
+            DiscountReasonEntity().apply {
+                id = UUID.randomUUID()
+                organizationId = testOrgId
+                code = "OLD_PROMO"
+                description = "旧キャンペーン"
+                isActive = false
+            }
+        whenever(discountReasonRepository.findAllOrdered()).thenReturn(listOf(active, inactive))
+
+        val result = discountReasonService.listAll()
+
+        assertEquals(2, result.size)
+        assertEquals("PROMO", result[0].code)
+        assertEquals(true, result[0].isActive)
+        assertEquals("OLD_PROMO", result[1].code)
+        assertEquals(false, result[1].isActive)
+    }
 }

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceUnitTest.kt
@@ -120,4 +120,36 @@ class DiscountReasonServiceUnitTest {
             assertEquals("PROMO", result[0].code)
         }
     }
+
+    @Nested
+    inner class ListAll {
+        @Test
+        fun `returns all reasons including inactive`() {
+            val active =
+                DiscountReasonEntity().apply {
+                    this.id = UUID.randomUUID()
+                    this.organizationId = orgId
+                    this.code = "PROMO"
+                    this.description = "キャンペーン"
+                    this.isActive = true
+                }
+            val inactive =
+                DiscountReasonEntity().apply {
+                    this.id = UUID.randomUUID()
+                    this.organizationId = orgId
+                    this.code = "OLD_PROMO"
+                    this.description = "旧キャンペーン"
+                    this.isActive = false
+                }
+            whenever(discountReasonRepository.findAllOrdered()).thenReturn(listOf(active, inactive))
+
+            val result = service.listAll()
+
+            assertEquals(2, result.size)
+            assertEquals("PROMO", result[0].code)
+            assertEquals(true, result[0].isActive)
+            assertEquals("OLD_PROMO", result[1].code)
+            assertEquals(false, result[1].isActive)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- **#1130**: Staff sales report query was filtering by `createdAt` instead of `completedAt`, causing transactions to be grouped by creation time rather than completion time. Fixed the JPQL query in `TransactionRepository.aggregateStaffSales()`.
- **#1132**: `ListDiscountReasons` RPC only returned active reasons, making it impossible to view/audit disabled discount reasons. Added `include_inactive` field to `ListDiscountReasonsRequest` proto, with corresponding `listAll()` method in service layer.

## Changes
- `TransactionRepository.kt`: `createdAt` -> `completedAt` in staff sales aggregation query
- `pos.proto`: Added `bool include_inactive = 1` to `ListDiscountReasonsRequest`
- `DiscountReasonRepository.kt`: Added `findAllOrdered()` method
- `DiscountReasonService.kt`: Added `listAll()` method
- `PosGrpcService.kt`: Branch on `request.includeInactive` in `listDiscountReasons()`
- Unit & functional tests added for `listAll` behavior

## Test plan
- [x] `./gradlew :services:pos-service:build` passes (includes all tests + JaCoCo coverage)
- [x] `buf lint` passes
- [x] New unit test: `DiscountReasonServiceUnitTest.ListAll`
- [x] New functional test: `DiscountReasonServiceTest.listAll should return all reasons including inactive`

Closes #1130, Closes #1132