### PR TITLE
fix(pos,analytics): endDate midnight truncation and category txn count inflation

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/AnalyticsQueryService.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/AnalyticsQueryService.kt
@@ -194,6 +194,11 @@ class AnalyticsQueryService {
     /**
      * カテゴリ別売上レポートを取得する。
      * category_id + category_name の組でグループ化し、同名の異なるカテゴリを区別する (#1141)。
+     *
+     * transactionCount は概算値: product_sales テーブルは日別×商品別の粒度で
+     * transaction_id を持たないため、正確なユニークトランザクション数は算出不可。
+     * 日別の最大 transactionCount を合計することで、同カテゴリ内の商品数による
+     * 水増しを防止している (#1148)。
      */
     fun getCategorySalesReport(
         storeId: UUID,
@@ -206,12 +211,18 @@ class AnalyticsQueryService {
         return raw
             .groupBy { Pair(it.categoryId, it.categoryName.ifBlank { "\u672A\u5206\u985E" }) }
             .map { (key, records) ->
+                // 日別にグループ化し、各日の最大 transactionCount を合計する（概算値）
+                val estimatedTxCount =
+                    records
+                        .groupBy { it.date }
+                        .values
+                        .sumOf { dayRecords -> dayRecords.maxOf { it.transactionCount } }
                 CategorySalesItem(
                     categoryId = key.first,
                     categoryName = key.second,
                     totalAmount = records.sumOf { it.totalAmount },
                     quantitySold = records.sumOf { it.quantitySold },
-                    transactionCount = records.sumOf { it.transactionCount },
+                    transactionCount = estimatedTxCount,
                 )
             }.sortedByDescending { it.totalAmount }
     }

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/service/CategorySalesReportTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/service/CategorySalesReportTest.kt
@@ -122,6 +122,72 @@ class CategorySalesReportTest {
         }
 
         @Test
+        fun `transactionCount uses daily max to avoid inflation from multiple products`() {
+            // Arrange: 2 products in same category on same day — transactionCount should be max, not sum
+            val catId = UUID.randomUUID()
+            val records =
+                listOf(
+                    createEntity(UUID.randomUUID(), "Coffee", catId, "Beverages", 100, 500000),
+                    createEntity(UUID.randomUUID(), "Tea", catId, "Beverages", 50, 200000),
+                )
+            whenever(productSalesRepository.findAggregatedByStoreAndDateRange(storeId, startDate, endDate))
+                .thenReturn(records)
+
+            // Act
+            val result = analyticsQueryService.getCategorySalesReport(storeId, startDate, endDate)
+
+            // Assert: transactionCount = max(100, 50) = 100, not sum(100 + 50) = 150
+            assertEquals(1, result.size)
+            assertEquals(100, result[0].transactionCount)
+            assertEquals(150, result[0].quantitySold) // quantitySold is still summed
+        }
+
+        @Test
+        fun `transactionCount sums daily max across multiple days`() {
+            // Arrange: same category, different days
+            val catId = UUID.randomUUID()
+            val day1Product =
+                ProductSalesEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    storeId = this@CategorySalesReportTest.storeId
+                    productId = UUID.randomUUID()
+                    productName = "Coffee"
+                    categoryId = catId
+                    categoryName = "Beverages"
+                    date = LocalDate.of(2026, 3, 1)
+                    quantitySold = 10
+                    totalAmount = 100000
+                    costAmount = 0
+                    transactionCount = 8
+                }
+            val day2Product =
+                ProductSalesEntity().apply {
+                    id = UUID.randomUUID()
+                    organizationId = orgId
+                    storeId = this@CategorySalesReportTest.storeId
+                    productId = UUID.randomUUID()
+                    productName = "Tea"
+                    categoryId = catId
+                    categoryName = "Beverages"
+                    date = LocalDate.of(2026, 3, 2)
+                    quantitySold = 5
+                    totalAmount = 50000
+                    costAmount = 0
+                    transactionCount = 3
+                }
+            whenever(productSalesRepository.findAggregatedByStoreAndDateRange(storeId, startDate, endDate))
+                .thenReturn(listOf(day1Product, day2Product))
+
+            // Act
+            val result = analyticsQueryService.getCategorySalesReport(storeId, startDate, endDate)
+
+            // Assert: transactionCount = max(8) + max(3) = 11
+            assertEquals(1, result.size)
+            assertEquals(11, result[0].transactionCount)
+        }
+
+        @Test
         fun `returns empty list when no data`() {
             // Arrange
             whenever(productSalesRepository.findAggregatedByStoreAndDateRange(storeId, startDate, endDate))

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -1218,7 +1218,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
 
             val storeId = request.storeId.toUUID()
             val startDate = parseInstantOrDate(request.dateRange.start)
-            val endDate = parseInstantOrDate(request.dateRange.end)
+            val endDate = parseInstantOrDateExclusive(request.dateRange.end)
 
             val aggregated = transactionService.aggregateStaffSales(storeId, startDate, endDate)
 
@@ -1488,11 +1488,28 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     /**
      * Instant 形式（ISO-8601）または日付文字列（YYYY-MM-DD）をパースして Instant を返す。
      * 日付文字列の場合は UTC の開始時刻（00:00:00Z）に変換する。
+     * startDate のパースに使用する（包含的下限）。
      */
     private fun parseInstantOrDate(value: String): Instant =
         try {
             Instant.parse(value)
         } catch (_: java.time.format.DateTimeParseException) {
             LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant()
+        }
+
+    /**
+     * endDate 用のパース関数。
+     * 日付文字列（YYYY-MM-DD）の場合は翌日の開始時刻に変換し、排他的上限として使用する。
+     * Instant 形式の場合はそのまま返す（呼び出し元が排他的上限として扱う）。
+     */
+    private fun parseInstantOrDateExclusive(value: String): Instant =
+        try {
+            Instant.parse(value)
+        } catch (_: java.time.format.DateTimeParseException) {
+            LocalDate
+                .parse(value)
+                .plusDays(1)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant()
         }
 }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/repository/TransactionRepository.kt
@@ -56,7 +56,7 @@ class TransactionRepository : PanacheRepositoryBase<TransactionEntity, UUID> {
         endDate: Instant,
     ): List<UUID> =
         find(
-            "storeId = :storeId AND status = :status AND completedAt >= :startDate AND completedAt <= :endDate",
+            "storeId = :storeId AND status = :status AND completedAt >= :startDate AND completedAt < :endDate",
             mapOf(
                 "storeId" to storeId,
                 "status" to "COMPLETED",
@@ -79,7 +79,7 @@ class TransactionRepository : PanacheRepositoryBase<TransactionEntity, UUID> {
                 WHERE t.storeId = :storeId
                   AND t.status = 'COMPLETED'
                   AND t.completedAt >= :startDate
-                  AND t.completedAt <= :endDate
+                  AND t.completedAt < :endDate
                 GROUP BY t.staffId
                 """.trimIndent(),
                 Array::class.java,


### PR DESCRIPTION
## Summary
- **#1147**: staff report の endDate が midnight (00:00:00Z) にパースされ、最終日のデータが欠落するバグを修正。`parseInstantOrDateExclusive` を追加し、日付文字列の場合は翌日 00:00:00Z に変換して排他的上限として使用。TransactionRepository のクエリも `<=` から `<` に変更。
- **#1148**: カテゴリ別売上レポートの transactionCount が、同カテゴリ内の商品数分だけ水増しされるバグを修正。`sumOf { transactionCount }` を日別 max の合計に変更。product_sales テーブルに transaction_id がないため正確な distinct count は不可能であり、概算値であることをコードコメントに明記。

## Changes
- `PosGrpcService.kt`: `parseInstantOrDateExclusive` 追加、`getStaffSalesReport` で使用
- `TransactionRepository.kt`: `findCompletedTransactionIds`, `aggregateStaffSales` の endDate 比較を `<` に変更
- `AnalyticsQueryService.kt`: `getCategorySalesReport` の transactionCount 集計を日別 max 合計に変更
- `CategorySalesReportTest.kt`: 新テスト2件追加（同日複数商品、複数日の集計）

## Test plan
- [x] `./gradlew :services:pos-service:build` pass
- [x] `./gradlew :services:analytics-service:build` pass
- [x] 新規テスト: 同日同カテゴリ複数商品で transactionCount が max になること
- [x] 新規テスト: 複数日にまたがる場合に日別 max の合計になること
- [x] 既存テスト全件 pass

Closes #1147, Closes #1148