### PR TITLE
fix(product): add tenant validation on variant creation

### DIFF
--- a/services/product-service/src/main/kotlin/com/openpos/product/service/ProductVariantService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/ProductVariantService.kt
@@ -3,6 +3,7 @@ package com.openpos.product.service
 import com.openpos.product.config.OrganizationIdHolder
 import com.openpos.product.config.TenantFilterService
 import com.openpos.product.entity.ProductVariantEntity
+import com.openpos.product.repository.ProductRepository
 import com.openpos.product.repository.ProductVariantRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -12,6 +13,9 @@ import jakarta.transaction.Transactional
 class ProductVariantService {
     @Inject
     lateinit var variantRepository: ProductVariantRepository
+
+    @Inject
+    lateinit var productRepository: ProductRepository
 
     @Inject
     lateinit var tenantFilterService: TenantFilterService
@@ -39,6 +43,14 @@ class ProductVariantService {
         displayOrder: Int,
     ): ProductVariantEntity {
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
+
+        // テナント検証: Hibernate Filter 有効状態で親商品を取得し、
+        // 他テナントの productId が指定された場合は null になるため NOT_FOUND として拒否する
+        tenantFilterService.enableFilter()
+        requireNotNull(productRepository.findById(productId)) {
+            "Product not found or belongs to another tenant: $productId"
+        }
+
         val entity =
             ProductVariantEntity().apply {
                 this.organizationId = orgId

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/ProductVariantServiceUnitTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/ProductVariantServiceUnitTest.kt
@@ -2,7 +2,9 @@ package com.openpos.product.service
 
 import com.openpos.product.config.OrganizationIdHolder
 import com.openpos.product.config.TenantFilterService
+import com.openpos.product.entity.ProductEntity
 import com.openpos.product.entity.ProductVariantEntity
+import com.openpos.product.repository.ProductRepository
 import com.openpos.product.repository.ProductVariantRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -22,6 +24,7 @@ import java.util.UUID
 class ProductVariantServiceUnitTest {
     private lateinit var service: ProductVariantService
     private lateinit var variantRepository: ProductVariantRepository
+    private lateinit var productRepository: ProductRepository
     private lateinit var tenantFilterService: TenantFilterService
     private lateinit var organizationIdHolder: OrganizationIdHolder
 
@@ -31,17 +34,28 @@ class ProductVariantServiceUnitTest {
     @BeforeEach
     fun setUp() {
         variantRepository = mock()
+        productRepository = mock()
         tenantFilterService = mock()
         organizationIdHolder = OrganizationIdHolder()
 
         service = ProductVariantService()
         service.variantRepository = variantRepository
+        service.productRepository = productRepository
         service.tenantFilterService = tenantFilterService
         service.organizationIdHolder = organizationIdHolder
 
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
         doNothing().whenever(variantRepository).persist(any<ProductVariantEntity>())
+
+        // デフォルト: 親商品がテナント内に存在する
+        whenever(productRepository.findById(productId)).thenReturn(
+            ProductEntity().apply {
+                id = productId
+                organizationId = orgId
+                name = "テスト商品"
+            },
+        )
     }
 
     @Nested
@@ -101,6 +115,43 @@ class ProductVariantServiceUnitTest {
             assertThrows<IllegalArgumentException> {
                 service.create(productId, "Lサイズ", null, null, 10000L, 0)
             }
+        }
+
+        @Test
+        fun `throws when productId belongs to another tenant`() {
+            // Arrange — テナントフィルタ有効時に他テナントの product は null が返る
+            val otherTenantProductId = UUID.randomUUID()
+            whenever(productRepository.findById(otherTenantProductId)).thenReturn(null)
+
+            // Act & Assert
+            val exception =
+                assertThrows<IllegalArgumentException> {
+                    service.create(otherTenantProductId, "不正バリアント", null, null, 10000L, 0)
+                }
+            assertTrue(exception.message?.contains("Product not found or belongs to another tenant") == true)
+            verify(tenantFilterService).enableFilter()
+        }
+
+        @Test
+        fun `throws when productId does not exist`() {
+            // Arrange — 存在しない productId
+            val nonExistentProductId = UUID.randomUUID()
+            whenever(productRepository.findById(nonExistentProductId)).thenReturn(null)
+
+            // Act & Assert
+            assertThrows<IllegalArgumentException> {
+                service.create(nonExistentProductId, "存在しない商品のバリアント", null, null, 5000L, 0)
+            }
+        }
+
+        @Test
+        fun `enables tenant filter before validating parent product`() {
+            // Arrange & Act
+            service.create(productId, "フィルタ確認用", null, null, 10000L, 0)
+
+            // Assert — テナントフィルタが有効化されていることを確認
+            verify(tenantFilterService).enableFilter()
+            verify(productRepository).findById(productId)
         }
     }
 


### PR DESCRIPTION
## Summary
- **セキュリティ修正**: `ProductVariantService.create()` にテナント検証を追加
- バリアント作成前に `tenantFilterService.enableFilter()` + `productRepository.findById()` で親商品の所有権を検証
- 他テナントの `productId` を指定した場合は `IllegalArgumentException` で拒否
- `ProductService.create()` の `validateForeignKeyOwnership()` パターンに準拠

## Changes
- `ProductVariantService.kt`: `ProductRepository` を inject し、`create()` メソッドにテナントフィルタ付き親商品検証を追加
- `ProductVariantServiceUnitTest.kt`: 3つの新規テストケース追加
  - 他テナントの productId → 例外スロー
  - 存在しない productId → 例外スロー
  - テナントフィルタの有効化確認

## Test plan
- [x] `./gradlew :services:product-service:clean :services:product-service:build` がパス（203テスト全パス）
- [x] JaCoCo カバレッジ検証パス
- [x] 新規テスト3件が正しく動作確認済み
- [x] 既存テスト全件パス（デフォルトモックで親商品を返すように更新）

Closes #1133