### PR TITLE
fix(auth,accounting): callback route outside guard + date normalization

### DIFF
--- a/apps/admin-dashboard/src/App.tsx
+++ b/apps/admin-dashboard/src/App.tsx
@@ -68,6 +68,14 @@ export function App() {
     <ErrorBoundary>
       <BrowserRouter>
         <Routes>
+          <Route
+            path="callback"
+            element={
+              <Suspense fallback={<RouteLoading />}>
+                <CallbackPage />
+              </Suspense>
+            }
+          />
           <Route element={<Layout />}>
             <Route index element={<DashboardPage />} />
             <Route
@@ -203,14 +211,6 @@ export function App() {
               element={
                 <Suspense fallback={<RouteLoading />}>
                   <TerminalsPage />
-                </Suspense>
-              }
-            />
-            <Route
-              path="callback"
-              element={
-                <Suspense fallback={<RouteLoading />}>
-                  <CallbackPage />
                 </Suspense>
               }
             />

--- a/apps/pos-terminal/src/App.tsx
+++ b/apps/pos-terminal/src/App.tsx
@@ -24,6 +24,14 @@ export function App() {
     <ErrorBoundary>
       <BrowserRouter>
         <Routes>
+          <Route
+            path="callback"
+            element={
+              <Suspense fallback={<RouteLoading />}>
+                <CallbackPage />
+              </Suspense>
+            }
+          />
           <Route element={<Layout />}>
             <Route index element={<ProductsPage />} />
             <Route
@@ -39,14 +47,6 @@ export function App() {
               element={
                 <Suspense fallback={<RouteLoading />}>
                   <HistoryPage />
-                </Suspense>
-              }
-            />
-            <Route
-              path="callback"
-              element={
-                <Suspense fallback={<RouteLoading />}>
-                  <CallbackPage />
                 </Suspense>
               }
             />

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AccountingResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AccountingResource.kt
@@ -26,6 +26,18 @@ import org.eclipse.microprofile.faulttolerance.Timeout
 @Blocking
 @Timeout(30000)
 class AccountingResource {
+    companion object {
+        private val DATE_ONLY_REGEX = Regex("""\d{4}-\d{2}-\d{2}""")
+
+        /**
+         * YYYY-MM-DD 形式の日付文字列を RFC 3339 タイムスタンプに正規化する。
+         * 既に RFC 3339（T を含む）形式の場合はそのまま返す。
+         */
+        fun normalizeStart(date: String): String = if (DATE_ONLY_REGEX.matches(date)) "${date}T00:00:00Z" else date
+
+        fun normalizeEnd(date: String): String = if (DATE_ONLY_REGEX.matches(date)) "${date}T23:59:59.999Z" else date
+    }
+
     @Inject
     @GrpcClient("analytics-service")
     lateinit var analyticsStub: AnalyticsServiceGrpc.AnalyticsServiceBlockingStub
@@ -54,8 +66,8 @@ class AccountingResource {
                 .setDateRange(
                     DateRange
                         .newBuilder()
-                        .setStart(date)
-                        .setEnd(date)
+                        .setStart(normalizeStart(date))
+                        .setEnd(normalizeEnd(date))
                         .build(),
                 ).build()
         val response = grpc.withTenant(analyticsStub).getDailySales(request)
@@ -80,8 +92,8 @@ class AccountingResource {
                     .setDateRange(
                         DateRange
                             .newBuilder()
-                            .setStart(startDate)
-                            .setEnd(endDate)
+                            .setStart(normalizeStart(startDate))
+                            .setEnd(normalizeEnd(endDate))
                             .build(),
                     ).setPagination(
                         PaginationRequest


### PR DESCRIPTION
## Summary
- **#1145**: `/callback` ルートが `Layout` コンポーネント内にネストされていたため、OIDC コールバックが認証/セットアップガードにブロックされていた。`pos-terminal` と `admin-dashboard` の両方で callback ルートを Layout の外に移動。
- **#1146**: `AccountingResource` が `YYYY-MM-DD` 形式の日付文字列をそのまま gRPC `DateRange` に渡していたため、時刻情報がなく不正確なクエリになっていた。`normalizeStart`/`normalizeEnd` ヘルパーで RFC 3339 形式に正規化するよう修正。

## Changes
| File | Change |
|------|--------|
| `apps/pos-terminal/src/App.tsx` | `/callback` ルートを `<Layout />` の外に移動 |
| `apps/admin-dashboard/src/App.tsx` | 同上 |
| `services/api-gateway/.../AccountingResource.kt` | `normalizeStart`/`normalizeEnd` companion methods 追加、`exportDailySales`/`exportTransactions` で使用 |

## Test plan
- [x] `pnpm -r typecheck` pass
- [x] `pnpm -r lint` pass
- [x] `./gradlew :services:api-gateway:build` pass (includes tests + coverage)

Closes #1145, Closes #1146