### PR TITLE
fix(pos): allow null productId, fix date parsing, guard event consumers

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventDtos.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/EventDtos.kt
@@ -43,10 +43,11 @@ data class SaleVoidedPayload(
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class SaleItemPayload(
-    val productId: String,
+    val productId: String? = null,
     val quantity: Int,
     val unitPrice: Long,
     val subtotal: Long,
     val productName: String? = null,
+    val categoryId: String? = null,
     val categoryName: String? = null,
 )

--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/SalesEventProcessor.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/event/SalesEventProcessor.kt
@@ -52,12 +52,14 @@ class SalesEventProcessor {
         // 日次売上更新
         updateDailySales(organizationId, storeId, saleDate, payload.totalAmount, payload.taxTotal, payload.discountTotal, payload.payments)
 
-        // 商品別売上更新
+        // 商品別売上更新（カスタムアイテム = productId null/blank はスキップ）
         for (item in payload.items) {
+            val pid = item.productId
+            if (pid.isNullOrBlank()) continue
             updateProductSales(
                 organizationId,
                 storeId,
-                UUID.fromString(item.productId),
+                UUID.fromString(pid),
                 item.productName,
                 item.categoryName,
                 saleDate,
@@ -89,12 +91,14 @@ class SalesEventProcessor {
         val totalAmount = payload.items.sumOf { it.subtotal }
         rollbackDailySales(organizationId, storeId, originalDate, totalAmount)
 
-        // 商品別売上ロールバック
+        // 商品別売上ロールバック（カスタムアイテム = productId null/blank はスキップ）
         for (item in payload.items) {
+            val pid = item.productId
+            if (pid.isNullOrBlank()) continue
             rollbackProductSales(
                 organizationId,
                 storeId,
-                UUID.fromString(item.productId),
+                UUID.fromString(pid),
                 originalDate,
                 item.quantity,
                 item.subtotal,

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/EventDtos.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/EventDtos.kt
@@ -27,7 +27,7 @@ data class SaleVoidedPayload(
 )
 
 data class SaleItemPayload(
-    val productId: String,
+    val productId: String? = null,
     val quantity: Int,
     val unitPrice: Long,
     val subtotal: Long,

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/StockEventProcessor.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/StockEventProcessor.kt
@@ -25,9 +25,11 @@ class StockEventProcessor {
         try {
             val storeId = UUID.fromString(payload.storeId)
             for (item in payload.items) {
+                val pid = item.productId
+                if (pid.isNullOrBlank()) continue // カスタムアイテムは在庫操作不要
                 stockService.adjustStock(
                     storeId = storeId,
-                    productId = UUID.fromString(item.productId),
+                    productId = UUID.fromString(pid),
                     quantityChange = -item.quantity,
                     movementType = "SALE",
                     referenceId = payload.transactionId,
@@ -47,9 +49,11 @@ class StockEventProcessor {
         try {
             val storeId = UUID.fromString(payload.storeId)
             for (item in payload.items) {
+                val pid = item.productId
+                if (pid.isNullOrBlank()) continue // カスタムアイテムは在庫操作不要
                 stockService.adjustStock(
                     storeId = storeId,
-                    productId = UUID.fromString(item.productId),
+                    productId = UUID.fromString(pid),
                     quantityChange = item.quantity,
                     movementType = "RETURN",
                     referenceId = payload.voidTransactionId,

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/event/SaleCompletedEventDto.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/event/SaleCompletedEventDto.kt
@@ -22,7 +22,7 @@ data class SalePaymentDto(
 )
 
 data class SaleItemDto(
-    val productId: String,
+    val productId: String? = null,
     val productName: String,
     val quantity: Int,
     val unitPrice: Long,

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -79,6 +79,8 @@ import openpos.pos.v1.UpdateTransactionItemResponse
 import openpos.pos.v1.VoidTransactionRequest
 import openpos.pos.v1.VoidTransactionResponse
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.UUID
 
 @GrpcService
@@ -1215,8 +1217,8 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             require(request.dateRange.end.isNotBlank()) { "date_range.end is required" }
 
             val storeId = request.storeId.toUUID()
-            val startDate = Instant.parse(request.dateRange.start)
-            val endDate = Instant.parse(request.dateRange.end)
+            val startDate = parseInstantOrDate(request.dateRange.start)
+            val endDate = parseInstantOrDate(request.dateRange.end)
 
             val aggregated = transactionService.aggregateStaffSales(storeId, startDate, endDate)
 
@@ -1482,4 +1484,15 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             .setCreatedAt(createdAt.toString())
             .setUpdatedAt(updatedAt.toString())
             .build()
+
+    /**
+     * Instant 形式（ISO-8601）または日付文字列（YYYY-MM-DD）をパースして Instant を返す。
+     * 日付文字列の場合は UTC の開始時刻（00:00:00Z）に変換する。
+     */
+    private fun parseInstantOrDate(value: String): Instant =
+        try {
+            Instant.parse(value)
+        } catch (_: java.time.format.DateTimeParseException) {
+            LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant()
+        }
 }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -888,7 +888,7 @@ class TransactionService {
                 items =
                     items.map { item ->
                         SaleItemDto(
-                            productId = item.productId?.toString().orEmpty(),
+                            productId = item.productId?.toString(),
                             productName = item.productName,
                             quantity = item.quantity,
                             unitPrice = item.unitPrice,
@@ -931,7 +931,7 @@ class TransactionService {
                 items =
                     items.map { item ->
                         SaleItemDto(
-                            productId = item.productId?.toString().orEmpty(),
+                            productId = item.productId?.toString(),
                             productName = item.productName,
                             quantity = item.quantity,
                             unitPrice = item.unitPrice,

--- a/services/pos-service/src/main/resources/db/migration/V21__allow_null_product_id_on_transaction_items.sql
+++ b/services/pos-service/src/main/resources/db/migration/V21__allow_null_product_id_on_transaction_items.sql
@@ -1,0 +1,2 @@
+-- Issue #1138: Allow custom items (no product_id) in transaction_items
+ALTER TABLE pos_schema.transaction_items ALTER COLUMN product_id DROP NOT NULL;


### PR DESCRIPTION
## Summary
- **#1138**: `transaction_items.product_id` の NOT NULL 制約がカスタムアイテム（商品マスタに紐付かない手入力アイテム）の登録をブロックしていた。V21 マイグレーションで DROP NOT NULL を追加
- **#1139**: `GetStaffSalesReport` が `Instant.parse()` のみで日付文字列をパースしていたため、`YYYY-MM-DD` 形式の入力で `DateTimeParseException` が発生。`LocalDate.parse()` へのフォールバックを追加
- **#1142**: カスタムアイテム（productId=null）のイベントペイロードで空文字列が送信され、analytics-service と inventory-service の消費側で `UUID.fromString("")` がクラッシュ。productId を nullable にし、消費側で null/blank をスキップするガードを追加

## Changes
| File | Change |
|------|--------|
| `V21__allow_null_product_id_on_transaction_items.sql` | ALTER COLUMN product_id DROP NOT NULL |
| `PosGrpcService.kt` | `parseInstantOrDate()` ヘルパー追加、GetStaffSalesReport で使用 |
| `SaleCompletedEventDto.kt` | `SaleItemDto.productId` を `String?` に変更 |
| `TransactionService.kt` | `.orEmpty()` を除去、null をそのまま送信 |
| `analytics EventDtos.kt` | `SaleItemPayload.productId` を `String?` に変更 |
| `analytics SalesEventProcessor.kt` | productId null/blank 時に商品別集計をスキップ |
| `inventory EventDtos.kt` | `SaleItemPayload.productId` を `String?` に変更 |
| `inventory StockEventProcessor.kt` | productId null/blank 時に在庫操作をスキップ |

## Test plan
- [x] `./gradlew :services:pos-service:build` pass (テスト含む)
- [ ] CI で全サービスのビルドを確認

Closes #1138, Closes #1139, Closes #1142