### PR TITLE
fix(store,gateway): reject negative points, validate custom item price, fix daily sales date

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AccountingResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/AccountingResource.kt
@@ -66,8 +66,8 @@ class AccountingResource {
                 .setDateRange(
                     DateRange
                         .newBuilder()
-                        .setStart(normalizeStart(date))
-                        .setEnd(normalizeEnd(date))
+                        .setStart(date)
+                        .setEnd(date)
                         .build(),
                 ).build()
         val response = grpc.withTenant(analyticsStub).getDailySales(request)

--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TransactionResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/TransactionResource.kt
@@ -130,6 +130,11 @@ class TransactionResource {
         @PathParam("id") id: String,
         body: AddItemBody,
     ): Map<String, Any?> {
+        if (!body.customProductName.isNullOrBlank() && (body.customProductPrice == null || body.customProductPrice <= 0)) {
+            throw jakarta.ws.rs.BadRequestException(
+                "customProductPrice must be positive when customProductName is specified, got: ${body.customProductPrice}",
+            )
+        }
         val request =
             AddTransactionItemRequest
                 .newBuilder()

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/AccountingResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/AccountingResourceTest.kt
@@ -2,6 +2,7 @@ package com.openpos.gateway.resource
 
 import com.openpos.gateway.config.ForbiddenException
 import com.openpos.gateway.config.TenantContext
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -52,6 +53,29 @@ class AccountingResourceTest {
             assertThrows<ForbiddenException> {
                 resource.exportTransactions(storeId = "store-1", startDate = "2026-03-01", endDate = "2026-03-27")
             }
+        }
+    }
+
+    @Nested
+    inner class NormalizeDateHelpers {
+        @Test
+        fun `normalizeStartはYYYY-MM-DDをRFC3339に変換`() {
+            assertEquals("2026-03-27T00:00:00Z", AccountingResource.normalizeStart("2026-03-27"))
+        }
+
+        @Test
+        fun `normalizeStartはRFC3339をそのまま返す`() {
+            assertEquals("2026-03-27T10:30:00Z", AccountingResource.normalizeStart("2026-03-27T10:30:00Z"))
+        }
+
+        @Test
+        fun `normalizeEndはYYYY-MM-DDをRFC3339に変換`() {
+            assertEquals("2026-03-27T23:59:59.999Z", AccountingResource.normalizeEnd("2026-03-27"))
+        }
+
+        @Test
+        fun `normalizeEndはRFC3339をそのまま返す`() {
+            assertEquals("2026-03-27T23:59:59Z", AccountingResource.normalizeEnd("2026-03-27T23:59:59Z"))
         }
     }
 }

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/TransactionResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/TransactionResourceTest.kt
@@ -5,6 +5,7 @@ import com.openpos.gateway.config.GrpcClientHelper
 import com.openpos.gateway.config.TenantContext
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
+import jakarta.ws.rs.BadRequestException
 import openpos.common.v1.PaginationResponse
 import openpos.pos.v1.CreateTransactionResponse
 import openpos.pos.v1.FinalizeTransactionResponse
@@ -17,6 +18,7 @@ import openpos.pos.v1.TransactionStatus
 import openpos.pos.v1.TransactionType
 import openpos.pos.v1.VoidTransactionResponse
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -291,6 +293,48 @@ class TransactionResourceTest {
             assertThrows<StatusRuntimeException> {
                 resource.get("nonexistent")
             }
+        }
+    }
+
+    @Nested
+    inner class AddItemValidation {
+        @Test
+        fun `カスタムアイテムでprice=nullなら400`() {
+            // Arrange
+            val body = AddItemBody(customProductName = "手書き商品", customProductPrice = null)
+
+            // Act & Assert
+            val ex =
+                assertThrows<BadRequestException> {
+                    resource.addItem(txId, body)
+                }
+            assertTrue(ex.message?.contains("customProductPrice must be positive") == true)
+        }
+
+        @Test
+        fun `カスタムアイテムでprice=0なら400`() {
+            // Arrange
+            val body = AddItemBody(customProductName = "手書き商品", customProductPrice = 0)
+
+            // Act & Assert
+            val ex =
+                assertThrows<BadRequestException> {
+                    resource.addItem(txId, body)
+                }
+            assertTrue(ex.message?.contains("customProductPrice must be positive") == true)
+        }
+
+        @Test
+        fun `カスタムアイテムでprice負数なら400`() {
+            // Arrange
+            val body = AddItemBody(customProductName = "手書き商品", customProductPrice = -100)
+
+            // Act & Assert
+            val ex =
+                assertThrows<BadRequestException> {
+                    resource.addItem(txId, body)
+                }
+            assertTrue(ex.message?.contains("customProductPrice must be positive") == true)
         }
     }
 }

--- a/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/grpc/StoreGrpcService.kt
@@ -23,43 +23,39 @@ import io.quarkus.grpc.GrpcService
 import io.smallrye.common.annotation.Blocking
 import jakarta.inject.Inject
 import openpos.common.v1.PaginationResponse
-import openpos.store.v1.CreateCustomerRequest
-import openpos.store.v1.CreateCustomerResponse
-import openpos.store.v1.Customer
-import openpos.store.v1.CustomerTier
-import openpos.store.v1.EarnPointsRequest
-import openpos.store.v1.EarnPointsResponse
-import openpos.store.v1.GetCustomerRequest
-import openpos.store.v1.GetCustomerResponse
-import openpos.store.v1.ListCustomersRequest
-import openpos.store.v1.ListCustomersResponse
-import openpos.store.v1.RedeemPointsRequest
-import openpos.store.v1.RedeemPointsResponse
-import openpos.store.v1.UpdateCustomerRequest
-import openpos.store.v1.UpdateCustomerResponse
 import openpos.store.v1.AnonymizeCustomerDataRequest
 import openpos.store.v1.AnonymizeCustomerDataResponse
 import openpos.store.v1.AnonymizeStaffDataRequest
 import openpos.store.v1.AnonymizeStaffDataResponse
 import openpos.store.v1.AuthenticateByPinRequest
 import openpos.store.v1.AuthenticateByPinResponse
+import openpos.store.v1.CreateCustomerRequest
+import openpos.store.v1.CreateCustomerResponse
 import openpos.store.v1.CreateOrganizationRequest
 import openpos.store.v1.CreateOrganizationResponse
 import openpos.store.v1.CreateStaffRequest
 import openpos.store.v1.CreateStaffResponse
 import openpos.store.v1.CreateStoreRequest
 import openpos.store.v1.CreateStoreResponse
+import openpos.store.v1.Customer
+import openpos.store.v1.CustomerTier
 import openpos.store.v1.DataProcessingConsent
 import openpos.store.v1.DeleteOrganizationDataRequest
 import openpos.store.v1.DeleteOrganizationDataResponse
+import openpos.store.v1.EarnPointsRequest
+import openpos.store.v1.EarnPointsResponse
 import openpos.store.v1.GetConsentRequest
 import openpos.store.v1.GetConsentResponse
+import openpos.store.v1.GetCustomerRequest
+import openpos.store.v1.GetCustomerResponse
 import openpos.store.v1.GetOrganizationRequest
 import openpos.store.v1.GetOrganizationResponse
 import openpos.store.v1.GetStaffRequest
 import openpos.store.v1.GetStaffResponse
 import openpos.store.v1.GetStoreRequest
 import openpos.store.v1.GetStoreResponse
+import openpos.store.v1.ListCustomersRequest
+import openpos.store.v1.ListCustomersResponse
 import openpos.store.v1.ListStaffRequest
 import openpos.store.v1.ListStaffResponse
 import openpos.store.v1.ListStoresRequest
@@ -69,6 +65,8 @@ import openpos.store.v1.ListTerminalsResponse
 import openpos.store.v1.Organization
 import openpos.store.v1.RecordConsentRequest
 import openpos.store.v1.RecordConsentResponse
+import openpos.store.v1.RedeemPointsRequest
+import openpos.store.v1.RedeemPointsResponse
 import openpos.store.v1.RegisterTerminalRequest
 import openpos.store.v1.RegisterTerminalResponse
 import openpos.store.v1.Staff
@@ -76,6 +74,8 @@ import openpos.store.v1.StaffRole
 import openpos.store.v1.Store
 import openpos.store.v1.StoreServiceGrpc
 import openpos.store.v1.Terminal
+import openpos.store.v1.UpdateCustomerRequest
+import openpos.store.v1.UpdateCustomerResponse
 import openpos.store.v1.UpdateOrganizationRequest
 import openpos.store.v1.UpdateOrganizationResponse
 import openpos.store.v1.UpdateStaffRequest
@@ -591,6 +591,11 @@ class StoreGrpcService : StoreServiceGrpc.StoreServiceImplBase() {
         request: RedeemPointsRequest,
         responseObserver: io.grpc.stub.StreamObserver<RedeemPointsResponse>,
     ) {
+        if (request.points <= 0) {
+            throw Status.INVALID_ARGUMENT
+                .withDescription("points must be positive, got: ${request.points}")
+                .asRuntimeException()
+        }
         tenantHelper.setupTenantContext()
         val customerId = request.customerId.toUUID()
         val transactionId = request.transactionId.ifBlank { null }?.let { it.toUUID() }

--- a/services/store-service/src/test/kotlin/com/openpos/store/grpc/StoreGrpcServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/grpc/StoreGrpcServiceTest.kt
@@ -5,15 +5,22 @@ import com.google.protobuf.BoolValue
 import com.openpos.store.entity.StaffEntity
 import com.openpos.store.entity.StoreEntity
 import com.openpos.store.service.AuditLogService
+import com.openpos.store.service.CustomerService
 import com.openpos.store.service.StaffService
 import com.openpos.store.service.StoreService
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
+import openpos.store.v1.RedeemPointsRequest
+import openpos.store.v1.RedeemPointsResponse
 import openpos.store.v1.UpdateStaffRequest
 import openpos.store.v1.UpdateStoreRequest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -26,6 +33,7 @@ class StoreGrpcServiceTest {
     private lateinit var grpcService: StoreGrpcService
     private val storeService = mock<StoreService>()
     private val staffService = mock<StaffService>()
+    private val customerService = mock<CustomerService>()
     private val auditLogService = mock<AuditLogService>()
     private val tenantHelper = mock<GrpcTenantHelper>()
 
@@ -35,10 +43,51 @@ class StoreGrpcServiceTest {
             StoreGrpcService().apply {
                 this.storeService = this@StoreGrpcServiceTest.storeService
                 this.staffService = this@StoreGrpcServiceTest.staffService
+                this.customerService = this@StoreGrpcServiceTest.customerService
                 this.auditLogService = this@StoreGrpcServiceTest.auditLogService
                 this.tenantHelper = this@StoreGrpcServiceTest.tenantHelper
                 this.objectMapper = ObjectMapper()
             }
+    }
+
+    @Test
+    fun `redeemPoints rejects negative points with INVALID_ARGUMENT`() {
+        // Arrange
+        val request =
+            RedeemPointsRequest
+                .newBuilder()
+                .setCustomerId(UUID.randomUUID().toString())
+                .setPoints(-10)
+                .build()
+        val observer = CapturingObserver<RedeemPointsResponse>()
+
+        // Act & Assert
+        val ex =
+            assertThrows<StatusRuntimeException> {
+                grpcService.redeemPoints(request, observer)
+            }
+        assertEquals(Status.INVALID_ARGUMENT.code, ex.status.code)
+        assertTrue(ex.message?.contains("points must be positive") == true)
+    }
+
+    @Test
+    fun `redeemPoints rejects zero points with INVALID_ARGUMENT`() {
+        // Arrange
+        val request =
+            RedeemPointsRequest
+                .newBuilder()
+                .setCustomerId(UUID.randomUUID().toString())
+                .setPoints(0)
+                .build()
+        val observer = CapturingObserver<RedeemPointsResponse>()
+
+        // Act & Assert
+        val ex =
+            assertThrows<StatusRuntimeException> {
+                grpcService.redeemPoints(request, observer)
+            }
+        assertEquals(Status.INVALID_ARGUMENT.code, ex.status.code)
+        assertTrue(ex.message?.contains("points must be positive") == true)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- **#1153**: `redeemPoints` で `points <= 0` を `INVALID_ARGUMENT` で拒否。負数ポイント償還によるポイント加算を防止
- **#1154**: `addItem` で `customProductName` 指定時に `customProductPrice` が null/0/負数なら 400 Bad Request を返却。price=0 のカスタムアイテム作成を防止
- **#1155**: `exportDailySales` で日付を `normalizeStart/normalizeEnd`（RFC3339変換）せずそのまま渡すように修正。analytics の `getDailySales` は `LocalDate.parse` を期待しているため、RFC3339 形式だとパースエラーになっていた。`normalizeStart/normalizeEnd` は `exportTransactions`（POS取引エクスポート）でのみ使用

## Test plan
- [x] `redeemPoints` 負数テスト: `INVALID_ARGUMENT` が返ること
- [x] `redeemPoints` ゼロテスト: `INVALID_ARGUMENT` が返ること
- [x] `addItem` customProductPrice=null テスト: `BadRequestException` が返ること
- [x] `addItem` customProductPrice=0 テスト: `BadRequestException` が返ること
- [x] `addItem` customProductPrice=-100 テスト: `BadRequestException` が返ること
- [x] `normalizeStart/normalizeEnd` ヘルパーテスト: RFC3339 変換の正確性
- [x] `./gradlew :services:store-service:build` BUILD SUCCESSFUL
- [x] `./gradlew :services:api-gateway:build` BUILD SUCCESSFUL

Closes #1153, Closes #1154, Closes #1155