### PR TITLE
fix(inventory,gateway): reject non-positive stock transfer qty and skip invalid CSV rows

### DIFF
--- a/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductImportResource.kt
+++ b/services/api-gateway/src/main/kotlin/com/openpos/gateway/resource/ProductImportResource.kt
@@ -57,6 +57,7 @@ class ProductImportResource {
         val results = mutableListOf<Map<String, Any?>>()
         var successCount = 0
         var errorCount = 0
+        var skippedCount = 0
 
         BufferedReader(
             InputStreamReader(file.uploadedFile().toFile().inputStream(), StandardCharsets.UTF_8),
@@ -87,13 +88,38 @@ class ProductImportResource {
             var lineNumber = 1
             reader.forEachLine { line ->
                 lineNumber++
+                if (line.isBlank()) {
+                    skippedCount++
+                    results.add(mapOf("line" to lineNumber, "status" to "skipped", "message" to "Empty line"))
+                    return@forEachLine
+                }
                 try {
                     val fields = parseCsvLine(line)
+                    val name = fields.getOrElse(nameIdx) { "" }
+                    if (name.isBlank()) {
+                        skippedCount++
+                        results.add(
+                            mapOf("line" to lineNumber, "status" to "skipped", "message" to "Empty product name"),
+                        )
+                        return@forEachLine
+                    }
+                    val price = fields.getOrElse(priceIdx) { "0" }.toLongOrNull() ?: 0L
+                    if (price <= 0) {
+                        skippedCount++
+                        results.add(
+                            mapOf(
+                                "line" to lineNumber,
+                                "status" to "skipped",
+                                "message" to "Price must be positive, got: $price",
+                            ),
+                        )
+                        return@forEachLine
+                    }
                     val request =
                         CreateProductRequest
                             .newBuilder()
-                            .setName(fields.getOrElse(nameIdx) { "" })
-                            .setPrice(fields.getOrElse(priceIdx) { "0" }.toLong())
+                            .setName(name)
+                            .setPrice(price)
                             .apply {
                                 if (barcodeIdx >= 0) {
                                     fields.getOrNull(barcodeIdx)?.takeIf { it.isNotBlank() }?.let { setBarcode(it) }
@@ -127,9 +153,10 @@ class ProductImportResource {
         return Response
             .ok(
                 mapOf(
-                    "totalProcessed" to (successCount + errorCount),
+                    "totalProcessed" to (successCount + errorCount + skippedCount),
                     "success" to successCount,
                     "errors" to errorCount,
+                    "skipped" to skippedCount,
                     "details" to results,
                 ),
             ).build()
@@ -141,12 +168,18 @@ class ProductImportResource {
         var inQuotes = false
         for (ch in line) {
             when {
-                ch == '"' -> inQuotes = !inQuotes
+                ch == '"' -> {
+                    inQuotes = !inQuotes
+                }
+
                 ch == ',' && !inQuotes -> {
                     fields.add(current.toString().trim())
                     current.clear()
                 }
-                else -> current.append(ch)
+
+                else -> {
+                    current.append(ch)
+                }
             }
         }
         fields.add(current.toString().trim())

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/ProductImportResourceTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/ProductImportResourceTest.kt
@@ -1,0 +1,261 @@
+package com.openpos.gateway.resource
+
+import com.openpos.gateway.config.GrpcClientHelper
+import com.openpos.gateway.config.TenantContext
+import openpos.product.v1.CreateProductResponse
+import openpos.product.v1.Product
+import openpos.product.v1.ProductServiceGrpc
+import org.jboss.resteasy.reactive.multipart.FileUpload
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.nio.file.Files
+import java.util.UUID
+
+class ProductImportResourceTest {
+    private val stub: ProductServiceGrpc.ProductServiceBlockingStub = mock()
+    private val grpc: GrpcClientHelper = mock()
+    private val tenantContext: TenantContext = TenantContext()
+    private val resource =
+        ProductImportResource().also { r ->
+            setField(r, "stub", stub)
+            setField(r, "grpc", grpc)
+            setField(r, "tenantContext", tenantContext)
+        }
+
+    private val orgId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        whenever(grpc.withTenant(stub)).thenReturn(stub)
+        tenantContext.organizationId = orgId
+    }
+
+    private fun createCsvFileUpload(content: String): FileUpload {
+        val tempFile = Files.createTempFile("test-import", ".csv")
+        Files.writeString(tempFile, content)
+        val fileUpload = mock<FileUpload>()
+        whenever(fileUpload.uploadedFile()).thenReturn(tempFile)
+        return fileUpload
+    }
+
+    private fun mockCreateProduct(id: String = UUID.randomUUID().toString()) {
+        val product =
+            Product
+                .newBuilder()
+                .setId(id)
+                .setOrganizationId(orgId.toString())
+                .setName("Test")
+                .setPrice(10000)
+                .build()
+        whenever(stub.createProduct(any())).thenReturn(
+            CreateProductResponse.newBuilder().setProduct(product).build(),
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun responseBody(response: jakarta.ws.rs.core.Response): Map<String, Any> = response.entity as Map<String, Any>
+
+    @Nested
+    inner class SkipEmptyLines {
+        @Test
+        fun `skips blank lines and counts them`() {
+            // Arrange
+            val csv = "name,price\nCoffee,30000\n\nTea,20000\n   \n"
+            val fileUpload = createCsvFileUpload(csv)
+            mockCreateProduct()
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+            assertEquals(200, response.status)
+            assertEquals(2, body["success"])
+            assertEquals(2, body["skipped"])
+            assertEquals(0, body["errors"])
+            verify(stub, times(2)).createProduct(any())
+        }
+    }
+
+    @Nested
+    inner class SkipEmptyName {
+        @Test
+        fun `skips rows with empty product name`() {
+            // Arrange
+            val csv = "name,price\n,30000\nCoffee,20000"
+            val fileUpload = createCsvFileUpload(csv)
+            mockCreateProduct()
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+            assertEquals(1, body["success"])
+            assertEquals(1, body["skipped"])
+            assertEquals(0, body["errors"])
+        }
+
+        @Test
+        fun `skips rows with whitespace-only name`() {
+            // Arrange
+            val csv = "name,price\n   ,30000\nCoffee,20000"
+            val fileUpload = createCsvFileUpload(csv)
+            mockCreateProduct()
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+            assertEquals(1, body["success"])
+            assertEquals(1, body["skipped"])
+        }
+    }
+
+    @Nested
+    inner class SkipInvalidPrice {
+        @Test
+        fun `skips rows with zero price`() {
+            // Arrange
+            val csv = "name,price\nCoffee,0\nTea,20000"
+            val fileUpload = createCsvFileUpload(csv)
+            mockCreateProduct()
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+            assertEquals(1, body["success"])
+            assertEquals(1, body["skipped"])
+        }
+
+        @Test
+        fun `skips rows with negative price`() {
+            // Arrange
+            val csv = "name,price\nCoffee,-100\nTea,20000"
+            val fileUpload = createCsvFileUpload(csv)
+            mockCreateProduct()
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+            assertEquals(1, body["success"])
+            assertEquals(1, body["skipped"])
+        }
+
+        @Test
+        fun `skips rows with non-numeric price`() {
+            // Arrange
+            val csv = "name,price\nCoffee,abc\nTea,20000"
+            val fileUpload = createCsvFileUpload(csv)
+            mockCreateProduct()
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+            assertEquals(1, body["success"])
+            assertEquals(1, body["skipped"])
+        }
+    }
+
+    @Nested
+    inner class ResponseFormat {
+        @Test
+        fun `includes skipped count in response`() {
+            // Arrange
+            val csv = "name,price\n,30000\nCoffee,-100\n\nTea,20000"
+            val fileUpload = createCsvFileUpload(csv)
+            mockCreateProduct()
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+            assertEquals(4, body["totalProcessed"])
+            assertEquals(1, body["success"])
+            assertEquals(0, body["errors"])
+            assertEquals(3, body["skipped"])
+        }
+
+        @Test
+        fun `includes skipped details with reason`() {
+            // Arrange
+            val csv = "name,price\n,30000"
+            val fileUpload = createCsvFileUpload(csv)
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+
+            @Suppress("UNCHECKED_CAST")
+            val details = body["details"] as List<Map<String, Any?>>
+            assertEquals(1, details.size)
+            assertEquals("skipped", details[0]["status"])
+            assertEquals("Empty product name", details[0]["message"])
+        }
+    }
+
+    @Nested
+    inner class ValidCsvProcessing {
+        @Test
+        fun `processes valid CSV rows successfully`() {
+            // Arrange
+            val csv = "name,price\nCoffee,30000\nTea,20000"
+            val fileUpload = createCsvFileUpload(csv)
+            mockCreateProduct()
+
+            // Act
+            val response = resource.importCsv(fileUpload)
+
+            // Assert
+            val body = responseBody(response)
+            assertEquals(200, response.status)
+            assertEquals(2, body["success"])
+            assertEquals(0, body["errors"])
+            assertEquals(0, body["skipped"])
+            verify(stub, times(2)).createProduct(any())
+        }
+
+        @Test
+        fun `does not call gRPC for skipped rows`() {
+            // Arrange -- all rows should be skipped
+            val csv = "name,price\n,30000\n,0"
+            val fileUpload = createCsvFileUpload(csv)
+
+            // Act
+            resource.importCsv(fileUpload)
+
+            // Assert
+            verify(stub, never()).createProduct(any())
+        }
+    }
+
+    companion object {
+        fun setField(
+            target: Any,
+            fieldName: String,
+            value: Any,
+        ) {
+            val field = target::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.set(target, value)
+        }
+    }
+}

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StockTransferService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StockTransferService.kt
@@ -28,6 +28,12 @@ class StockTransferService {
         note: String?,
     ): StockTransferEntity {
         require(fromStoreId != toStoreId) { "fromStoreId and toStoreId must be different" }
+        val parsedItems = parseItems(items)
+        val invalidItems = parsedItems.filter { it.quantity <= 0 }
+        require(invalidItems.isEmpty()) {
+            "All item quantities must be positive, got non-positive quantities for products: " +
+                "${invalidItems.map { it.productId }}"
+        }
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
         val entity =
             StockTransferEntity().apply {
@@ -129,7 +135,7 @@ class StockTransferService {
      */
     internal fun parseItems(json: String): List<TransferItem> {
         val items = mutableListOf<TransferItem>()
-        val regex = Regex(""""productId"\s*:\s*"([^"]+)"\s*,\s*"quantity"\s*:\s*(\d+)""")
+        val regex = Regex(""""productId"\s*:\s*"([^"]+)"\s*,\s*"quantity"\s*:\s*(-?\d+)""")
         for (match in regex.findAll(json)) {
             items.add(
                 TransferItem(

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StockTransferServiceTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StockTransferServiceTest.kt
@@ -48,9 +48,16 @@ class StockTransferServiceTest {
         fun `sets PENDING status`() {
             val fromStore = UUID.randomUUID()
             val toStore = UUID.randomUUID()
+            val productId = UUID.randomUUID()
             doNothing().whenever(stockTransferRepository).persist(any<StockTransferEntity>())
 
-            val result = service.create(fromStore, toStore, """[{"productId":"abc","quantity":10}]""", "転送テスト")
+            val result =
+                service.create(
+                    fromStore,
+                    toStore,
+                    """[{"productId":"$productId","quantity":10}]""",
+                    "転送テスト",
+                )
 
             assertNotNull(result)
             assertEquals(fromStore, result.fromStoreId)
@@ -64,6 +71,48 @@ class StockTransferServiceTest {
             val sameId = UUID.randomUUID()
             assertThrows(IllegalArgumentException::class.java) {
                 service.create(sameId, sameId, "[]", null)
+            }
+        }
+
+        @Test
+        fun `throws when item quantity is zero`() {
+            val fromStore = UUID.randomUUID()
+            val toStore = UUID.randomUUID()
+            val productId = UUID.randomUUID()
+            val itemsJson = """[{"productId":"$productId","quantity":0}]"""
+
+            val exception =
+                assertThrows(IllegalArgumentException::class.java) {
+                    service.create(fromStore, toStore, itemsJson, null)
+                }
+            assertEquals(true, exception.message?.contains("non-positive"))
+        }
+
+        @Test
+        fun `throws when item quantity is negative`() {
+            val fromStore = UUID.randomUUID()
+            val toStore = UUID.randomUUID()
+            val productId = UUID.randomUUID()
+            val itemsJson = """[{"productId":"$productId","quantity":-5}]"""
+
+            val exception =
+                assertThrows(IllegalArgumentException::class.java) {
+                    service.create(fromStore, toStore, itemsJson, null)
+                }
+            assertEquals(true, exception.message?.contains("non-positive"))
+        }
+
+        @Test
+        fun `throws when one of multiple items has non-positive quantity`() {
+            val fromStore = UUID.randomUUID()
+            val toStore = UUID.randomUUID()
+            val pid1 = UUID.randomUUID()
+            val pid2 = UUID.randomUUID()
+            val itemsJson =
+                """[{"productId":"$pid1","quantity":5},{"productId":"$pid2","quantity":-1}]"""
+
+            assertThrows(IllegalArgumentException::class.java) {
+                service.create(fromStore, toStore, itemsJson, null)
             }
         }
     }
@@ -381,6 +430,29 @@ class StockTransferServiceTest {
             val result = service.parseItems("[]")
 
             assertEquals(0, result.size)
+        }
+
+        @Test
+        fun `parses negative quantity`() {
+            val productId = UUID.randomUUID()
+            val json = """[{"productId":"$productId","quantity":-3}]"""
+
+            val result = service.parseItems(json)
+
+            assertEquals(1, result.size)
+            assertEquals(productId, result[0].productId)
+            assertEquals(-3, result[0].quantity)
+        }
+
+        @Test
+        fun `parses zero quantity`() {
+            val productId = UUID.randomUUID()
+            val json = """[{"productId":"$productId","quantity":0}]"""
+
+            val result = service.parseItems(json)
+
+            assertEquals(1, result.size)
+            assertEquals(0, result[0].quantity)
         }
     }
 }


### PR DESCRIPTION
## Summary
- **#1156**: `StockTransferService.create()` で items の各 quantity が <= 0 の場合に `IllegalArgumentException` を投げるバリデーションを追加。`parseItems` の正規表現も `-?\d+` に修正し、負数がサイレントスキップされる根本原因を修正
- **#1157**: `ProductImportResource.importCsv()` で空行・blank name・price <= 0 の行をスキップし、`skippedCount` をレスポンスに追加。gRPC 呼び出しを行わずにスキップすることで空商品の作成を防止

## Changes
- `StockTransferService.kt`: `create()` に quantity バリデーション追加、`parseItems()` の正規表現修正
- `ProductImportResource.kt`: CSV行バリデーション（空行、blank name、non-positive price）追加、レスポンスに `skipped` フィールド追加
- `StockTransferServiceTest.kt`: 負数・ゼロ・混在ケースのテスト追加、既存テストのダミーデータ修正
- `ProductImportResourceTest.kt`: 新規テストファイル（10テスト）— 空行スキップ、空名スキップ、不正価格スキップ、レスポンスフォーマット検証

## Test plan
- [x] `./gradlew :services:inventory-service:build` 全テストパス（157テスト）
- [x] `./gradlew :services:api-gateway:build` 全テストパス（278テスト）
- [ ] CI パス確認

Closes #1156, Closes #1157