### PR TITLE
security: fix Hibernate Filter bypass via findById() across all 5 services

### DIFF
--- a/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/ProductAlertService.kt
+++ b/services/analytics-service/src/main/kotlin/com/openpos/analytics/service/ProductAlertService.kt
@@ -62,8 +62,9 @@ class ProductAlertService {
             requireNotNull(organizationIdHolder.organizationId) {
                 "organizationId is not set in OrganizationIdHolder"
             }
-        val entity = productAlertRepository.findById(id) ?: return null
         // ProductAlertEntity は BaseEntity を継承していないため Hibernate Filter が効かない。
+        // HQL クエリで全テナントのレコードが返るため、手動でテナント所有権を検証する。
+        val entity = productAlertRepository.find("id = ?1", id).firstResult() ?: return null
         // 手動でテナント所有権を検証し、他テナントのアラートを操作できないようにする。
         if (entity.organizationId != orgId) {
             return null

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/grpc/AnalyticsGrpcServiceSalesTargetTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/grpc/AnalyticsGrpcServiceSalesTargetTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.Instant

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/service/ProductAlertServiceTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/service/ProductAlertServiceTest.kt
@@ -4,10 +4,8 @@ import com.openpos.analytics.config.OrganizationIdHolder
 import com.openpos.analytics.config.TenantFilterService
 import com.openpos.analytics.entity.ProductAlertEntity
 import com.openpos.analytics.repository.ProductAlertRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import io.quarkus.panache.common.Page
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -17,28 +15,31 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
 class ProductAlertServiceTest {
-    @Inject
-    lateinit var productAlertService: ProductAlertService
-
-    @InjectMock
-    lateinit var productAlertRepository: ProductAlertRepository
-
-    @InjectMock
-    lateinit var organizationIdHolder: OrganizationIdHolder
-
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var productAlertService: ProductAlertService
+    private lateinit var productAlertRepository: ProductAlertRepository
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var tenantFilterService: TenantFilterService
 
     private val orgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
-        whenever(organizationIdHolder.organizationId).thenReturn(orgId)
+        productAlertRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        productAlertService = ProductAlertService()
+        productAlertService.productAlertRepository = productAlertRepository
+        productAlertService.tenantFilterService = tenantFilterService
+        productAlertService.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
     }
 
@@ -135,7 +136,9 @@ class ProductAlertServiceTest {
             // Arrange
             val alertId = UUID.randomUUID()
             val alert = createAlert(id = alertId, isRead = false, alertOrgId = orgId)
-            whenever(productAlertRepository.findById(alertId)).thenReturn(alert)
+            val mockQuery1 = mock<PanacheQuery<ProductAlertEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(alert)
+            whenever(productAlertRepository.find(eq("id = ?1"), eq(alertId))).thenReturn(mockQuery1)
             doNothing().whenever(productAlertRepository).persist(any<ProductAlertEntity>())
 
             // Act
@@ -150,7 +153,9 @@ class ProductAlertServiceTest {
         fun `returns null when alert not found`() {
             // Arrange
             val alertId = UUID.randomUUID()
-            whenever(productAlertRepository.findById(alertId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<ProductAlertEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(productAlertRepository.find(eq("id = ?1"), eq(alertId))).thenReturn(mockQuery2)
 
             // Act
             val result = productAlertService.markAsRead(alertId)
@@ -165,7 +170,9 @@ class ProductAlertServiceTest {
             val alertId = UUID.randomUUID()
             val otherOrgId = UUID.randomUUID()
             val alert = createAlert(id = alertId, isRead = false, alertOrgId = otherOrgId)
-            whenever(productAlertRepository.findById(alertId)).thenReturn(alert)
+            val mockQuery3 = mock<PanacheQuery<ProductAlertEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(alert)
+            whenever(productAlertRepository.find(eq("id = ?1"), eq(alertId))).thenReturn(mockQuery3)
 
             // Act
             val result = productAlertService.markAsRead(alertId)

--- a/services/analytics-service/src/test/kotlin/com/openpos/analytics/service/ProductAlertServiceUnitTest.kt
+++ b/services/analytics-service/src/test/kotlin/com/openpos/analytics/service/ProductAlertServiceUnitTest.kt
@@ -4,6 +4,7 @@ import com.openpos.analytics.config.OrganizationIdHolder
 import com.openpos.analytics.config.TenantFilterService
 import com.openpos.analytics.entity.ProductAlertEntity
 import com.openpos.analytics.repository.ProductAlertRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import io.quarkus.panache.common.Page
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -92,7 +94,9 @@ class ProductAlertServiceUnitTest {
         fun `marks alert as read when owned by current tenant`() {
             val alertId = UUID.randomUUID()
             val alert = createAlert(id = alertId, alertOrgId = orgId)
-            whenever(productAlertRepository.findById(alertId)).thenReturn(alert)
+            val mockQuery1 = mock<PanacheQuery<ProductAlertEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(alert)
+            whenever(productAlertRepository.find(eq("id = ?1"), eq(alertId))).thenReturn(mockQuery1)
 
             val result = service.markAsRead(alertId)
 
@@ -103,7 +107,9 @@ class ProductAlertServiceUnitTest {
         @Test
         fun `returns null when alert not found`() {
             val alertId = UUID.randomUUID()
-            whenever(productAlertRepository.findById(alertId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<ProductAlertEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(productAlertRepository.find(eq("id = ?1"), eq(alertId))).thenReturn(mockQuery2)
 
             assertNull(service.markAsRead(alertId))
         }
@@ -113,7 +119,9 @@ class ProductAlertServiceUnitTest {
             val alertId = UUID.randomUUID()
             val otherOrgId = UUID.randomUUID()
             val alert = createAlert(id = alertId, alertOrgId = otherOrgId)
-            whenever(productAlertRepository.findById(alertId)).thenReturn(alert)
+            val mockQuery3 = mock<PanacheQuery<ProductAlertEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(alert)
+            whenever(productAlertRepository.find(eq("id = ?1"), eq(alertId))).thenReturn(mockQuery3)
 
             assertNull(service.markAsRead(alertId))
         }

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/PurchaseOrderService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/PurchaseOrderService.kt
@@ -82,7 +82,9 @@ class PurchaseOrderService {
      */
     fun findById(id: UUID): PurchaseOrderEntity? {
         tenantFilterService.enableFilter()
-        return purchaseOrderRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return purchaseOrderRepository.find("id = ?1", id).firstResult()
     }
 
     /**
@@ -118,7 +120,7 @@ class PurchaseOrderService {
     ): PurchaseOrderEntity {
         tenantFilterService.enableFilter()
         val order =
-            purchaseOrderRepository.findById(id)
+            purchaseOrderRepository.find("id = ?1", id).firstResult()
                 ?: throw IllegalArgumentException("PurchaseOrder not found: $id")
 
         validateStatusTransition(order.status, newStatus)

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StockTransferService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StockTransferService.kt
@@ -50,7 +50,9 @@ class StockTransferService {
 
     fun findById(id: UUID): StockTransferEntity? {
         tenantFilterService.enableFilter()
-        return stockTransferRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return stockTransferRepository.find("id = ?1", id).firstResult()
     }
 
     fun list(
@@ -82,7 +84,7 @@ class StockTransferService {
         status: String,
     ): StockTransferEntity? {
         tenantFilterService.enableFilter()
-        val entity = stockTransferRepository.findById(id) ?: return null
+        val entity = stockTransferRepository.find("id = ?1", id).firstResult() ?: return null
         entity.status = status
         stockTransferRepository.persist(entity)
         return entity
@@ -96,7 +98,7 @@ class StockTransferService {
     fun complete(id: UUID): StockTransferEntity {
         tenantFilterService.enableFilter()
         val entity =
-            stockTransferRepository.findById(id)
+            stockTransferRepository.find("id = ?1", id).firstResult()
                 ?: throw IllegalArgumentException("StockTransfer not found: $id")
         require(entity.status == "PENDING" || entity.status == "IN_TRANSIT") {
             "Cannot complete transfer with status: ${entity.status}"

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StocktakeService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/StocktakeService.kt
@@ -60,8 +60,10 @@ class StocktakeService {
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
         tenantFilterService.enableFilter()
 
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
         val stocktake =
-            stocktakeRepository.findById(stocktakeId)
+            stocktakeRepository.find("id = ?1", stocktakeId).firstResult()
                 ?: throw IllegalArgumentException("Stocktake not found: $stocktakeId")
         require(stocktake.status == "IN_PROGRESS") { "Stocktake is not in progress" }
 
@@ -93,7 +95,7 @@ class StocktakeService {
     fun completeStocktake(stocktakeId: UUID): StocktakeEntity {
         tenantFilterService.enableFilter()
         val stocktake =
-            stocktakeRepository.findById(stocktakeId)
+            stocktakeRepository.find("id = ?1", stocktakeId).firstResult()
                 ?: throw IllegalArgumentException("Stocktake not found: $stocktakeId")
         require(stocktake.status == "IN_PROGRESS") { "Stocktake is not in progress" }
 

--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/SupplierService.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/service/SupplierService.kt
@@ -13,30 +13,44 @@ import java.util.UUID
 @ApplicationScoped
 class SupplierService {
     @Inject lateinit var supplierRepository: SupplierRepository
+
     @Inject lateinit var tenantFilterService: TenantFilterService
+
     @Inject lateinit var organizationIdHolder: OrganizationIdHolder
 
     @Transactional
-    fun create(name: String, contactPerson: String?, email: String?, phone: String?, address: String?): SupplierEntity {
+    fun create(
+        name: String,
+        contactPerson: String?,
+        email: String?,
+        phone: String?,
+        address: String?,
+    ): SupplierEntity {
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
-        val entity = SupplierEntity().apply {
-            this.organizationId = orgId
-            this.name = name
-            this.contactPerson = contactPerson
-            this.email = email
-            this.phone = phone
-            this.address = address
-        }
+        val entity =
+            SupplierEntity().apply {
+                this.organizationId = orgId
+                this.name = name
+                this.contactPerson = contactPerson
+                this.email = email
+                this.phone = phone
+                this.address = address
+            }
         supplierRepository.persist(entity)
         return entity
     }
 
     fun findById(id: UUID): SupplierEntity? {
         tenantFilterService.enableFilter()
-        return supplierRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return supplierRepository.find("id = ?1", id).firstResult()
     }
 
-    fun list(page: Int, pageSize: Int): Pair<List<SupplierEntity>, Long> {
+    fun list(
+        page: Int,
+        pageSize: Int,
+    ): Pair<List<SupplierEntity>, Long> {
         tenantFilterService.enableFilter()
         val items = supplierRepository.listPaginated(Page.of(page, pageSize))
         val total = supplierRepository.count()
@@ -44,9 +58,16 @@ class SupplierService {
     }
 
     @Transactional
-    fun update(id: UUID, name: String?, contactPerson: String?, email: String?, phone: String?, address: String?): SupplierEntity? {
+    fun update(
+        id: UUID,
+        name: String?,
+        contactPerson: String?,
+        email: String?,
+        phone: String?,
+        address: String?,
+    ): SupplierEntity? {
         tenantFilterService.enableFilter()
-        val entity = supplierRepository.findById(id) ?: return null
+        val entity = supplierRepository.find("id = ?1", id).firstResult() ?: return null
         name?.let { entity.name = it }
         contactPerson?.let { entity.contactPerson = it }
         email?.let { entity.email = it }

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/PurchaseOrderServiceTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/PurchaseOrderServiceTest.kt
@@ -8,10 +8,9 @@ import com.openpos.inventory.repository.PurchaseOrderItemRepository
 import com.openpos.inventory.repository.PurchaseOrderRepository
 import io.grpc.StatusRuntimeException
 import io.quarkus.panache.common.Page
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
 import jakarta.persistence.OptimisticLockException
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.mock
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -28,31 +27,37 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
 class PurchaseOrderServiceTest {
-    @Inject
-    lateinit var purchaseOrderService: PurchaseOrderService
+    private lateinit var purchaseOrderService: PurchaseOrderService
 
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
-    @InjectMock
-    lateinit var purchaseOrderRepository: PurchaseOrderRepository
+    private lateinit var purchaseOrderRepository: PurchaseOrderRepository
 
-    @InjectMock
-    lateinit var itemRepository: PurchaseOrderItemRepository
+    private lateinit var itemRepository: PurchaseOrderItemRepository
 
-    @InjectMock
-    lateinit var stockService: StockService
+    private lateinit var stockService: StockService
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
     private val orgId = UUID.randomUUID()
     private val storeId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        purchaseOrderRepository = mock()
+        itemRepository = mock()
+        stockService = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        purchaseOrderService = PurchaseOrderService()
+        purchaseOrderService.purchaseOrderRepository = purchaseOrderRepository
+        purchaseOrderService.itemRepository = itemRepository
+        purchaseOrderService.stockService = stockService
+        purchaseOrderService.tenantFilterService = tenantFilterService
+        purchaseOrderService.organizationIdHolder = organizationIdHolder
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
     }
@@ -127,7 +132,9 @@ class PurchaseOrderServiceTest {
                     this.supplierName = "テスト仕入先"
                     this.status = "DRAFT"
                 }
-            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<PurchaseOrderEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(entity)
+            whenever(purchaseOrderRepository.find(eq("id = ?1"), eq(orderId))).thenReturn(mockQuery1)
 
             // Act
             val result = purchaseOrderService.findById(orderId)
@@ -143,7 +150,9 @@ class PurchaseOrderServiceTest {
         fun `存在しないIDの場合はnullを返す`() {
             // Arrange
             val orderId = UUID.randomUUID()
-            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<PurchaseOrderEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(purchaseOrderRepository.find(eq("id = ?1"), eq(orderId))).thenReturn(mockQuery2)
 
             // Act
             val result = purchaseOrderService.findById(orderId)
@@ -210,7 +219,9 @@ class PurchaseOrderServiceTest {
                     this.supplierName = "テスト仕入先"
                     this.status = "DRAFT"
                 }
-            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<PurchaseOrderEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(entity)
+            whenever(purchaseOrderRepository.find(eq("id = ?1"), eq(orderId))).thenReturn(mockQuery3)
             doNothing().whenever(purchaseOrderRepository).persist(any<PurchaseOrderEntity>())
 
             // Act
@@ -234,7 +245,9 @@ class PurchaseOrderServiceTest {
                     this.supplierName = "テスト仕入先"
                     this.status = "DRAFT"
                 }
-            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(entity)
+            val mockQuery4 = mock<PanacheQuery<PurchaseOrderEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(entity)
+            whenever(purchaseOrderRepository.find(eq("id = ?1"), eq(orderId))).thenReturn(mockQuery4)
             doNothing().whenever(purchaseOrderRepository).persist(any<PurchaseOrderEntity>())
 
             // Act
@@ -266,7 +279,9 @@ class PurchaseOrderServiceTest {
                     this.orderedQuantity = 10
                     this.unitCost = 5000L
                 }
-            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(entity)
+            val mockQuery5 = mock<PanacheQuery<PurchaseOrderEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(entity)
+            whenever(purchaseOrderRepository.find(eq("id = ?1"), eq(orderId))).thenReturn(mockQuery5)
             whenever(itemRepository.findByPurchaseOrderId(orderId)).thenReturn(listOf(item))
             doNothing().whenever(purchaseOrderRepository).persist(any<PurchaseOrderEntity>())
             doNothing().whenever(itemRepository).persist(any<PurchaseOrderItemEntity>())
@@ -314,7 +329,9 @@ class PurchaseOrderServiceTest {
                     this.supplierName = "テスト仕入先"
                     this.status = "RECEIVED"
                 }
-            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(entity)
+            val mockQuery6 = mock<PanacheQuery<PurchaseOrderEntity>>()
+            whenever(mockQuery6.firstResult()).thenReturn(entity)
+            whenever(purchaseOrderRepository.find(eq("id = ?1"), eq(orderId))).thenReturn(mockQuery6)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {
@@ -326,7 +343,9 @@ class PurchaseOrderServiceTest {
         fun `存在しない発注の更新は例外を投げる`() {
             // Arrange
             val orderId = UUID.randomUUID()
-            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(null)
+            val mockQuery7 = mock<PanacheQuery<PurchaseOrderEntity>>()
+            whenever(mockQuery7.firstResult()).thenReturn(null)
+            whenever(purchaseOrderRepository.find(eq("id = ?1"), eq(orderId))).thenReturn(mockQuery7)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {
@@ -346,7 +365,9 @@ class PurchaseOrderServiceTest {
                     this.supplierName = "テスト仕入先"
                     this.status = "DRAFT"
                 }
-            whenever(purchaseOrderRepository.findById(orderId)).thenReturn(entity)
+            val mockQuery8 = mock<PanacheQuery<PurchaseOrderEntity>>()
+            whenever(mockQuery8.firstResult()).thenReturn(entity)
+            whenever(purchaseOrderRepository.find(eq("id = ?1"), eq(orderId))).thenReturn(mockQuery8)
             doNothing().whenever(purchaseOrderRepository).persist(any<PurchaseOrderEntity>())
             doThrow(OptimisticLockException("concurrent modification"))
                 .whenever(purchaseOrderRepository)

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StockTransferServiceTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StockTransferServiceTest.kt
@@ -4,6 +4,7 @@ import com.openpos.inventory.config.OrganizationIdHolder
 import com.openpos.inventory.config.TenantFilterService
 import com.openpos.inventory.entity.StockTransferEntity
 import com.openpos.inventory.repository.StockTransferRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import io.quarkus.panache.common.Page
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -131,7 +132,9 @@ class StockTransferServiceTest {
                     this.items = "[]"
                     this.status = "PENDING"
                 }
-            whenever(stockTransferRepository.findById(id)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(entity)
+            whenever(stockTransferRepository.find(eq("id = ?1"), eq(id))).thenReturn(mockQuery1)
 
             val result = service.findById(id)
 
@@ -142,7 +145,9 @@ class StockTransferServiceTest {
 
         @Test
         fun `returns null when not found`() {
-            whenever(stockTransferRepository.findById(any<UUID>())).thenReturn(null)
+            val notFoundQuery = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(notFoundQuery.firstResult()).thenReturn(null)
+            whenever(stockTransferRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(notFoundQuery)
 
             val result = service.findById(UUID.randomUUID())
 
@@ -256,7 +261,9 @@ class StockTransferServiceTest {
                     items = "[]"
                     status = "PENDING"
                 }
-            whenever(stockTransferRepository.findById(transferId)).thenReturn(entity)
+            val mockQuery2 = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(entity)
+            whenever(stockTransferRepository.find(eq("id = ?1"), eq(transferId))).thenReturn(mockQuery2)
             doNothing().whenever(stockTransferRepository).persist(any<StockTransferEntity>())
 
             val result = service.updateStatus(transferId, "IN_TRANSIT")
@@ -267,7 +274,9 @@ class StockTransferServiceTest {
 
         @Test
         fun `returns null when not found`() {
-            whenever(stockTransferRepository.findById(any<UUID>())).thenReturn(null)
+            val notFoundQuery = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(notFoundQuery.firstResult()).thenReturn(null)
+            whenever(stockTransferRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(notFoundQuery)
 
             val result = service.updateStatus(UUID.randomUUID(), "IN_TRANSIT")
 
@@ -297,7 +306,9 @@ class StockTransferServiceTest {
                     items = itemsJson
                     status = "PENDING"
                 }
-            whenever(stockTransferRepository.findById(transferId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(entity)
+            whenever(stockTransferRepository.find(eq("id = ?1"), eq(transferId))).thenReturn(mockQuery3)
             doNothing().whenever(stockTransferRepository).persist(any<StockTransferEntity>())
             whenever(stockService.adjustStock(any(), any(), any(), any(), any(), any())).thenReturn(mock())
 
@@ -328,7 +339,9 @@ class StockTransferServiceTest {
 
         @Test
         fun `throws when transfer not found`() {
-            whenever(stockTransferRepository.findById(any<UUID>())).thenReturn(null)
+            val notFoundQuery = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(notFoundQuery.firstResult()).thenReturn(null)
+            whenever(stockTransferRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(notFoundQuery)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.complete(UUID.randomUUID())
@@ -347,7 +360,9 @@ class StockTransferServiceTest {
                     items = "[]"
                     status = "COMPLETED"
                 }
-            whenever(stockTransferRepository.findById(transferId)).thenReturn(entity)
+            val mockQuery4 = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(entity)
+            whenever(stockTransferRepository.find(eq("id = ?1"), eq(transferId))).thenReturn(mockQuery4)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.complete(transferId)
@@ -366,7 +381,9 @@ class StockTransferServiceTest {
                     items = "[]"
                     status = "CANCELLED"
                 }
-            whenever(stockTransferRepository.findById(transferId)).thenReturn(entity)
+            val mockQuery5 = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(entity)
+            whenever(stockTransferRepository.find(eq("id = ?1"), eq(transferId))).thenReturn(mockQuery5)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.complete(transferId)
@@ -386,7 +403,9 @@ class StockTransferServiceTest {
                     items = itemsJson
                     status = "IN_TRANSIT"
                 }
-            whenever(stockTransferRepository.findById(transferId)).thenReturn(entity)
+            val mockQuery6 = mock<PanacheQuery<StockTransferEntity>>()
+            whenever(mockQuery6.firstResult()).thenReturn(entity)
+            whenever(stockTransferRepository.find(eq("id = ?1"), eq(transferId))).thenReturn(mockQuery6)
             doNothing().whenever(stockTransferRepository).persist(any<StockTransferEntity>())
             whenever(stockService.adjustStock(any(), any(), any(), any(), any(), any())).thenReturn(mock())
 

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StocktakeServiceTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StocktakeServiceTest.kt
@@ -8,9 +8,8 @@ import com.openpos.inventory.entity.StocktakeItemEntity
 import com.openpos.inventory.repository.StockRepository
 import com.openpos.inventory.repository.StocktakeItemRepository
 import com.openpos.inventory.repository.StocktakeRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.mock
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -25,34 +24,41 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
 class StocktakeServiceTest {
-    @Inject
-    lateinit var stocktakeService: StocktakeService
+    private lateinit var stocktakeService: StocktakeService
 
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
-    @InjectMock
-    lateinit var stocktakeRepository: StocktakeRepository
+    private lateinit var stocktakeRepository: StocktakeRepository
 
-    @InjectMock
-    lateinit var stocktakeItemRepository: StocktakeItemRepository
+    private lateinit var stocktakeItemRepository: StocktakeItemRepository
 
-    @InjectMock
-    lateinit var stockRepository: StockRepository
+    private lateinit var stockRepository: StockRepository
 
-    @InjectMock
-    lateinit var stockService: StockService
+    private lateinit var stockService: StockService
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
     private val orgId = UUID.randomUUID()
     private val storeId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        stocktakeRepository = mock()
+        stocktakeItemRepository = mock()
+        stockRepository = mock()
+        stockService = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        stocktakeService = StocktakeService()
+        stocktakeService.stocktakeRepository = stocktakeRepository
+        stocktakeService.stocktakeItemRepository = stocktakeItemRepository
+        stocktakeService.stockRepository = stockRepository
+        stocktakeService.stockService = stockService
+        stocktakeService.tenantFilterService = tenantFilterService
+        stocktakeService.organizationIdHolder = organizationIdHolder
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
     }
@@ -98,7 +104,9 @@ class StocktakeServiceTest {
                     this.productId = productId
                     this.quantity = 10
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery1 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery1)
             whenever(stockRepository.findByStoreAndProduct(storeId, productId)).thenReturn(stockEntity)
             whenever(stocktakeItemRepository.findByStocktakeAndProduct(stocktakeId, productId)).thenReturn(null)
             doNothing().whenever(stocktakeItemRepository).persist(any<StocktakeItemEntity>())
@@ -133,7 +141,9 @@ class StocktakeServiceTest {
                     this.actualQty = 5
                     this.difference = -5
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery2 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery2)
             whenever(stockRepository.findByStoreAndProduct(storeId, productId)).thenReturn(null)
             whenever(stocktakeItemRepository.findByStocktakeAndProduct(stocktakeId, productId)).thenReturn(existingItem)
             doNothing().whenever(stocktakeItemRepository).persist(any<StocktakeItemEntity>())
@@ -154,7 +164,9 @@ class StocktakeServiceTest {
             // Arrange
             val stocktakeId = UUID.randomUUID()
             val productId = UUID.randomUUID()
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(null)
+            val mockQuery3 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(null)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery3)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {
@@ -174,7 +186,9 @@ class StocktakeServiceTest {
                     this.storeId = this@StocktakeServiceTest.storeId
                     this.status = "COMPLETED"
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery4 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery4)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {
@@ -207,7 +221,9 @@ class StocktakeServiceTest {
                     this.actualQty = 8
                     this.difference = -2
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery5 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery5)
             whenever(stocktakeItemRepository.findByStocktakeId(stocktakeId)).thenReturn(listOf(item))
             doNothing().whenever(stocktakeRepository).persist(any<StocktakeEntity>())
             whenever(stockService.adjustStock(any(), any(), any(), any(), any(), any())).thenReturn(
@@ -258,7 +274,9 @@ class StocktakeServiceTest {
                     this.actualQty = 10
                     this.difference = 0
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery6 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery6.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery6)
             whenever(stocktakeItemRepository.findByStocktakeId(stocktakeId)).thenReturn(listOf(item))
             doNothing().whenever(stocktakeRepository).persist(any<StocktakeEntity>())
 
@@ -274,7 +292,9 @@ class StocktakeServiceTest {
         fun `存在しない棚卸しの完了は例外を投げる`() {
             // Arrange
             val stocktakeId = UUID.randomUUID()
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(null)
+            val mockQuery7 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery7.firstResult()).thenReturn(null)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery7)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {
@@ -293,7 +313,9 @@ class StocktakeServiceTest {
                     this.storeId = this@StocktakeServiceTest.storeId
                     this.status = "COMPLETED"
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery8 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery8.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery8)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StocktakeServiceUnitTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/StocktakeServiceUnitTest.kt
@@ -8,6 +8,7 @@ import com.openpos.inventory.entity.StocktakeItemEntity
 import com.openpos.inventory.repository.StockRepository
 import com.openpos.inventory.repository.StocktakeItemRepository
 import com.openpos.inventory.repository.StocktakeRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -97,7 +98,9 @@ class StocktakeServiceUnitTest {
                     this.productId = productId
                     this.quantity = 10
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery1 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery1)
             whenever(stockRepository.findByStoreAndProduct(storeId, productId)).thenReturn(stockEntity)
             whenever(stocktakeItemRepository.findByStocktakeAndProduct(stocktakeId, productId)).thenReturn(null)
 
@@ -128,7 +131,9 @@ class StocktakeServiceUnitTest {
                     this.actualQty = 5
                     this.difference = -5
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery2 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery2)
             whenever(stockRepository.findByStoreAndProduct(storeId, productId)).thenReturn(null)
             whenever(stocktakeItemRepository.findByStocktakeAndProduct(stocktakeId, productId)).thenReturn(existingItem)
 
@@ -141,7 +146,9 @@ class StocktakeServiceUnitTest {
 
         @Test
         fun `throws when stocktake not found`() {
-            whenever(stocktakeRepository.findById(any<UUID>())).thenReturn(null)
+            val notFoundQuery = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(notFoundQuery.firstResult()).thenReturn(null)
+            whenever(stocktakeRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(notFoundQuery)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.recordItem(UUID.randomUUID(), UUID.randomUUID(), 5)
@@ -158,7 +165,9 @@ class StocktakeServiceUnitTest {
                     this.storeId = this@StocktakeServiceUnitTest.storeId
                     this.status = "COMPLETED"
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery3 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery3)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.recordItem(stocktakeId, UUID.randomUUID(), 5)
@@ -189,7 +198,9 @@ class StocktakeServiceUnitTest {
                     this.actualQty = 8
                     this.difference = -2
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery4 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery4)
             whenever(stocktakeItemRepository.findByStocktakeId(stocktakeId)).thenReturn(listOf(item))
             whenever(stockService.adjustStock(any(), any(), any(), any(), any(), any())).thenReturn(mock())
 
@@ -227,7 +238,9 @@ class StocktakeServiceUnitTest {
                     this.actualQty = 10
                     this.difference = 0
                 }
-            whenever(stocktakeRepository.findById(stocktakeId)).thenReturn(stocktake)
+            val mockQuery5 = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(stocktake)
+            whenever(stocktakeRepository.find(eq("id = ?1"), eq(stocktakeId))).thenReturn(mockQuery5)
             whenever(stocktakeItemRepository.findByStocktakeId(stocktakeId)).thenReturn(listOf(item))
 
             val result = service.completeStocktake(stocktakeId)
@@ -238,7 +251,9 @@ class StocktakeServiceUnitTest {
 
         @Test
         fun `throws when stocktake not found`() {
-            whenever(stocktakeRepository.findById(any<UUID>())).thenReturn(null)
+            val notFoundQuery = mock<PanacheQuery<StocktakeEntity>>()
+            whenever(notFoundQuery.firstResult()).thenReturn(null)
+            whenever(stocktakeRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(notFoundQuery)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.completeStocktake(UUID.randomUUID())

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/SupplierServiceTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/service/SupplierServiceTest.kt
@@ -5,9 +5,9 @@ import com.openpos.inventory.config.TenantFilterService
 import com.openpos.inventory.entity.SupplierEntity
 import com.openpos.inventory.repository.SupplierRepository
 import io.quarkus.panache.common.Page
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -20,24 +20,28 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
 class SupplierServiceTest {
-    @Inject
-    lateinit var supplierService: SupplierService
+    private lateinit var supplierService: SupplierService
 
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
-    @InjectMock
-    lateinit var supplierRepository: SupplierRepository
+    private lateinit var supplierRepository: SupplierRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
     private val orgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        supplierRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        supplierService = SupplierService()
+        supplierService.supplierRepository = supplierRepository
+        supplierService.tenantFilterService = tenantFilterService
+        supplierService.organizationIdHolder = organizationIdHolder
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
     }
@@ -106,7 +110,9 @@ class SupplierServiceTest {
                     this.organizationId = orgId
                     this.name = "テスト仕入先"
                 }
-            whenever(supplierRepository.findById(supplierId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<SupplierEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(entity)
+            whenever(supplierRepository.find(eq("id = ?1"), eq(supplierId))).thenReturn(mockQuery1)
 
             // Act
             val result = supplierService.findById(supplierId)
@@ -122,7 +128,9 @@ class SupplierServiceTest {
         fun `存在しないIDの場合はnullを返す`() {
             // Arrange
             val supplierId = UUID.randomUUID()
-            whenever(supplierRepository.findById(supplierId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<SupplierEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(supplierRepository.find(eq("id = ?1"), eq(supplierId))).thenReturn(mockQuery2)
 
             // Act
             val result = supplierService.findById(supplierId)
@@ -192,7 +200,9 @@ class SupplierServiceTest {
                     this.contactPerson = "旧担当者"
                     this.email = "old@example.com"
                 }
-            whenever(supplierRepository.findById(supplierId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<SupplierEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(entity)
+            whenever(supplierRepository.find(eq("id = ?1"), eq(supplierId))).thenReturn(mockQuery3)
             doNothing().whenever(supplierRepository).persist(any<SupplierEntity>())
 
             // Act
@@ -218,7 +228,9 @@ class SupplierServiceTest {
         fun `存在しない仕入先の更新はnullを返す`() {
             // Arrange
             val supplierId = UUID.randomUUID()
-            whenever(supplierRepository.findById(supplierId)).thenReturn(null)
+            val mockQuery4 = mock<PanacheQuery<SupplierEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(null)
+            whenever(supplierRepository.find(eq("id = ?1"), eq(supplierId))).thenReturn(mockQuery4)
 
             // Act
             val result =

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/DiscountReasonService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/DiscountReasonService.kt
@@ -61,7 +61,9 @@ class DiscountReasonService {
         isActive: Boolean?,
     ): DiscountReasonEntity? {
         tenantFilterService.enableFilter()
-        val entity = discountReasonRepository.findById(id) ?: return null
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        val entity = discountReasonRepository.find("id = ?1", id).firstResult() ?: return null
         description?.let { entity.description = it }
         isActive?.let { entity.isActive = it }
         discountReasonRepository.persist(entity)

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/ReservationService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/ReservationService.kt
@@ -28,7 +28,9 @@ class ReservationService {
 
     fun findById(id: UUID): ReservationEntity? {
         tenantFilterService.enableFilter()
-        return reservationRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return reservationRepository.find("id = ?1", id).firstResult()
     }
 
     fun listByStoreId(
@@ -81,7 +83,7 @@ class ReservationService {
     @Transactional
     fun fulfill(id: UUID): ReservationEntity? {
         tenantFilterService.enableFilter()
-        val entity = reservationRepository.findById(id) ?: return null
+        val entity = reservationRepository.find("id = ?1", id).firstResult() ?: return null
         entity.status = "FULFILLED"
         reservationRepository.persist(entity)
         return entity
@@ -90,7 +92,7 @@ class ReservationService {
     @Transactional
     fun cancel(id: UUID): ReservationEntity? {
         tenantFilterService.enableFilter()
-        val entity = reservationRepository.findById(id) ?: return null
+        val entity = reservationRepository.find("id = ?1", id).firstResult() ?: return null
         entity.status = "CANCELLED"
         reservationRepository.persist(entity)
         return entity

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/service/TransactionService.kt
@@ -279,7 +279,7 @@ class TransactionService {
         val tx = getWritableTransaction(transactionId)
 
         val item =
-            itemRepository.findById(itemId)
+            itemRepository.find("id = ?1", itemId).firstResult()
                 ?: throw ResourceNotFoundException("Item not found: $itemId")
         if (item.transactionId != transactionId) throw BusinessPreconditionException("Item does not belong to this transaction")
 
@@ -313,7 +313,7 @@ class TransactionService {
         val tx = getWritableTransaction(transactionId)
 
         val item =
-            itemRepository.findById(itemId)
+            itemRepository.find("id = ?1", itemId).firstResult()
                 ?: throw ResourceNotFoundException("Item not found: $itemId")
         if (item.transactionId != transactionId) throw BusinessPreconditionException("Item does not belong to this transaction")
 
@@ -381,7 +381,7 @@ class TransactionService {
                 val targetSubtotal =
                     if (transactionItemId != null) {
                         val item =
-                            itemRepository.findById(transactionItemId)
+                            itemRepository.find("id = ?1", transactionItemId).firstResult()
                                 ?: throw IllegalArgumentException("Transaction item not found: $transactionItemId")
                         require(item.transactionId == transactionId) {
                             "Item does not belong to this transaction"
@@ -449,7 +449,7 @@ class TransactionService {
         }
 
         val tx =
-            transactionRepository.findById(transactionId)
+            transactionRepository.find("id = ?1", transactionId).firstResult()
                 ?: throw ResourceNotFoundException("Transaction not found: $transactionId")
         if (tx.status !=
             "DRAFT"
@@ -553,7 +553,7 @@ class TransactionService {
     ): TransactionEntity {
         tenantFilterService.enableFilter()
         val tx =
-            transactionRepository.findById(transactionId)
+            transactionRepository.find("id = ?1", transactionId).firstResult()
                 ?: throw ResourceNotFoundException("Transaction not found: $transactionId")
         if (tx.status !=
             "COMPLETED"
@@ -584,7 +584,9 @@ class TransactionService {
      */
     fun getTransaction(transactionId: UUID): TransactionEntity {
         tenantFilterService.enableFilter()
-        return transactionRepository.findById(transactionId)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return transactionRepository.find("id = ?1", transactionId).firstResult()
             ?: throw ResourceNotFoundException("Transaction not found: $transactionId")
     }
 
@@ -824,7 +826,7 @@ class TransactionService {
     private fun getWritableTransaction(transactionId: UUID): TransactionEntity {
         tenantFilterService.enableFilter()
         val tx =
-            transactionRepository.findById(transactionId)
+            transactionRepository.find("id = ?1", transactionId).firstResult()
                 ?: throw ResourceNotFoundException("Transaction not found: $transactionId")
         if (tx.status != "DRAFT") throw BusinessPreconditionException("Transaction is not in DRAFT status: ${tx.status}")
         return tx

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceTest.kt
@@ -4,9 +4,9 @@ import com.openpos.pos.config.OrganizationIdHolder
 import com.openpos.pos.config.TenantFilterService
 import com.openpos.pos.entity.DiscountReasonEntity
 import com.openpos.pos.repository.DiscountReasonRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
@@ -16,27 +16,31 @@ import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
 class DiscountReasonServiceTest {
-    @Inject
-    lateinit var discountReasonService: DiscountReasonService
+    private lateinit var discountReasonService: DiscountReasonService
 
-    @InjectMock
-    lateinit var discountReasonRepository: DiscountReasonRepository
+    private lateinit var discountReasonRepository: DiscountReasonRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
-    @InjectMock
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
     private val testOrgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        discountReasonRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        discountReasonService = DiscountReasonService()
+        discountReasonService.discountReasonRepository = discountReasonRepository
+        discountReasonService.tenantFilterService = tenantFilterService
+        discountReasonService.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = testOrgId
         doNothing().whenever(discountReasonRepository).persist(any<DiscountReasonEntity>())
         doNothing().whenever(tenantFilterService).enableFilter()
-        whenever(organizationIdHolder.organizationId).thenReturn(testOrgId)
     }
 
     @Test
@@ -64,7 +68,9 @@ class DiscountReasonServiceTest {
                 description = "商品損傷"
                 isActive = true
             }
-        whenever(discountReasonRepository.findById(reasonId)).thenReturn(entity)
+        val mockQuery1 = mock<PanacheQuery<DiscountReasonEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(entity)
+            whenever(discountReasonRepository.find(eq("id = ?1"), eq(reasonId))).thenReturn(mockQuery1)
 
         val result =
             discountReasonService.update(

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/DiscountReasonServiceUnitTest.kt
@@ -4,6 +4,8 @@ import com.openpos.pos.config.OrganizationIdHolder
 import com.openpos.pos.config.TenantFilterService
 import com.openpos.pos.entity.DiscountReasonEntity
 import com.openpos.pos.repository.DiscountReasonRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -71,7 +73,9 @@ class DiscountReasonServiceUnitTest {
     inner class Update {
         @Test
         fun `returns null when not found`() {
-            whenever(discountReasonRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix1 = mock<PanacheQuery<DiscountReasonEntity>>()
+            whenever(mockQueryFix1.firstResult()).thenReturn(null)
+            whenever(discountReasonRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix1)
 
             val result = service.update(UUID.randomUUID(), "新しい説明", null)
 
@@ -89,7 +93,9 @@ class DiscountReasonServiceUnitTest {
                     this.description = "旧説明"
                     this.isActive = true
                 }
-            whenever(discountReasonRepository.findById(id)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<DiscountReasonEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(entity)
+whenever(discountReasonRepository.find(eq("id = ?1"), eq(id))).thenReturn(mockQuery1)
             doNothing().whenever(discountReasonRepository).persist(any<DiscountReasonEntity>())
 
             val result = service.update(id, "新しい説明", null)

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/ReservationServiceTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/ReservationServiceTest.kt
@@ -4,9 +4,9 @@ import com.openpos.pos.config.OrganizationIdHolder
 import com.openpos.pos.config.TenantFilterService
 import com.openpos.pos.entity.ReservationEntity
 import com.openpos.pos.repository.ReservationRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
@@ -17,28 +17,32 @@ import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.util.UUID
 
-@QuarkusTest
 class ReservationServiceTest {
-    @Inject
-    lateinit var reservationService: ReservationService
+    private lateinit var reservationService: ReservationService
 
-    @InjectMock
-    lateinit var reservationRepository: ReservationRepository
+    private lateinit var reservationRepository: ReservationRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
-    @InjectMock
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
     private val testOrgId = UUID.randomUUID()
     private val testStoreId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        reservationRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        reservationService = ReservationService()
+        reservationService.reservationRepository = reservationRepository
+        reservationService.tenantFilterService = tenantFilterService
+        reservationService.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = testOrgId
         doNothing().whenever(reservationRepository).persist(any<ReservationEntity>())
         doNothing().whenever(tenantFilterService).enableFilter()
-        whenever(organizationIdHolder.organizationId).thenReturn(testOrgId)
     }
 
     @Test
@@ -70,7 +74,9 @@ class ReservationServiceTest {
                 reservedUntil = Instant.now().plusSeconds(86400)
                 status = "RESERVED"
             }
-        whenever(reservationRepository.findById(reservationId)).thenReturn(entity)
+        val mockQuery1 = mock<PanacheQuery<ReservationEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(entity)
+            whenever(reservationRepository.find(eq("id = ?1"), eq(reservationId))).thenReturn(mockQuery1)
 
         val result = reservationService.fulfill(reservationId)
 
@@ -89,7 +95,9 @@ class ReservationServiceTest {
                 reservedUntil = Instant.now().plusSeconds(86400)
                 status = "RESERVED"
             }
-        whenever(reservationRepository.findById(reservationId)).thenReturn(entity)
+        val mockQuery2 = mock<PanacheQuery<ReservationEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(entity)
+            whenever(reservationRepository.find(eq("id = ?1"), eq(reservationId))).thenReturn(mockQuery2)
 
         val result = reservationService.cancel(reservationId)
 

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/ReservationServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/ReservationServiceUnitTest.kt
@@ -5,6 +5,7 @@ import com.openpos.pos.config.TenantFilterService
 import com.openpos.pos.entity.ReservationEntity
 import com.openpos.pos.repository.ReservationRepository
 import io.quarkus.panache.common.Page
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -63,7 +64,9 @@ class ReservationServiceUnitTest {
                     this.items = "[]"
                     this.reservedUntil = Instant.now().plusSeconds(3600)
                 }
-            whenever(reservationRepository.findById(id)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<ReservationEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(entity)
+whenever(reservationRepository.find(eq("id = ?1"), eq(id))).thenReturn(mockQuery1)
 
             val result = service.findById(id)
 
@@ -74,7 +77,9 @@ class ReservationServiceUnitTest {
 
         @Test
         fun `returns null when not found`() {
-            whenever(reservationRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix1 = mock<PanacheQuery<ReservationEntity>>()
+            whenever(mockQueryFix1.firstResult()).thenReturn(null)
+            whenever(reservationRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix1)
 
             val result = service.findById(UUID.randomUUID())
 
@@ -147,7 +152,9 @@ class ReservationServiceUnitTest {
                     this.id = id
                     this.status = "RESERVED"
                 }
-            whenever(reservationRepository.findById(id)).thenReturn(entity)
+            val mockQuery2 = mock<PanacheQuery<ReservationEntity>>()
+whenever(mockQuery2.firstResult()).thenReturn(entity)
+whenever(reservationRepository.find(eq("id = ?1"), eq(id))).thenReturn(mockQuery2)
             doNothing().whenever(reservationRepository).persist(any<ReservationEntity>())
 
             val result = service.fulfill(id)
@@ -158,7 +165,9 @@ class ReservationServiceUnitTest {
 
         @Test
         fun `returns null when not found`() {
-            whenever(reservationRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix2 = mock<PanacheQuery<ReservationEntity>>()
+            whenever(mockQueryFix2.firstResult()).thenReturn(null)
+            whenever(reservationRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix2)
 
             val result = service.fulfill(UUID.randomUUID())
 
@@ -176,7 +185,9 @@ class ReservationServiceUnitTest {
                     this.id = id
                     this.status = "RESERVED"
                 }
-            whenever(reservationRepository.findById(id)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<ReservationEntity>>()
+whenever(mockQuery3.firstResult()).thenReturn(entity)
+whenever(reservationRepository.find(eq("id = ?1"), eq(id))).thenReturn(mockQuery3)
             doNothing().whenever(reservationRepository).persist(any<ReservationEntity>())
 
             val result = service.cancel(id)
@@ -187,7 +198,9 @@ class ReservationServiceUnitTest {
 
         @Test
         fun `returns null when not found`() {
-            whenever(reservationRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix3 = mock<PanacheQuery<ReservationEntity>>()
+            whenever(mockQueryFix3.firstResult()).thenReturn(null)
+            whenever(reservationRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix3)
 
             val result = service.cancel(UUID.randomUUID())
 

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceUnitTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/service/TransactionServiceUnitTest.kt
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.quarkus.panache.common.Page
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -152,7 +153,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `adds new item to transaction`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix1 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix1.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix1)
             whenever(productServiceClient.getProductSnapshot(productId, orgId)).thenReturn(standardProduct)
             whenever(itemRepository.findByTransactionAndProduct(tx.id, productId)).thenReturn(null)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
@@ -183,7 +186,9 @@ class TransactionServiceUnitTest {
                     this.taxAmount = 2000
                     this.total = 22000
                 }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix2 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix2.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix2)
             whenever(productServiceClient.getProductSnapshot(productId, orgId)).thenReturn(standardProduct)
             whenever(itemRepository.findByTransactionAndProduct(tx.id, productId)).thenReturn(existingItem)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(existingItem))
@@ -204,7 +209,9 @@ class TransactionServiceUnitTest {
 
         @Test
         fun `throws when transaction not found`() {
-            whenever(transactionRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix1 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix1.firstResult()).thenReturn(null)
+            whenever(transactionRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix1)
 
             assertThrows(ResourceNotFoundException::class.java) {
                 service.addItem(UUID.randomUUID(), productId, 1)
@@ -214,7 +221,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `uses provided productSnapshot`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix3 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix3.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix3)
             whenever(itemRepository.findByTransactionAndProduct(tx.id, productId)).thenReturn(null)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
@@ -233,8 +242,12 @@ class TransactionServiceUnitTest {
         fun `updates item quantity`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id)
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
-            whenever(itemRepository.findById(item.id)).thenReturn(item)
+            val mockQueryFix4 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix4.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix4)
+            val mockQueryFix1 = mock<PanacheQuery<TransactionItemEntity>>()
+            whenever(mockQueryFix1.firstResult()).thenReturn(item)
+            whenever(itemRepository.find(eq("id = ?1"), eq(item.id))).thenReturn(mockQueryFix1)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
 
@@ -253,8 +266,12 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws when item not found`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
-            whenever(itemRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix5 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix5.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix5)
+            val mockQueryFix1 = mock<PanacheQuery<TransactionItemEntity>>()
+            whenever(mockQueryFix1.firstResult()).thenReturn(null)
+            whenever(itemRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix1)
 
             assertThrows(ResourceNotFoundException::class.java) {
                 service.updateItem(tx.id, UUID.randomUUID(), 5)
@@ -265,8 +282,12 @@ class TransactionServiceUnitTest {
         fun `throws when item belongs to different transaction`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(UUID.randomUUID()) // different transaction
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
-            whenever(itemRepository.findById(item.id)).thenReturn(item)
+            val mockQueryFix6 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix6.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix6)
+            val mockQueryFix2 = mock<PanacheQuery<TransactionItemEntity>>()
+            whenever(mockQueryFix2.firstResult()).thenReturn(item)
+            whenever(itemRepository.find(eq("id = ?1"), eq(item.id))).thenReturn(mockQueryFix2)
 
             assertThrows(BusinessPreconditionException::class.java) {
                 service.updateItem(tx.id, item.id, 5)
@@ -280,8 +301,12 @@ class TransactionServiceUnitTest {
         fun `removes item from transaction`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id)
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
-            whenever(itemRepository.findById(item.id)).thenReturn(item)
+            val mockQueryFix7 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix7.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix7)
+            val mockQueryFix3 = mock<PanacheQuery<TransactionItemEntity>>()
+            whenever(mockQueryFix3.firstResult()).thenReturn(item)
+            whenever(itemRepository.find(eq("id = ?1"), eq(item.id))).thenReturn(mockQueryFix3)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             doNothing().whenever(itemRepository).delete(any<TransactionItemEntity>())
@@ -297,8 +322,12 @@ class TransactionServiceUnitTest {
         fun `throws when item belongs to different transaction`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(UUID.randomUUID())
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
-            whenever(itemRepository.findById(item.id)).thenReturn(item)
+            val mockQueryFix8 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix8.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix8)
+            val mockQueryFix4 = mock<PanacheQuery<TransactionItemEntity>>()
+            whenever(mockQueryFix4.firstResult()).thenReturn(item)
+            whenever(itemRepository.find(eq("id = ?1"), eq(item.id))).thenReturn(mockQueryFix4)
 
             assertThrows(BusinessPreconditionException::class.java) {
                 service.removeItem(tx.id, item.id)
@@ -311,7 +340,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `applies percentage discount`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix9 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix9.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix9)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
 
@@ -324,7 +355,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws on negative discount amount`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix10 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix10.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix10)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.applyDiscount(tx.id, null, "Bad", "PERCENTAGE", "10", -100, null)
@@ -334,7 +367,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws on unknown discount type`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix11 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix11.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix11)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
 
             assertThrows(IllegalArgumentException::class.java) {
@@ -357,7 +392,9 @@ class TransactionServiceUnitTest {
                     this.value = "5"
                     this.amount = 500
                 }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix12 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix12.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix12)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(listOf(existing))
 
             assertThrows(IllegalArgumentException::class.java) {
@@ -369,7 +406,9 @@ class TransactionServiceUnitTest {
         fun `applies fixed amount discount to whole transaction`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id).apply { this.subtotal = 50000 }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix13 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix13.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix13)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
 
@@ -383,7 +422,9 @@ class TransactionServiceUnitTest {
         fun `throws when fixed amount exceeds subtotal`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id).apply { this.subtotal = 1000 }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix14 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix14.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix14)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
 
@@ -396,9 +437,13 @@ class TransactionServiceUnitTest {
         fun `applies fixed amount discount to specific item`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id).apply { this.subtotal = 50000 }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix15 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix15.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix15)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
-            whenever(itemRepository.findById(item.id)).thenReturn(item)
+            val mockQueryFix5 = mock<PanacheQuery<TransactionItemEntity>>()
+            whenever(mockQueryFix5.firstResult()).thenReturn(item)
+            whenever(itemRepository.find(eq("id = ?1"), eq(item.id))).thenReturn(mockQueryFix5)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
 
             val result = service.applyDiscount(tx.id, null, "Item Off", "FIXED_AMOUNT", "1000", 1000, item.id)
@@ -411,9 +456,13 @@ class TransactionServiceUnitTest {
         fun `throws when fixed amount item not found`() {
             val tx = createTransactionEntity()
             val fakeItemId = UUID.randomUUID()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix16 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix16.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix16)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
-            whenever(itemRepository.findById(fakeItemId)).thenReturn(null)
+            val mockQuery1 = mock<PanacheQuery<TransactionItemEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(null)
+whenever(itemRepository.find(eq("id = ?1"), eq(fakeItemId))).thenReturn(mockQuery1)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.applyDiscount(tx.id, null, "Item Off", "FIXED_AMOUNT", "1000", 1000, fakeItemId)
@@ -424,9 +473,13 @@ class TransactionServiceUnitTest {
         fun `throws when fixed amount item belongs to different transaction`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(UUID.randomUUID()).apply { this.subtotal = 50000 } // different transaction
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix17 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix17.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix17)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
-            whenever(itemRepository.findById(item.id)).thenReturn(item)
+            val mockQueryFix6 = mock<PanacheQuery<TransactionItemEntity>>()
+            whenever(mockQueryFix6.firstResult()).thenReturn(item)
+            whenever(itemRepository.find(eq("id = ?1"), eq(item.id))).thenReturn(mockQueryFix6)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.applyDiscount(tx.id, null, "Item Off", "FIXED_AMOUNT", "1000", 1000, item.id)
@@ -436,7 +489,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws on invalid percentage value`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix18 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix18.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix18)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
 
             assertThrows(IllegalArgumentException::class.java) {
@@ -447,7 +502,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws when percentage out of range`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix19 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix19.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix19)
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
 
             assertThrows(IllegalArgumentException::class.java) {
@@ -462,7 +519,9 @@ class TransactionServiceUnitTest {
         fun `finalizes transaction with CASH payment`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id)
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix20 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix20.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix20)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(paymentRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
@@ -479,7 +538,9 @@ class TransactionServiceUnitTest {
 
         @Test
         fun `throws when transaction not found`() {
-            whenever(transactionRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix2 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix2.firstResult()).thenReturn(null)
+            whenever(transactionRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix2)
 
             assertThrows(ResourceNotFoundException::class.java) {
                 service.finalizeTransaction(UUID.randomUUID(), emptyList())
@@ -489,7 +550,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws when transaction not DRAFT`() {
             val tx = createTransactionEntity().apply { this.status = "COMPLETED" }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix21 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix21.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix21)
 
             assertThrows(BusinessPreconditionException::class.java) {
                 service.finalizeTransaction(tx.id, emptyList())
@@ -499,7 +562,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws when no items`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix22 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix22.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix22)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
 
@@ -512,7 +577,9 @@ class TransactionServiceUnitTest {
         fun `throws when payment insufficient`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id)
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix23 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix23.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix23)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
 
@@ -543,7 +610,9 @@ class TransactionServiceUnitTest {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id)
             whenever(transactionRepository.findByIdempotencyKey(idempotencyKey)).thenReturn(null)
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix24 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix24.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix24)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(paymentRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
@@ -560,7 +629,9 @@ class TransactionServiceUnitTest {
         fun `null idempotency key does not store key`() {
             val tx = createTransactionEntity()
             val item = createItemEntity(tx.id)
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix25 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix25.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix25)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(listOf(item))
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(paymentRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
@@ -583,7 +654,9 @@ class TransactionServiceUnitTest {
                     this.status = "COMPLETED"
                     this.completedAt = Instant.now()
                 }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix26 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix26.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix26)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
 
             val result = service.voidTransaction(tx.id, "Customer request")
@@ -594,7 +667,9 @@ class TransactionServiceUnitTest {
 
         @Test
         fun `throws when transaction not found`() {
-            whenever(transactionRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix3 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix3.firstResult()).thenReturn(null)
+            whenever(transactionRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix3)
 
             assertThrows(ResourceNotFoundException::class.java) {
                 service.voidTransaction(UUID.randomUUID(), "reason")
@@ -604,7 +679,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws when not COMPLETED`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix27 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix27.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix27)
 
             assertThrows(BusinessPreconditionException::class.java) {
                 service.voidTransaction(tx.id, "reason")
@@ -614,7 +691,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws when reason is blank`() {
             val tx = createTransactionEntity().apply { this.status = "COMPLETED" }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix28 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix28.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix28)
 
             assertThrows(InvalidInputException::class.java) {
                 service.voidTransaction(tx.id, "  ")
@@ -627,7 +706,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `getTransaction returns entity`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix29 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix29.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix29)
 
             val result = service.getTransaction(tx.id)
 
@@ -636,7 +717,9 @@ class TransactionServiceUnitTest {
 
         @Test
         fun `getTransaction throws when not found`() {
-            whenever(transactionRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix4 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix4.firstResult()).thenReturn(null)
+            whenever(transactionRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix4)
 
             assertThrows(ResourceNotFoundException::class.java) {
                 service.getTransaction(UUID.randomUUID())
@@ -735,7 +818,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `adds custom item to transaction`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix30 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix30.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix30)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             val result = service.addCustomItem(tx.id, "Hand-made item", 50000, 1, standardTaxRate)
@@ -747,7 +832,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `creates item with null productId and correct tax calculation`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix31 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix31.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix31)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             service.addCustomItem(tx.id, "Custom item", 30000, 2, standardTaxRate)
@@ -764,7 +851,9 @@ class TransactionServiceUnitTest {
         @Test
         fun `supports reduced tax rate`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix32 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix32.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix32)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             service.addCustomItem(tx.id, "Food item", 10000, 1, reducedTaxRate)
@@ -795,7 +884,9 @@ class TransactionServiceUnitTest {
 
         @Test
         fun `throws when transaction not found`() {
-            whenever(transactionRepository.findById(any<UUID>())).thenReturn(null)
+            val mockQueryFix5 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix5.firstResult()).thenReturn(null)
+            whenever(transactionRepository.find(eq("id = ?1"), any<UUID>())).thenReturn(mockQueryFix5)
             assertThrows(
                 ResourceNotFoundException::class.java,
             ) { service.addCustomItem(UUID.randomUUID(), "Item", 10000, 1, standardTaxRate) }
@@ -804,14 +895,18 @@ class TransactionServiceUnitTest {
         @Test
         fun `throws when transaction is not DRAFT`() {
             val tx = createTransactionEntity().apply { this.status = "COMPLETED" }
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix33 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix33.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix33)
             assertThrows(BusinessPreconditionException::class.java) { service.addCustomItem(tx.id, "Item", 10000, 1, standardTaxRate) }
         }
 
         @Test
         fun `allows zero unit price for complimentary items`() {
             val tx = createTransactionEntity()
-            whenever(transactionRepository.findById(tx.id)).thenReturn(tx)
+            val mockQueryFix34 = mock<PanacheQuery<TransactionEntity>>()
+            whenever(mockQueryFix34.firstResult()).thenReturn(tx)
+            whenever(transactionRepository.find(eq("id = ?1"), eq(tx.id))).thenReturn(mockQueryFix34)
             whenever(itemRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             whenever(discountRepository.findByTransactionId(tx.id)).thenReturn(emptyList())
             val result = service.addCustomItem(tx.id, "Free sample", 0, 1, standardTaxRate)

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/CategoryService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/CategoryService.kt
@@ -149,12 +149,14 @@ class CategoryService {
                 }
             } catch (e: Exception) {
                 log.warnf("Failed to deserialize category cache: %s", e.message)
-                categoryRepository.findById(id)
+                // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+                categoryRepository.find("id = ?1", id).firstResult()
             }
         }
 
         // cache miss: DB から取得
-        val entity = categoryRepository.findById(id) ?: return null
+        // findById() は em.find() ベースのため HQL クエリを使用して organizationFilter を適用する。
+        val entity = categoryRepository.find("id = ?1", id).firstResult() ?: return null
 
         // キャッシュに書き込み
         try {
@@ -183,7 +185,7 @@ class CategoryService {
             requireNotNull(organizationIdHolder.organizationId) {
                 "organizationId is not set"
             }
-        val entity = categoryRepository.findById(id) ?: return null
+        val entity = categoryRepository.find("id = ?1", id).firstResult() ?: return null
 
         name?.let { entity.name = it }
         // parentId は nullable なので明示的にセット（空文字列の場合も想定）
@@ -209,7 +211,7 @@ class CategoryService {
             requireNotNull(organizationIdHolder.organizationId) {
                 "organizationId is not set"
             }
-        val entity = categoryRepository.findById(id) ?: return false
+        val entity = categoryRepository.find("id = ?1", id).firstResult() ?: return false
         categoryRepository.delete(entity)
         cacheService.invalidateCategory(orgId.toString(), id.toString())
         return true

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/CouponService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/CouponService.kt
@@ -57,8 +57,10 @@ class CouponService {
             }
 
         tenantFilterService.enableFilter()
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
         val discount =
-            requireNotNull(discountRepository.findById(discountId)) {
+            requireNotNull(discountRepository.find("id = ?1", discountId).firstResult()) {
                 "Discount not found or belongs to another tenant: $discountId"
             }
         DiscountService.validateDiscountValue(discount.discountType, discount.value)
@@ -104,7 +106,9 @@ class CouponService {
      */
     fun findById(id: UUID): CouponEntity? {
         tenantFilterService.enableFilter()
-        return couponRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return couponRepository.find("id = ?1", id).firstResult()
     }
 
     /**
@@ -143,7 +147,7 @@ class CouponService {
         }
 
         // 紐付き割引の有効性チェック
-        val discount = discountRepository.findById(coupon.discountId)
+        val discount = discountRepository.find("id = ?1", coupon.discountId).firstResult()
         if (discount == null || !discount.isActive) {
             return CouponValidationResult(isValid = false, coupon = coupon, reason = "DISCOUNT_INACTIVE")
         }
@@ -185,7 +189,7 @@ class CouponService {
             }
         }
 
-        val discount = discountRepository.findById(coupon.discountId)
+        val discount = discountRepository.find("id = ?1", coupon.discountId).firstResult()
         if (discount == null || !discount.isActive) {
             return CouponValidationResult(isValid = false, coupon = coupon, reason = "DISCOUNT_INACTIVE")
         }

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/DiscountService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/DiscountService.kt
@@ -143,12 +143,14 @@ class DiscountService {
                 dto.toEntity()
             } catch (e: Exception) {
                 log.warnf("Failed to deserialize discount cache: %s", e.message)
-                discountRepository.findById(id)
+                // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+                discountRepository.find("id = ?1", id).firstResult()
             }
         }
 
         // cache miss: DB から取得
-        val entity = discountRepository.findById(id) ?: return null
+        // findById() は em.find() ベースのため HQL クエリを使用して organizationFilter を適用する。
+        val entity = discountRepository.find("id = ?1", id).firstResult() ?: return null
 
         // キャッシュに書き込み
         try {
@@ -170,7 +172,7 @@ class DiscountService {
             requireNotNull(organizationIdHolder.organizationId) {
                 "organizationId is not set"
             }
-        val entity = discountRepository.findById(id) ?: return false
+        val entity = discountRepository.find("id = ?1", id).firstResult() ?: return false
         entity.isActive = false
         discountRepository.persist(entity)
         cacheService.invalidate(discountKey(orgId.toString(), id.toString()))
@@ -196,7 +198,7 @@ class DiscountService {
             requireNotNull(organizationIdHolder.organizationId) {
                 "organizationId is not set"
             }
-        val entity = discountRepository.findById(id) ?: return null
+        val entity = discountRepository.find("id = ?1", id).firstResult() ?: return null
 
         name?.let { entity.name = it }
         discountType?.let { entity.discountType = it }

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/ProductService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/ProductService.kt
@@ -81,7 +81,9 @@ class ProductService {
      */
     fun findById(id: UUID): ProductEntity? {
         tenantFilterService.enableFilter()
-        return productRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return productRepository.find("id = ?1", id).firstResult()
     }
 
     /**
@@ -137,7 +139,7 @@ class ProductService {
         isActive: Boolean?,
     ): ProductEntity? {
         tenantFilterService.enableFilter()
-        val entity = productRepository.findById(id) ?: return null
+        val entity = productRepository.find("id = ?1", id).firstResult() ?: return null
 
         validateForeignKeyOwnership(categoryId, taxRateId)
 
@@ -166,7 +168,7 @@ class ProductService {
     @Transactional
     fun delete(id: UUID): Boolean {
         tenantFilterService.enableFilter()
-        val entity = productRepository.findById(id) ?: return false
+        val entity = productRepository.find("id = ?1", id).firstResult() ?: return false
         entity.isActive = false
         entity.deletedAt = java.time.Instant.now()
         productRepository.persist(entity)
@@ -175,20 +177,21 @@ class ProductService {
 
     /**
      * categoryId / taxRateId が現在のテナントに属するか検証する。
-     * テナントフィルタが有効な状態で findById を呼ぶことで、
-     * 他テナントのレコードは null になり検出できる。
+     * findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+     * HQL クエリで organizationFilter が有効な状態で検索し、
+     * 他テナントのレコードは null になることで検出する。
      */
     private fun validateForeignKeyOwnership(
         categoryId: UUID?,
         taxRateId: UUID?,
     ) {
         categoryId?.let { id ->
-            requireNotNull(categoryRepository.findById(id)) {
+            requireNotNull(categoryRepository.find("id = ?1", id).firstResult()) {
                 "Category not found or belongs to another tenant: $id"
             }
         }
         taxRateId?.let { id ->
-            requireNotNull(taxRateRepository.findById(id)) {
+            requireNotNull(taxRateRepository.find("id = ?1", id).firstResult()) {
                 "TaxRate not found or belongs to another tenant: $id"
             }
         }

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/ProductVariantService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/ProductVariantService.kt
@@ -54,8 +54,9 @@ class ProductVariantService {
 
         // テナント検証: Hibernate Filter 有効状態で親商品を取得し、
         // 他テナントの productId が指定された場合は null になるため NOT_FOUND として拒否する
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
         tenantFilterService.enableFilter()
-        requireNotNull(productRepository.findById(productId)) {
+        requireNotNull(productRepository.find("id = ?1", productId).firstResult()) {
             "Product not found or belongs to another tenant: $productId"
         }
 
@@ -84,7 +85,9 @@ class ProductVariantService {
         displayOrder: Int?,
     ): ProductVariantEntity {
         tenantFilterService.enableFilter()
-        val entity = requireNotNull(variantRepository.findById(id)) { "Variant not found: $id" }
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        val entity = requireNotNull(variantRepository.find("id = ?1", id).firstResult()) { "Variant not found: $id" }
         name?.let { entity.name = it }
         sku?.let { entity.sku = it }
         barcode?.let { entity.barcode = it }
@@ -98,6 +101,10 @@ class ProductVariantService {
     @Transactional
     fun delete(id: java.util.UUID): Boolean {
         tenantFilterService.enableFilter()
-        return variantRepository.deleteById(id)
+        // deleteById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        val entity = variantRepository.find("id = ?1", id).firstResult() ?: return false
+        variantRepository.delete(entity)
+        return true
     }
 }

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateScheduleService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateScheduleService.kt
@@ -8,10 +8,10 @@ import com.openpos.product.repository.TaxRateScheduleRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.transaction.Transactional
+import org.jboss.logging.Logger
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
-import org.jboss.logging.Logger
 
 /**
  * 税率変更スケジュールサービス。
@@ -74,7 +74,8 @@ class TaxRateScheduleService {
         var applied = 0
 
         for (schedule in pending) {
-            val taxRate = taxRateRepository.findById(schedule.taxRateId)
+            // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+            val taxRate = taxRateRepository.find("id = ?1", schedule.taxRateId).firstResult()
             if (taxRate != null) {
                 taxRate.rate = schedule.newRate
                 taxRateRepository.persist(taxRate)

--- a/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateService.kt
+++ b/services/product-service/src/main/kotlin/com/openpos/product/service/TaxRateService.kt
@@ -70,7 +70,9 @@ class TaxRateService {
      */
     fun findById(id: UUID): TaxRateEntity? {
         tenantFilterService.enableFilter()
-        return taxRateRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return taxRateRepository.find("id = ?1", id).firstResult()
     }
 
     /**
@@ -79,7 +81,7 @@ class TaxRateService {
     @Transactional
     fun delete(id: UUID): Boolean {
         tenantFilterService.enableFilter()
-        val entity = taxRateRepository.findById(id) ?: return false
+        val entity = taxRateRepository.find("id = ?1", id).firstResult() ?: return false
         entity.isActive = false
         taxRateRepository.persist(entity)
         return true
@@ -98,7 +100,7 @@ class TaxRateService {
         isDefault: Boolean?,
     ): TaxRateEntity? {
         tenantFilterService.enableFilter()
-        val entity = taxRateRepository.findById(id) ?: return null
+        val entity = taxRateRepository.find("id = ?1", id).firstResult() ?: return null
 
         name?.let { entity.name = it }
         rate?.let { entity.rate = it }

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/CategoryServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/CategoryServiceTest.kt
@@ -1,13 +1,12 @@
 package com.openpos.product.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openpos.product.cache.ProductCacheService
 import com.openpos.product.config.OrganizationIdHolder
 import com.openpos.product.config.TenantFilterService
 import com.openpos.product.entity.CategoryEntity
 import com.openpos.product.repository.CategoryRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -18,31 +17,39 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
 class CategoryServiceTest {
-    @Inject
-    lateinit var categoryService: CategoryService
+    private lateinit var categoryService: CategoryService
 
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
-    @InjectMock
-    lateinit var categoryRepository: CategoryRepository
+    private lateinit var categoryRepository: CategoryRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
-    @InjectMock
-    lateinit var cacheService: ProductCacheService
+    private lateinit var cacheService: ProductCacheService
 
     private val orgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        categoryRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+        cacheService = mock()
+
+        categoryService = CategoryService()
+        categoryService.categoryRepository = categoryRepository
+        categoryService.tenantFilterService = tenantFilterService
+        categoryService.organizationIdHolder = organizationIdHolder
+        categoryService.cacheService = cacheService
+        categoryService.objectMapper = ObjectMapper()
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
         doNothing().whenever(cacheService).invalidateCategory(any(), any())
@@ -176,7 +183,9 @@ class CategoryServiceTest {
                     this.name = "フード"
                     this.displayOrder = 1
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(entity)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery1)
 
             // Act
             val result = categoryService.findById(categoryId)
@@ -192,7 +201,9 @@ class CategoryServiceTest {
         fun `存在しないIDの場合はnullを返す`() {
             // Arrange
             val categoryId = UUID.randomUUID()
-            whenever(categoryRepository.findById(categoryId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery2)
 
             // Act
             val result = categoryService.findById(categoryId)
@@ -220,7 +231,9 @@ class CategoryServiceTest {
                     this.icon = "old-icon"
                     this.displayOrder = 1
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(entity)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery3)
             doNothing().whenever(categoryRepository).persist(any<CategoryEntity>())
 
             // Act
@@ -257,7 +270,9 @@ class CategoryServiceTest {
                     this.color = "#FF0000"
                     this.displayOrder = 1
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery4 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(entity)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery4)
             doNothing().whenever(categoryRepository).persist(any<CategoryEntity>())
 
             // Act
@@ -282,7 +297,9 @@ class CategoryServiceTest {
         fun `存在しないカテゴリの更新はnullを返す`() {
             // Arrange
             val categoryId = UUID.randomUUID()
-            whenever(categoryRepository.findById(categoryId)).thenReturn(null)
+            val mockQuery5 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(null)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery5)
 
             // Act
             val result =
@@ -316,7 +333,9 @@ class CategoryServiceTest {
                     this.name = "削除対象カテゴリ"
                     this.displayOrder = 0
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery6 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery6.firstResult()).thenReturn(entity)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery6)
             doNothing().whenever(categoryRepository).delete(any<CategoryEntity>())
 
             // Act
@@ -332,7 +351,9 @@ class CategoryServiceTest {
         fun `存在しないカテゴリの削除はfalseを返す`() {
             // Arrange
             val categoryId = UUID.randomUUID()
-            whenever(categoryRepository.findById(categoryId)).thenReturn(null)
+            val mockQuery7 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery7.firstResult()).thenReturn(null)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery7)
 
             // Act
             val result = categoryService.delete(categoryId)

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/CategoryServiceUnitTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/CategoryServiceUnitTest.kt
@@ -6,6 +6,7 @@ import com.openpos.product.config.OrganizationIdHolder
 import com.openpos.product.config.TenantFilterService
 import com.openpos.product.entity.CategoryEntity
 import com.openpos.product.repository.CategoryRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -197,7 +198,9 @@ class CategoryServiceUnitTest {
                     this.name = "DB Fallback"
                     this.displayOrder = 1
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<CategoryEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(entity)
+whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery1)
 
             val result = service.findById(categoryId)
 
@@ -220,7 +223,9 @@ class CategoryServiceUnitTest {
                     this.name = "DB Entity"
                     this.displayOrder = 1
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery2 = mock<PanacheQuery<CategoryEntity>>()
+whenever(mockQuery2.firstResult()).thenReturn(entity)
+whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery2)
 
             val result = service.findById(categoryId)
 
@@ -244,7 +249,9 @@ class CategoryServiceUnitTest {
                     this.name = "Fallback Entity"
                     this.displayOrder = 1
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<CategoryEntity>>()
+whenever(mockQuery3.firstResult()).thenReturn(entity)
+whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery3)
 
             val result = service.findById(categoryId)
 
@@ -258,7 +265,9 @@ class CategoryServiceUnitTest {
             val cacheKey = "openpos:product-service:$orgId:category:$categoryId"
             whenever(cacheService.categoryKey(eq(orgId.toString()), eq(categoryId.toString()))).thenReturn(cacheKey)
             whenever(cacheService.get(cacheKey)).thenReturn(null)
-            whenever(categoryRepository.findById(categoryId)).thenReturn(null)
+            val mockQuery4 = mock<PanacheQuery<CategoryEntity>>()
+whenever(mockQuery4.firstResult()).thenReturn(null)
+whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery4)
 
             val result = service.findById(categoryId)
 
@@ -293,7 +302,9 @@ class CategoryServiceUnitTest {
                     this.name = "Old"
                     this.displayOrder = 1
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery5 = mock<PanacheQuery<CategoryEntity>>()
+whenever(mockQuery5.firstResult()).thenReturn(entity)
+whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery5)
             doNothing().whenever(categoryRepository).persist(any<CategoryEntity>())
 
             val result = service.update(categoryId, "New Name", newParentId, "#00FF00", "new-icon", 5)
@@ -313,7 +324,9 @@ class CategoryServiceUnitTest {
         @Test
         fun `returns null when category not found`() {
             val categoryId = UUID.randomUUID()
-            whenever(categoryRepository.findById(categoryId)).thenReturn(null)
+            val mockQuery6 = mock<PanacheQuery<CategoryEntity>>()
+whenever(mockQuery6.firstResult()).thenReturn(null)
+whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery6)
 
             val result = service.update(categoryId, "New", null, null, null, null)
 
@@ -333,7 +346,9 @@ class CategoryServiceUnitTest {
                     this.name = "To Delete"
                     this.displayOrder = 0
                 }
-            whenever(categoryRepository.findById(categoryId)).thenReturn(entity)
+            val mockQuery7 = mock<PanacheQuery<CategoryEntity>>()
+whenever(mockQuery7.firstResult()).thenReturn(entity)
+whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery7)
             doNothing().whenever(categoryRepository).delete(any<CategoryEntity>())
 
             val result = service.delete(categoryId)
@@ -345,7 +360,9 @@ class CategoryServiceUnitTest {
         @Test
         fun `returns false when category not found`() {
             val categoryId = UUID.randomUUID()
-            whenever(categoryRepository.findById(categoryId)).thenReturn(null)
+            val mockQuery8 = mock<PanacheQuery<CategoryEntity>>()
+whenever(mockQuery8.firstResult()).thenReturn(null)
+whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockQuery8)
 
             val result = service.delete(categoryId)
 

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/CouponServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/CouponServiceTest.kt
@@ -6,9 +6,9 @@ import com.openpos.product.entity.CouponEntity
 import com.openpos.product.entity.DiscountEntity
 import com.openpos.product.repository.CouponRepository
 import com.openpos.product.repository.DiscountRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -26,28 +26,33 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
-@QuarkusTest
 class CouponServiceTest {
-    @Inject
-    lateinit var couponService: CouponService
+    private lateinit var couponService: CouponService
 
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
-    @InjectMock
-    lateinit var couponRepository: CouponRepository
+    private lateinit var couponRepository: CouponRepository
 
-    @InjectMock
-    lateinit var discountRepository: DiscountRepository
+    private lateinit var discountRepository: DiscountRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
     private val orgId = UUID.randomUUID()
     private val discountId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        couponRepository = mock()
+        discountRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        couponService = CouponService()
+        couponService.couponRepository = couponRepository
+        couponService.discountRepository = discountRepository
+        couponService.tenantFilterService = tenantFilterService
+        couponService.organizationIdHolder = organizationIdHolder
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
     }
@@ -71,7 +76,9 @@ class CouponServiceTest {
                     this.value = 10
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(discount)
+            val mockQuery1 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(discount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery1)
 
             // Act
             val result =
@@ -108,7 +115,9 @@ class CouponServiceTest {
                     this.value = 50000
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(discount)
+            val mockQuery2 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(discount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery2)
 
             // Act
             val result =
@@ -132,7 +141,9 @@ class CouponServiceTest {
         @Test
         fun `存在しない割引IDの場合はIllegalArgumentExceptionを投げる`() {
             // Arrange
-            whenever(discountRepository.findById(discountId)).thenReturn(null)
+            val mockQuery3 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(null)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery3)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {
@@ -158,7 +169,9 @@ class CouponServiceTest {
                     this.value = 150
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(invalidDiscount)
+            val mockQuery4 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(invalidDiscount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery4)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {
@@ -230,7 +243,9 @@ class CouponServiceTest {
                     this.discountId = this@CouponServiceTest.discountId
                     this.usedCount = 0
                 }
-            whenever(couponRepository.findById(couponId)).thenReturn(entity)
+            val mockQuery5 = mock<PanacheQuery<CouponEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(entity)
+            whenever(couponRepository.find(eq("id = ?1"), eq(couponId))).thenReturn(mockQuery5)
 
             // Act
             val result = couponService.findById(couponId)
@@ -245,7 +260,9 @@ class CouponServiceTest {
         fun `存在しないIDの場合はnullを返す`() {
             // Arrange
             val couponId = UUID.randomUUID()
-            whenever(couponRepository.findById(couponId)).thenReturn(null)
+            val mockQuery6 = mock<PanacheQuery<CouponEntity>>()
+            whenever(mockQuery6.firstResult()).thenReturn(null)
+            whenever(couponRepository.find(eq("id = ?1"), eq(couponId))).thenReturn(mockQuery6)
 
             // Act
             val result = couponService.findById(couponId)
@@ -396,7 +413,9 @@ class CouponServiceTest {
                     this.isActive = false
                 }
             whenever(couponRepository.findByCodeForUpdate("INACTIVE_DISC")).thenReturn(entity)
-            whenever(discountRepository.findById(discountId)).thenReturn(inactiveDiscount)
+            val mockQuery7 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery7.firstResult()).thenReturn(inactiveDiscount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery7)
 
             // Act
             val result = couponService.redeem("INACTIVE_DISC")
@@ -421,7 +440,9 @@ class CouponServiceTest {
                     this.validUntil = Instant.now().plus(7, ChronoUnit.DAYS)
                 }
             whenever(couponRepository.findByCodeForUpdate("NO_DISC")).thenReturn(entity)
-            whenever(discountRepository.findById(discountId)).thenReturn(null)
+            val mockQuery8 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery8.firstResult()).thenReturn(null)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery8)
 
             // Act
             val result = couponService.redeem("NO_DISC")
@@ -456,7 +477,9 @@ class CouponServiceTest {
                     this.isActive = true
                 }
             whenever(couponRepository.findByCodeForUpdate("VALID")).thenReturn(entity)
-            whenever(discountRepository.findById(discountId)).thenReturn(activeDiscount)
+            val mockQuery9 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery9.firstResult()).thenReturn(activeDiscount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery9)
             doNothing().whenever(couponRepository).persist(any<CouponEntity>())
 
             // Act
@@ -495,7 +518,9 @@ class CouponServiceTest {
                     this.isActive = true
                 }
             whenever(couponRepository.findByCodeForUpdate("UNLIMITED")).thenReturn(entity)
-            whenever(discountRepository.findById(discountId)).thenReturn(activeDiscount)
+            val mockQuery10 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery10.firstResult()).thenReturn(activeDiscount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery10)
             doNothing().whenever(couponRepository).persist(any<CouponEntity>())
 
             // Act
@@ -650,7 +675,9 @@ class CouponServiceTest {
                     this.isActive = false
                 }
             whenever(couponRepository.findByCode("INACTIVE_DISC")).thenReturn(entity)
-            whenever(discountRepository.findById(discountId)).thenReturn(inactiveDiscount)
+            val mockQuery11 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery11.firstResult()).thenReturn(inactiveDiscount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery11)
 
             // Act
             val result = couponService.validate("INACTIVE_DISC")
@@ -675,7 +702,9 @@ class CouponServiceTest {
                     this.validUntil = Instant.now().plus(7, ChronoUnit.DAYS)
                 }
             whenever(couponRepository.findByCode("NO_DISC")).thenReturn(entity)
-            whenever(discountRepository.findById(discountId)).thenReturn(null)
+            val mockQuery12 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery12.firstResult()).thenReturn(null)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery12)
 
             // Act
             val result = couponService.validate("NO_DISC")
@@ -710,7 +739,9 @@ class CouponServiceTest {
                     this.isActive = true
                 }
             whenever(couponRepository.findByCode("VALID")).thenReturn(entity)
-            whenever(discountRepository.findById(discountId)).thenReturn(activeDiscount)
+            val mockQuery13 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery13.firstResult()).thenReturn(activeDiscount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery13)
 
             // Act
             val result = couponService.validate("VALID")
@@ -748,7 +779,9 @@ class CouponServiceTest {
                     this.isActive = true
                 }
             whenever(couponRepository.findByCode("UNLIMITED")).thenReturn(entity)
-            whenever(discountRepository.findById(discountId)).thenReturn(activeDiscount)
+            val mockQuery14 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery14.firstResult()).thenReturn(activeDiscount)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery14)
 
             // Act
             val result = couponService.validate("UNLIMITED")

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/DiscountServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/DiscountServiceTest.kt
@@ -1,12 +1,11 @@
 package com.openpos.product.service
 
+import com.openpos.product.cache.ProductCacheService
 import com.openpos.product.config.OrganizationIdHolder
 import com.openpos.product.config.TenantFilterService
 import com.openpos.product.entity.DiscountEntity
 import com.openpos.product.repository.DiscountRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -17,30 +16,43 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
-@QuarkusTest
 class DiscountServiceTest {
-    @Inject
-    lateinit var discountService: DiscountService
+    private lateinit var discountService: DiscountService
 
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
-    @InjectMock
-    lateinit var discountRepository: DiscountRepository
+    private lateinit var discountRepository: DiscountRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
+
+    private lateinit var cacheService: ProductCacheService
 
     private val orgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        discountRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+        cacheService = mock()
+
+        discountService = DiscountService()
+        discountService.discountRepository = discountRepository
+        discountService.tenantFilterService = tenantFilterService
+        discountService.organizationIdHolder = organizationIdHolder
+        discountService.cacheService = cacheService
+        discountService.objectMapper =
+            com.fasterxml.jackson.databind
+                .ObjectMapper()
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
     }
@@ -295,7 +307,9 @@ class DiscountServiceTest {
                     this.value = 15
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(entity)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery1)
 
             // Act
             val result = discountService.findById(discountId)
@@ -311,7 +325,9 @@ class DiscountServiceTest {
         fun `存在しないIDの場合はnullを返す`() {
             // Arrange
             val discountId = UUID.randomUUID()
-            whenever(discountRepository.findById(discountId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery2)
 
             // Act
             val result = discountService.findById(discountId)
@@ -341,7 +357,9 @@ class DiscountServiceTest {
                     this.validUntil = Instant.now().plus(7, ChronoUnit.DAYS)
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(entity)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery3)
             doNothing().whenever(discountRepository).persist(any<DiscountEntity>())
 
             // Act
@@ -379,7 +397,9 @@ class DiscountServiceTest {
                     this.value = 50000
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            val mockQuery4 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(entity)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery4)
             doNothing().whenever(discountRepository).persist(any<DiscountEntity>())
 
             // Act
@@ -404,7 +424,9 @@ class DiscountServiceTest {
         fun `存在しない割引の更新はnullを返す`() {
             // Arrange
             val discountId = UUID.randomUUID()
-            whenever(discountRepository.findById(discountId)).thenReturn(null)
+            val mockQuery5 = mock<PanacheQuery<DiscountEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(null)
+            whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery5)
 
             // Act
             val result =

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/DiscountServiceUnitTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/DiscountServiceUnitTest.kt
@@ -6,6 +6,7 @@ import com.openpos.product.config.OrganizationIdHolder
 import com.openpos.product.config.TenantFilterService
 import com.openpos.product.entity.DiscountEntity
 import com.openpos.product.repository.DiscountRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -88,7 +89,9 @@ class DiscountServiceUnitTest {
                     this.value = 10
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<DiscountEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(entity)
+whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery1)
 
             val result = service.findById(discountId)
 
@@ -111,7 +114,9 @@ class DiscountServiceUnitTest {
                     this.value = 50000
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            val mockQuery2 = mock<PanacheQuery<DiscountEntity>>()
+whenever(mockQuery2.firstResult()).thenReturn(entity)
+whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery2)
 
             val result = service.findById(discountId)
 
@@ -123,7 +128,9 @@ class DiscountServiceUnitTest {
         fun `returns null when not in cache or DB`() {
             val discountId = UUID.randomUUID()
             whenever(cacheService.get(any())).thenReturn(null)
-            whenever(discountRepository.findById(discountId)).thenReturn(null)
+            val mockQuery3 = mock<PanacheQuery<DiscountEntity>>()
+whenever(mockQuery3.firstResult()).thenReturn(null)
+whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery3)
 
             val result = service.findById(discountId)
 
@@ -145,7 +152,9 @@ class DiscountServiceUnitTest {
                     this.value = 5
                     this.isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            val mockQuery4 = mock<PanacheQuery<DiscountEntity>>()
+whenever(mockQuery4.firstResult()).thenReturn(entity)
+whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery4)
 
             val result = service.findById(discountId)
 
@@ -261,7 +270,9 @@ class DiscountServiceUnitTest {
                     value = 10
                     isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            val mockQuery5 = mock<PanacheQuery<DiscountEntity>>()
+whenever(mockQuery5.firstResult()).thenReturn(entity)
+whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery5)
             doNothing().whenever(cacheService).invalidate(any())
             doNothing().whenever(cacheService).invalidatePattern(any())
 
@@ -290,7 +301,9 @@ class DiscountServiceUnitTest {
                     value = 10
                     isActive = true
                 }
-            whenever(discountRepository.findById(discountId)).thenReturn(entity)
+            val mockQuery6 = mock<PanacheQuery<DiscountEntity>>()
+whenever(mockQuery6.firstResult()).thenReturn(entity)
+whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery6)
             doNothing().whenever(cacheService).invalidate(any())
             doNothing().whenever(cacheService).invalidatePattern(any())
 
@@ -305,7 +318,9 @@ class DiscountServiceUnitTest {
         @Test
         fun `delete returns false when entity not found`() {
             val discountId = UUID.randomUUID()
-            whenever(discountRepository.findById(discountId)).thenReturn(null)
+            val mockQuery7 = mock<PanacheQuery<DiscountEntity>>()
+whenever(mockQuery7.firstResult()).thenReturn(null)
+whenever(discountRepository.find(eq("id = ?1"), eq(discountId))).thenReturn(mockQuery7)
 
             val result = service.delete(discountId)
 

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/ProductServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/ProductServiceTest.kt
@@ -9,10 +9,8 @@ import com.openpos.product.entity.TaxRateEntity
 import com.openpos.product.repository.CategoryRepository
 import com.openpos.product.repository.ProductRepository
 import com.openpos.product.repository.TaxRateRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import io.quarkus.panache.common.Page
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -25,32 +23,26 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
 class ProductServiceTest {
-    @Inject
-    lateinit var productService: ProductService
+    private lateinit var productService: ProductService
 
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
-    @InjectMock
-    lateinit var productRepository: ProductRepository
+    private lateinit var productRepository: ProductRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
-    @InjectMock
-    lateinit var categoryRepository: CategoryRepository
+    private lateinit var categoryRepository: CategoryRepository
 
-    @InjectMock
-    lateinit var taxRateRepository: TaxRateRepository
+    private lateinit var taxRateRepository: TaxRateRepository
 
-    @InjectMock
-    lateinit var cacheService: ProductCacheService
+    private lateinit var cacheService: ProductCacheService
 
     private val orgId = UUID.randomUUID()
     private val categoryId = UUID.randomUUID()
@@ -58,21 +50,36 @@ class ProductServiceTest {
 
     @BeforeEach
     fun setUp() {
+        productRepository = mock()
+        categoryRepository = mock()
+        taxRateRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+        cacheService = mock()
+
+        productService = ProductService()
+        productService.productRepository = productRepository
+        productService.categoryRepository = categoryRepository
+        productService.taxRateRepository = taxRateRepository
+        productService.tenantFilterService = tenantFilterService
+        productService.organizationIdHolder = organizationIdHolder
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
-        doNothing().whenever(cacheService).invalidateProduct(any(), any(), anyOrNull())
-        doNothing().whenever(cacheService).invalidateCategory(any(), any())
-        doNothing().whenever(cacheService).invalidateAllCategoryLists(any())
 
-        // FK 検証: デフォルトで同一テナントのレコードとして返す
-        whenever(categoryRepository.findById(categoryId)).thenReturn(
+        // FK 検証: デフォルトで同一テナントのレコードとして返す（HQL パターン）
+        val mockCatQuery = mock<PanacheQuery<CategoryEntity>>()
+        whenever(mockCatQuery.firstResult()).thenReturn(
             CategoryEntity().apply {
                 this.id = categoryId
                 this.organizationId = orgId
                 this.name = "テストカテゴリ"
             },
         )
-        whenever(taxRateRepository.findById(taxRateId)).thenReturn(
+        whenever(categoryRepository.find(eq("id = ?1"), eq(categoryId))).thenReturn(mockCatQuery)
+
+        val mockTaxQuery = mock<PanacheQuery<TaxRateEntity>>()
+        whenever(mockTaxQuery.firstResult()).thenReturn(
             TaxRateEntity().apply {
                 this.id = taxRateId
                 this.organizationId = orgId
@@ -80,6 +87,7 @@ class ProductServiceTest {
                 this.rate = java.math.BigDecimal("10.00")
             },
         )
+        whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockTaxQuery)
     }
 
     // === create ===
@@ -201,7 +209,9 @@ class ProductServiceTest {
         fun `他テナントのcategoryIdで作成するとIllegalArgumentException`() {
             // Arrange: categoryId が他テナント（テナントフィルタで null 返却）
             val otherTenantCategoryId = UUID.randomUUID()
-            whenever(categoryRepository.findById(otherTenantCategoryId)).thenReturn(null)
+            val mockQuery1 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(null)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(otherTenantCategoryId))).thenReturn(mockQuery1)
             doNothing().whenever(productRepository).persist(any<ProductEntity>())
 
             // Act & Assert
@@ -224,7 +234,9 @@ class ProductServiceTest {
         fun `他テナントのtaxRateIdで作成するとIllegalArgumentException`() {
             // Arrange: taxRateId が他テナント
             val otherTenantTaxRateId = UUID.randomUUID()
-            whenever(taxRateRepository.findById(otherTenantTaxRateId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(otherTenantTaxRateId))).thenReturn(mockQuery2)
             doNothing().whenever(productRepository).persist(any<ProductEntity>())
 
             // Act & Assert
@@ -256,10 +268,14 @@ class ProductServiceTest {
                     this.displayOrder = 0
                     this.isActive = true
                 }
-            whenever(productRepository.findById(productId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(entity)
+            whenever(productRepository.find(eq("id = ?1"), eq(productId))).thenReturn(mockQuery3)
 
             val otherTenantCategoryId = UUID.randomUUID()
-            whenever(categoryRepository.findById(otherTenantCategoryId)).thenReturn(null)
+            val mockQuery4 = mock<PanacheQuery<CategoryEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(null)
+            whenever(categoryRepository.find(eq("id = ?1"), eq(otherTenantCategoryId))).thenReturn(mockQuery4)
 
             // Act & Assert
             assertThrows(IllegalArgumentException::class.java) {
@@ -297,7 +313,9 @@ class ProductServiceTest {
                     this.displayOrder = 1
                     this.isActive = true
                 }
-            whenever(productRepository.findById(productId)).thenReturn(entity)
+            val mockQuery5 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(entity)
+            whenever(productRepository.find(eq("id = ?1"), eq(productId))).thenReturn(mockQuery5)
 
             // Act
             val result = productService.findById(productId)
@@ -307,14 +325,16 @@ class ProductServiceTest {
             assertEquals(productId, result!!.id)
             assertEquals("テスト商品", result.name)
             verify(tenantFilterService).enableFilter()
-            verify(productRepository).findById(productId)
+            verify(productRepository).find(eq("id = ?1"), eq(productId))
         }
 
         @Test
         fun `存在しないIDの場合はnullを返す`() {
             // Arrange
             val productId = UUID.randomUUID()
-            whenever(productRepository.findById(productId)).thenReturn(null)
+            val mockQuery6 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery6.firstResult()).thenReturn(null)
+            whenever(productRepository.find(eq("id = ?1"), eq(productId))).thenReturn(mockQuery6)
 
             // Act
             val result = productService.findById(productId)
@@ -515,7 +535,9 @@ class ProductServiceTest {
                     this.displayOrder = 1
                     this.isActive = true
                 }
-            whenever(productRepository.findById(productId)).thenReturn(entity)
+            val mockQuery7 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery7.firstResult()).thenReturn(entity)
+            whenever(productRepository.find(eq("id = ?1"), eq(productId))).thenReturn(mockQuery7)
             doNothing().whenever(productRepository).persist(any<ProductEntity>())
 
             // Act
@@ -550,7 +572,9 @@ class ProductServiceTest {
         fun `存在しない商品の更新はnullを返す`() {
             // Arrange
             val productId = UUID.randomUUID()
-            whenever(productRepository.findById(productId)).thenReturn(null)
+            val mockQuery8 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery8.firstResult()).thenReturn(null)
+            whenever(productRepository.find(eq("id = ?1"), eq(productId))).thenReturn(mockQuery8)
 
             // Act
             val result =
@@ -591,7 +615,9 @@ class ProductServiceTest {
                     this.displayOrder = 0
                     this.isActive = true
                 }
-            whenever(productRepository.findById(productId)).thenReturn(entity)
+            val mockQuery9 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery9.firstResult()).thenReturn(entity)
+            whenever(productRepository.find(eq("id = ?1"), eq(productId))).thenReturn(mockQuery9)
             doNothing().whenever(productRepository).persist(any<ProductEntity>())
 
             // Act
@@ -608,7 +634,9 @@ class ProductServiceTest {
         fun `存在しない商品の削除はfalseを返す`() {
             // Arrange
             val productId = UUID.randomUUID()
-            whenever(productRepository.findById(productId)).thenReturn(null)
+            val mockQuery10 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery10.firstResult()).thenReturn(null)
+            whenever(productRepository.find(eq("id = ?1"), eq(productId))).thenReturn(mockQuery10)
 
             // Act
             val result = productService.delete(productId)

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/ProductVariantServiceUnitTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/ProductVariantServiceUnitTest.kt
@@ -6,6 +6,7 @@ import com.openpos.product.entity.ProductEntity
 import com.openpos.product.entity.ProductVariantEntity
 import com.openpos.product.repository.ProductRepository
 import com.openpos.product.repository.ProductVariantRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -48,14 +50,16 @@ class ProductVariantServiceUnitTest {
         doNothing().whenever(tenantFilterService).enableFilter()
         doNothing().whenever(variantRepository).persist(any<ProductVariantEntity>())
 
-        // デフォルト: 親商品がテナント内に存在する
-        whenever(productRepository.findById(productId)).thenReturn(
+        // デフォルト: 親商品がテナント内に存在する（HQL パターン）
+        val mockDefaultProductQuery = mock<PanacheQuery<ProductEntity>>()
+        whenever(mockDefaultProductQuery.firstResult()).thenReturn(
             ProductEntity().apply {
                 id = productId
                 organizationId = orgId
                 name = "テスト商品"
             },
         )
+        whenever(productRepository.find(eq("id = ?1"), eq(productId))).thenReturn(mockDefaultProductQuery)
     }
 
     @Nested
@@ -121,7 +125,9 @@ class ProductVariantServiceUnitTest {
         fun `throws when productId belongs to another tenant`() {
             // Arrange — テナントフィルタ有効時に他テナントの product は null が返る
             val otherTenantProductId = UUID.randomUUID()
-            whenever(productRepository.findById(otherTenantProductId)).thenReturn(null)
+            val mockQuery1 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(null)
+            whenever(productRepository.find(eq("id = ?1"), eq(otherTenantProductId))).thenReturn(mockQuery1)
 
             // Act & Assert
             val exception =
@@ -136,7 +142,9 @@ class ProductVariantServiceUnitTest {
         fun `throws when productId does not exist`() {
             // Arrange — 存在しない productId
             val nonExistentProductId = UUID.randomUUID()
-            whenever(productRepository.findById(nonExistentProductId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<ProductEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(productRepository.find(eq("id = ?1"), eq(nonExistentProductId))).thenReturn(mockQuery2)
 
             // Act & Assert
             assertThrows<IllegalArgumentException> {
@@ -151,7 +159,7 @@ class ProductVariantServiceUnitTest {
 
             // Assert — テナントフィルタが有効化されていることを確認
             verify(tenantFilterService).enableFilter()
-            verify(productRepository).findById(productId)
+            verify(productRepository).find(eq("id = ?1"), eq(productId))
         }
     }
 
@@ -267,7 +275,9 @@ class ProductVariantServiceUnitTest {
                     isActive = true
                     displayOrder = 0
                 }
-            whenever(variantRepository.findById(variantId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<ProductVariantEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(entity)
+            whenever(variantRepository.find(eq("id = ?1"), eq(variantId))).thenReturn(mockQuery3)
 
             // Act
             val result = service.update(variantId, "New Name", null, null, null, null, null)
@@ -292,7 +302,9 @@ class ProductVariantServiceUnitTest {
                     isActive = true
                     displayOrder = 0
                 }
-            whenever(variantRepository.findById(variantId)).thenReturn(entity)
+            val mockQuery4 = mock<PanacheQuery<ProductVariantEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(entity)
+            whenever(variantRepository.find(eq("id = ?1"), eq(variantId))).thenReturn(mockQuery4)
 
             // Act
             val result = service.update(variantId, null, null, null, 20000L, null, null)
@@ -316,7 +328,9 @@ class ProductVariantServiceUnitTest {
                     isActive = true
                     displayOrder = 0
                 }
-            whenever(variantRepository.findById(variantId)).thenReturn(entity)
+            val mockQuery5 = mock<PanacheQuery<ProductVariantEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(entity)
+            whenever(variantRepository.find(eq("id = ?1"), eq(variantId))).thenReturn(mockQuery5)
 
             // Act
             val result = service.update(variantId, null, null, null, null, false, null)
@@ -341,7 +355,9 @@ class ProductVariantServiceUnitTest {
                     isActive = true
                     displayOrder = 0
                 }
-            whenever(variantRepository.findById(variantId)).thenReturn(entity)
+            val mockQuery6 = mock<PanacheQuery<ProductVariantEntity>>()
+            whenever(mockQuery6.firstResult()).thenReturn(entity)
+            whenever(variantRepository.find(eq("id = ?1"), eq(variantId))).thenReturn(mockQuery6)
 
             // Act
             val result =
@@ -368,7 +384,9 @@ class ProductVariantServiceUnitTest {
         fun `throws when variant not found`() {
             // Arrange
             val variantId = UUID.randomUUID()
-            whenever(variantRepository.findById(variantId)).thenReturn(null)
+            val mockQuery7 = mock<PanacheQuery<ProductVariantEntity>>()
+            whenever(mockQuery7.firstResult()).thenReturn(null)
+            whenever(variantRepository.find(eq("id = ?1"), eq(variantId))).thenReturn(mockQuery7)
 
             // Act & Assert
             assertThrows<IllegalArgumentException> {
@@ -390,7 +408,9 @@ class ProductVariantServiceUnitTest {
                     isActive = true
                     displayOrder = 0
                 }
-            whenever(variantRepository.findById(variantId)).thenReturn(entity)
+            val mockQuery8 = mock<PanacheQuery<ProductVariantEntity>>()
+            whenever(mockQuery8.firstResult()).thenReturn(entity)
+            whenever(variantRepository.find(eq("id = ?1"), eq(variantId))).thenReturn(mockQuery8)
 
             // Act
             val result = service.update(variantId, null, null, null, 0L, null, null)
@@ -406,7 +426,20 @@ class ProductVariantServiceUnitTest {
         fun `deletes variant and returns true`() {
             // Arrange
             val variantId = UUID.randomUUID()
-            whenever(variantRepository.deleteById(variantId)).thenReturn(true)
+            val entity =
+                ProductVariantEntity().apply {
+                    id = variantId
+                    organizationId = orgId
+                    this.productId = this@ProductVariantServiceUnitTest.productId
+                    name = "削除対象"
+                    price = 10000L
+                    isActive = true
+                    displayOrder = 0
+                }
+            val mockQuery = mock<PanacheQuery<ProductVariantEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(entity)
+            whenever(variantRepository.find(eq("id = ?1"), eq(variantId))).thenReturn(mockQuery)
+            doNothing().whenever(variantRepository).delete(entity)
 
             // Act
             val result = service.delete(variantId)
@@ -420,7 +453,9 @@ class ProductVariantServiceUnitTest {
         fun `returns false when variant not found`() {
             // Arrange
             val variantId = UUID.randomUUID()
-            whenever(variantRepository.deleteById(variantId)).thenReturn(false)
+            val mockQuery = mock<PanacheQuery<ProductVariantEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(null)
+            whenever(variantRepository.find(eq("id = ?1"), eq(variantId))).thenReturn(mockQuery)
 
             // Act
             val result = service.delete(variantId)

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/TaxRateScheduleServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/TaxRateScheduleServiceTest.kt
@@ -6,9 +6,9 @@ import com.openpos.product.entity.TaxRateEntity
 import com.openpos.product.entity.TaxRateScheduleEntity
 import com.openpos.product.repository.TaxRateRepository
 import com.openpos.product.repository.TaxRateScheduleRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -22,31 +22,36 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 
-@QuarkusTest
 class TaxRateScheduleServiceTest {
-    @Inject
-    lateinit var scheduleService: TaxRateScheduleService
+    private lateinit var scheduleService: TaxRateScheduleService
 
-    @InjectMock
-    lateinit var scheduleRepository: TaxRateScheduleRepository
+    private lateinit var scheduleRepository: TaxRateScheduleRepository
 
-    @InjectMock
-    lateinit var taxRateRepository: TaxRateRepository
+    private lateinit var taxRateRepository: TaxRateRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
-    @InjectMock
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
     private val testOrgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        scheduleRepository = mock()
+        taxRateRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        scheduleService = TaxRateScheduleService()
+        scheduleService.scheduleRepository = scheduleRepository
+        scheduleService.taxRateRepository = taxRateRepository
+        scheduleService.tenantFilterService = tenantFilterService
+        scheduleService.organizationIdHolder = organizationIdHolder
+
+        organizationIdHolder.organizationId = testOrgId
         doNothing().whenever(scheduleRepository).persist(any<TaxRateScheduleEntity>())
         doNothing().whenever(taxRateRepository).persist(any<TaxRateEntity>())
         doNothing().whenever(tenantFilterService).enableFilter()
-        whenever(organizationIdHolder.organizationId).thenReturn(testOrgId)
     }
 
     @Test
@@ -119,7 +124,9 @@ class TaxRateScheduleServiceTest {
             }
 
         whenever(scheduleRepository.findPendingByDate(any())).thenReturn(listOf(schedule))
-        whenever(taxRateRepository.findById(taxRateId)).thenReturn(null)
+        val mockQuery1 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(null)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockQuery1)
 
         val applied = scheduleService.applyPendingSchedules()
 
@@ -158,7 +165,9 @@ class TaxRateScheduleServiceTest {
             }
 
         whenever(scheduleRepository.findPendingByDate(any())).thenReturn(listOf(schedule))
-        whenever(taxRateRepository.findById(taxRateId)).thenReturn(taxRate)
+        val mockQuery2 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(taxRate)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockQuery2)
 
         val applied = scheduleService.applyPendingSchedules()
 

--- a/services/product-service/src/test/kotlin/com/openpos/product/service/TaxRateServiceTest.kt
+++ b/services/product-service/src/test/kotlin/com/openpos/product/service/TaxRateServiceTest.kt
@@ -4,9 +4,9 @@ import com.openpos.product.config.OrganizationIdHolder
 import com.openpos.product.config.TenantFilterService
 import com.openpos.product.entity.TaxRateEntity
 import com.openpos.product.repository.TaxRateRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -21,24 +21,28 @@ import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.util.UUID
 
-@QuarkusTest
 class TaxRateServiceTest {
-    @Inject
-    lateinit var taxRateService: TaxRateService
+    private lateinit var taxRateService: TaxRateService
 
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
-    @InjectMock
-    lateinit var taxRateRepository: TaxRateRepository
+    private lateinit var taxRateRepository: TaxRateRepository
 
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var tenantFilterService: TenantFilterService
 
     private val orgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        taxRateRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        taxRateService = TaxRateService()
+        taxRateService.taxRateRepository = taxRateRepository
+        taxRateService.tenantFilterService = tenantFilterService
+        taxRateService.organizationIdHolder = organizationIdHolder
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
     }
@@ -198,7 +202,9 @@ class TaxRateServiceTest {
                     this.taxType = "STANDARD"
                     this.isActive = true
                 }
-            whenever(taxRateRepository.findById(taxRateId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery1.firstResult()).thenReturn(entity)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockQuery1)
 
             // Act
             val result = taxRateService.findById(taxRateId)
@@ -214,7 +220,9 @@ class TaxRateServiceTest {
         fun `存在しないIDの場合はnullを返す`() {
             // Arrange
             val taxRateId = UUID.randomUUID()
-            whenever(taxRateRepository.findById(taxRateId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery2.firstResult()).thenReturn(null)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockQuery2)
 
             // Act
             val result = taxRateService.findById(taxRateId)
@@ -242,7 +250,9 @@ class TaxRateServiceTest {
                     this.taxType = "STANDARD"
                     this.isActive = true
                 }
-            whenever(taxRateRepository.findById(taxRateId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery3.firstResult()).thenReturn(entity)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockQuery3)
             doNothing().whenever(taxRateRepository).persist(any<TaxRateEntity>())
 
             // Act
@@ -279,7 +289,9 @@ class TaxRateServiceTest {
                     this.taxType = "STANDARD"
                     this.isActive = true
                 }
-            whenever(taxRateRepository.findById(taxRateId)).thenReturn(entity)
+            val mockQuery4 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery4.firstResult()).thenReturn(entity)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockQuery4)
             doNothing().whenever(taxRateRepository).persist(any<TaxRateEntity>())
 
             // Act
@@ -303,7 +315,9 @@ class TaxRateServiceTest {
         fun `存在しない税率の更新はnullを返す`() {
             // Arrange
             val taxRateId = UUID.randomUUID()
-            whenever(taxRateRepository.findById(taxRateId)).thenReturn(null)
+            val mockQuery5 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery5.firstResult()).thenReturn(null)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockQuery5)
 
             // Act
             val result =
@@ -346,7 +360,9 @@ class TaxRateServiceTest {
                     this.isDefault = true
                     this.isActive = true
                 }
-            whenever(taxRateRepository.findById(taxRateId)).thenReturn(entity)
+            val mockQuery6 = mock<PanacheQuery<TaxRateEntity>>()
+            whenever(mockQuery6.firstResult()).thenReturn(entity)
+            whenever(taxRateRepository.find(eq("id = ?1"), eq(taxRateId))).thenReturn(mockQuery6)
             whenever(taxRateRepository.findDefaultsByOrganizationIdExcludingId(orgId, taxRateId)).thenReturn(listOf(existingDefault))
             doNothing().whenever(taxRateRepository).persist(any<TaxRateEntity>())
 

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/CustomerService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/CustomerService.kt
@@ -62,7 +62,9 @@ class CustomerService {
      */
     fun findById(id: UUID): CustomerEntity? {
         tenantFilterService.enableFilter()
-        return customerRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return customerRepository.find("id = ?1", id).firstResult()
     }
 
     /**
@@ -108,7 +110,7 @@ class CustomerService {
         notes: String?,
     ): CustomerEntity? {
         tenantFilterService.enableFilter()
-        val entity = customerRepository.findById(id) ?: return null
+        val entity = customerRepository.find("id = ?1", id).firstResult() ?: return null
         name?.let { entity.name = it }
         email?.let { entity.email = it }
         phone?.let { entity.phone = it }
@@ -137,7 +139,7 @@ class CustomerService {
     ): Long {
         tenantFilterService.enableFilter()
         val customer =
-            customerRepository.findById(customerId)
+            customerRepository.find("id = ?1", customerId).firstResult()
                 ?: throw IllegalArgumentException("Customer not found: $customerId")
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
         val points = transactionTotal / 10000

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/GiftCardService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/GiftCardService.kt
@@ -42,7 +42,9 @@ class GiftCardService {
 
     fun findById(id: UUID): GiftCardEntity? {
         tenantFilterService.enableFilter()
-        return giftCardRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return giftCardRepository.find("id = ?1", id).firstResult()
     }
 
     @Transactional

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/StaffService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/StaffService.kt
@@ -51,8 +51,9 @@ class StaffService {
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
         // storeId が自組織に属するか検証
         tenantFilterService.enableFilter()
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
         val store =
-            storeRepository.findById(storeId)
+            storeRepository.find("id = ?1", storeId).firstResult()
                 ?: throw IllegalArgumentException("Store $storeId not found in organization $orgId")
         require(store.organizationId == orgId) {
             "Store $storeId does not belong to organization $orgId"
@@ -74,7 +75,9 @@ class StaffService {
     @Transactional
     fun findById(id: UUID): StaffEntity? {
         tenantFilterService.enableFilter()
-        return staffRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return staffRepository.find("id = ?1", id).firstResult()
     }
 
     @Transactional
@@ -99,7 +102,7 @@ class StaffService {
         isActive: Boolean?,
     ): StaffEntity? {
         tenantFilterService.enableFilter()
-        val entity = staffRepository.findById(id) ?: return null
+        val entity = staffRepository.find("id = ?1", id).firstResult() ?: return null
         name?.let { entity.name = it }
         email?.let { entity.email = it }
         role?.let { entity.role = it }

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/StoreService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/StoreService.kt
@@ -50,7 +50,9 @@ class StoreService {
 
     fun findById(id: UUID): StoreEntity? {
         tenantFilterService.enableFilter()
-        return storeRepository.findById(id)
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        return storeRepository.find("id = ?1", id).firstResult()
     }
 
     fun list(
@@ -74,7 +76,7 @@ class StoreService {
         isActive: Boolean?,
     ): StoreEntity? {
         tenantFilterService.enableFilter()
-        val entity = storeRepository.findById(id) ?: return null
+        val entity = storeRepository.find("id = ?1", id).firstResult() ?: return null
         name?.let { entity.name = it }
         address?.let { entity.address = it }
         phone?.let { entity.phone = it }

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/TerminalService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/TerminalService.kt
@@ -38,8 +38,9 @@ class TerminalService {
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
         // storeId が自組織に属するか検証
         tenantFilterService.enableFilter()
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
         val store =
-            storeRepository.findById(storeId)
+            storeRepository.find("id = ?1", storeId).firstResult()
                 ?: throw IllegalArgumentException("Store $storeId not found in organization $orgId")
         require(store.organizationId == orgId) {
             "Store $storeId does not belong to organization $orgId"
@@ -66,7 +67,9 @@ class TerminalService {
     fun updateSync(terminalId: UUID): TerminalEntity? {
         val orgId = requireNotNull(organizationIdHolder.organizationId) { "organizationId is not set" }
         tenantFilterService.enableFilter()
-        val entity = terminalRepository.findById(terminalId) ?: return null
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        val entity = terminalRepository.find("id = ?1", terminalId).firstResult() ?: return null
         entity.lastSyncAt = Instant.now()
         terminalRepository.persist(entity)
         cacheService.invalidateTerminalList(orgId.toString(), entity.storeId.toString())

--- a/services/store-service/src/main/kotlin/com/openpos/store/service/WebhookService.kt
+++ b/services/store-service/src/main/kotlin/com/openpos/store/service/WebhookService.kt
@@ -7,8 +7,8 @@ import com.openpos.store.repository.WebhookRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import jakarta.transaction.Transactional
-import java.util.UUID
 import org.jboss.logging.Logger
+import java.util.UUID
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -68,7 +68,9 @@ class WebhookService {
         isActive: Boolean?,
     ): WebhookEntity? {
         tenantFilterService.enableFilter()
-        val entity = webhookRepository.findById(id) ?: return null
+        // findById() は em.find() ベースのため Hibernate Filter をバイパスする。
+        // HQL クエリで organizationFilter を適用してテナント隔離を保証する。
+        val entity = webhookRepository.find("id = ?1", id).firstResult() ?: return null
         url?.let { entity.url = it }
         events?.let { entity.events = it }
         isActive?.let { entity.isActive = it }
@@ -79,7 +81,7 @@ class WebhookService {
     @Transactional
     fun delete(id: UUID): Boolean {
         tenantFilterService.enableFilter()
-        val entity = webhookRepository.findById(id) ?: return false
+        val entity = webhookRepository.find("id = ?1", id).firstResult() ?: return false
         webhookRepository.delete(entity)
         return true
     }

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/CustomerServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/CustomerServiceTest.kt
@@ -6,6 +6,8 @@ import com.openpos.store.entity.CustomerEntity
 import com.openpos.store.entity.PointTransactionEntity
 import com.openpos.store.repository.CustomerRepository
 import com.openpos.store.repository.PointTransactionRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -63,7 +65,9 @@ class CustomerServiceTest {
                 name = "テスト顧客"
                 points = 100
             }
-        whenever(customerRepository.findById(customerId)).thenReturn(customer)
+        val mockQuery1 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(customer)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery1)
 
         // Act: 50000 sen = 500 yen => 5 points
         val earned = service.earnPoints(customerId, 50000, null)
@@ -85,7 +89,9 @@ class CustomerServiceTest {
                 name = "テスト顧客"
                 points = 100
             }
-        whenever(customerRepository.findById(customerId)).thenReturn(customer)
+        val mockQuery2 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery2.firstResult()).thenReturn(customer)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery2)
 
         // Act: 9999 sen = 99.99 yen => 0 points
         val earned = service.earnPoints(customerId, 9999, null)

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/CustomerServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/CustomerServiceUnitTest.kt
@@ -7,6 +7,8 @@ import com.openpos.store.entity.PointTransactionEntity
 import com.openpos.store.repository.CustomerRepository
 import com.openpos.store.repository.PointTransactionRepository
 import io.quarkus.panache.common.Page
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -60,7 +62,9 @@ class CustomerServiceUnitTest {
                     organizationId = orgId
                     name = "Test"
                 }
-            whenever(customerRepository.findById(customerId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(entity)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery1)
 
             val result = service.findById(customerId)
 
@@ -72,7 +76,9 @@ class CustomerServiceUnitTest {
         @Test
         fun `returns null when not found`() {
             val customerId = UUID.randomUUID()
-            whenever(customerRepository.findById(customerId)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery2.firstResult()).thenReturn(null)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery2)
 
             val result = service.findById(customerId)
 
@@ -115,7 +121,9 @@ class CustomerServiceUnitTest {
                     email = "old@test.com"
                     phone = "090-0000-0000"
                 }
-            whenever(customerRepository.findById(customerId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery3.firstResult()).thenReturn(entity)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery3)
 
             val result = service.update(customerId, "New Name", null, "090-1111-1111", null)
 
@@ -128,7 +136,9 @@ class CustomerServiceUnitTest {
         @Test
         fun `returns null when customer not found`() {
             val customerId = UUID.randomUUID()
-            whenever(customerRepository.findById(customerId)).thenReturn(null)
+            val mockQuery4 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery4.firstResult()).thenReturn(null)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery4)
 
             val result = service.update(customerId, "New", null, null, null)
 
@@ -202,7 +212,9 @@ class CustomerServiceUnitTest {
                     name = "Test"
                     notes = null
                 }
-            whenever(customerRepository.findById(customerId)).thenReturn(entity)
+            val mockQuery5 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery5.firstResult()).thenReturn(entity)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery5)
 
             val result = service.update(customerId, null, null, null, "新しいメモ")
 
@@ -216,7 +228,9 @@ class CustomerServiceUnitTest {
         @Test
         fun `throws when customer not found`() {
             val customerId = UUID.randomUUID()
-            whenever(customerRepository.findById(customerId)).thenReturn(null)
+            val mockQuery6 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery6.firstResult()).thenReturn(null)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery6)
 
             assertThrows(IllegalArgumentException::class.java) {
                 service.earnPoints(customerId, 50000, null)
@@ -234,7 +248,9 @@ class CustomerServiceUnitTest {
                     name = "Test"
                     points = 0
                 }
-            whenever(customerRepository.findById(customerId)).thenReturn(customer)
+            val mockQuery7 = mock<PanacheQuery<CustomerEntity>>()
+whenever(mockQuery7.firstResult()).thenReturn(customer)
+whenever(customerRepository.find(eq("id = ?1"), eq(customerId))).thenReturn(mockQuery7)
 
             val earned = service.earnPoints(customerId, 100000, txId)
 

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/GiftCardServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/GiftCardServiceUnitTest.kt
@@ -4,6 +4,8 @@ import com.openpos.store.config.OrganizationIdHolder
 import com.openpos.store.config.TenantFilterService
 import com.openpos.store.entity.GiftCardEntity
 import com.openpos.store.repository.GiftCardRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -99,7 +101,9 @@ class GiftCardServiceUnitTest {
                     initialBalance = 20000
                     status = "ACTIVE"
                 }
-            whenever(giftCardRepository.findById(cardId)).thenReturn(card)
+            val mockQuery1 = mock<PanacheQuery<GiftCardEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(card)
+whenever(giftCardRepository.find(eq("id = ?1"), eq(cardId))).thenReturn(mockQuery1)
 
             val result = service.findById(cardId)
 

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/StaffServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/StaffServiceTest.kt
@@ -6,10 +6,7 @@ import com.openpos.store.entity.StaffEntity
 import com.openpos.store.entity.StoreEntity
 import com.openpos.store.repository.StaffRepository
 import com.openpos.store.repository.StoreRepository
-import io.quarkus.panache.common.Page
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -20,42 +17,43 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.util.UUID
 
-@QuarkusTest
+/**
+ * StaffService の純粋ユニットテスト。
+ * findById / update / create は HQL クエリ (find("id = ?1", id)) を使うため
+ * PanacheQuery をモックして検証する。
+ */
 class StaffServiceTest {
-    @Inject
-    lateinit var staffService: StaffService
-
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
-
-    @InjectMock
-    lateinit var staffRepository: StaffRepository
-
-    @InjectMock
-    lateinit var storeRepository: StoreRepository
-
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
+    private lateinit var staffService: StaffService
+    private lateinit var staffRepository: StaffRepository
+    private lateinit var storeRepository: StoreRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
     private val orgId = UUID.randomUUID()
     private val storeId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        staffRepository = mock()
+        storeRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+
+        staffService = StaffService()
+        staffService.staffRepository = staffRepository
+        staffService.storeRepository = storeRepository
+        staffService.tenantFilterService = tenantFilterService
+        staffService.organizationIdHolder = organizationIdHolder
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
-        val storeEntity =
-            StoreEntity().apply {
-                this.id = storeId
-                this.organizationId = orgId
-                this.name = "テスト店舗"
-            }
-        whenever(storeRepository.findById(storeId)).thenReturn(storeEntity)
     }
 
     // === create ===
@@ -65,6 +63,15 @@ class StaffServiceTest {
         @Test
         fun `スタッフを正常に作成する`() {
             // Arrange
+            val storeEntity =
+                StoreEntity().apply {
+                    this.id = storeId
+                    this.organizationId = orgId
+                    this.name = "テスト店舗"
+                }
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(storeEntity)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
@@ -79,6 +86,19 @@ class StaffServiceTest {
             assertEquals("CASHIER", result.role)
             assertEquals("hashed_pin_123", result.pinHash)
             assertTrue(result.isActive)
+        }
+
+        @Test
+        fun `存在しない店舗IDの場合はIllegalArgumentExceptionをスローする`() {
+            // Arrange
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(null)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
+
+            // Act & Assert
+            org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+                staffService.create(storeId, "田中太郎", "tanaka@example.com", "CASHIER", "hashed_pin_123")
+            }
         }
     }
 
@@ -99,7 +119,9 @@ class StaffServiceTest {
                     this.email = "tanaka@example.com"
                     this.role = "CASHIER"
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            val mockQuery = mock<PanacheQuery<StaffEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(entity)
+            whenever(staffRepository.find(eq("id = ?1"), eq(staffId))).thenReturn(mockQuery)
 
             // Act
             val result = staffService.findById(staffId)
@@ -112,10 +134,12 @@ class StaffServiceTest {
         }
 
         @Test
-        fun `存在しないIDの場合はnullを返す`() {
+        fun `存在しないIDの場合はnullを返す（テナント隔離：他テナントのIDはnull）`() {
             // Arrange
             val staffId = UUID.randomUUID()
-            whenever(staffRepository.findById(staffId)).thenReturn(null)
+            val mockQuery = mock<PanacheQuery<StaffEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(null)
+            whenever(staffRepository.find(eq("id = ?1"), eq(staffId))).thenReturn(mockQuery)
 
             // Act
             val result = staffService.findById(staffId)
@@ -195,7 +219,9 @@ class StaffServiceTest {
                     this.pinHash = "old_hash"
                     this.isActive = true
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            val mockQuery = mock<PanacheQuery<StaffEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(entity)
+            whenever(staffRepository.find(eq("id = ?1"), eq(staffId))).thenReturn(mockQuery)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
@@ -226,7 +252,9 @@ class StaffServiceTest {
                     this.pinHash = "old_hash"
                     this.isActive = true
                 }
-            whenever(staffRepository.findById(staffId)).thenReturn(entity)
+            val mockQuery = mock<PanacheQuery<StaffEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(entity)
+            whenever(staffRepository.find(eq("id = ?1"), eq(staffId))).thenReturn(mockQuery)
             doNothing().whenever(staffRepository).persist(any<StaffEntity>())
 
             // Act
@@ -242,10 +270,12 @@ class StaffServiceTest {
         }
 
         @Test
-        fun `存在しないIDの場合はnullを返す`() {
+        fun `存在しないIDの場合はnullを返す（テナント隔離：他テナントのIDはnull）`() {
             // Arrange
             val staffId = UUID.randomUUID()
-            whenever(staffRepository.findById(staffId)).thenReturn(null)
+            val mockQuery = mock<PanacheQuery<StaffEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(null)
+            whenever(staffRepository.find(eq("id = ?1"), eq(staffId))).thenReturn(mockQuery)
 
             // Act
             val result = staffService.update(staffId, "新名前", null, null, null, null)

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/StoreServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/StoreServiceTest.kt
@@ -5,10 +5,7 @@ import com.openpos.store.config.OrganizationIdHolder
 import com.openpos.store.config.TenantFilterService
 import com.openpos.store.entity.StoreEntity
 import com.openpos.store.repository.StoreRepository
-import io.quarkus.panache.common.Page
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -18,31 +15,39 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
+/**
+ * StoreService の純粋ユニットテスト。
+ * findById / update は HQL クエリ (find("id = ?1", id)) を使うため
+ * PanacheQuery をモックして検証する。
+ */
 class StoreServiceTest {
-    @Inject
-    lateinit var storeService: StoreService
-
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
-
-    @InjectMock
-    lateinit var storeRepository: StoreRepository
-
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
-
-    @InjectMock
-    lateinit var cacheService: StoreCacheService
+    private lateinit var storeService: StoreService
+    private lateinit var storeRepository: StoreRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var cacheService: StoreCacheService
 
     private val orgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        storeRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+        cacheService = mock()
+
+        storeService = StoreService()
+        storeService.storeRepository = storeRepository
+        storeService.tenantFilterService = tenantFilterService
+        storeService.organizationIdHolder = organizationIdHolder
+        storeService.cacheService = cacheService
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
         doNothing().whenever(cacheService).invalidateStore(any(), any())
@@ -105,7 +110,9 @@ class StoreServiceTest {
                     this.settings = "{}"
                     this.isActive = true
                 }
-            whenever(storeRepository.findById(storeId)).thenReturn(entity)
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(entity)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
 
             // Act
             val result = storeService.findById(storeId)
@@ -118,10 +125,12 @@ class StoreServiceTest {
         }
 
         @Test
-        fun `存在しないIDの場合はnullを返す`() {
+        fun `存在しないIDの場合はnullを返す（テナント隔離：他テナントのIDはnull）`() {
             // Arrange
             val storeId = UUID.randomUUID()
-            whenever(storeRepository.findById(storeId)).thenReturn(null)
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(null)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
 
             // Act
             val result = storeService.findById(storeId)
@@ -201,7 +210,9 @@ class StoreServiceTest {
                     this.settings = "{}"
                     this.isActive = true
                 }
-            whenever(storeRepository.findById(storeId)).thenReturn(entity)
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(entity)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
             doNothing().whenever(storeRepository).persist(any<StoreEntity>())
 
             // Act
@@ -231,7 +242,9 @@ class StoreServiceTest {
                     this.settings = "{}"
                     this.isActive = true
                 }
-            whenever(storeRepository.findById(storeId)).thenReturn(entity)
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(entity)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
             doNothing().whenever(storeRepository).persist(any<StoreEntity>())
 
             // Act
@@ -257,10 +270,12 @@ class StoreServiceTest {
         }
 
         @Test
-        fun `存在しないIDの場合はnullを返す`() {
+        fun `存在しないIDの場合はnullを返す（テナント隔離：他テナントのIDはnull）`() {
             // Arrange
             val storeId = UUID.randomUUID()
-            whenever(storeRepository.findById(storeId)).thenReturn(null)
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(null)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
 
             // Act
             val result = storeService.update(storeId, "新店舗名", null, null, null, null, null)

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/TerminalServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/TerminalServiceTest.kt
@@ -7,9 +7,7 @@ import com.openpos.store.entity.StoreEntity
 import com.openpos.store.entity.TerminalEntity
 import com.openpos.store.repository.StoreRepository
 import com.openpos.store.repository.TerminalRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -19,45 +17,46 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
+/**
+ * TerminalService の純粋ユニットテスト。
+ * register / updateSync は HQL クエリ (find("id = ?1", id)) を使うため
+ * PanacheQuery をモックして検証する。
+ */
 class TerminalServiceTest {
-    @Inject
-    lateinit var terminalService: TerminalService
-
-    @Inject
-    lateinit var organizationIdHolder: OrganizationIdHolder
-
-    @InjectMock
-    lateinit var terminalRepository: TerminalRepository
-
-    @InjectMock
-    lateinit var storeRepository: StoreRepository
-
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
-
-    @InjectMock
-    lateinit var cacheService: StoreCacheService
+    private lateinit var terminalService: TerminalService
+    private lateinit var terminalRepository: TerminalRepository
+    private lateinit var storeRepository: StoreRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var cacheService: StoreCacheService
 
     private val orgId = UUID.randomUUID()
     private val storeId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        terminalRepository = mock()
+        storeRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = OrganizationIdHolder()
+        cacheService = mock()
+
+        terminalService = TerminalService()
+        terminalService.terminalRepository = terminalRepository
+        terminalService.storeRepository = storeRepository
+        terminalService.tenantFilterService = tenantFilterService
+        terminalService.organizationIdHolder = organizationIdHolder
+        terminalService.cacheService = cacheService
+
         organizationIdHolder.organizationId = orgId
         doNothing().whenever(tenantFilterService).enableFilter()
         doNothing().whenever(cacheService).invalidateTerminalList(any(), any())
-        val storeEntity =
-            StoreEntity().apply {
-                this.id = storeId
-                this.organizationId = orgId
-                this.name = "テスト店舗"
-            }
-        whenever(storeRepository.findById(storeId)).thenReturn(storeEntity)
     }
 
     // === register ===
@@ -67,6 +66,15 @@ class TerminalServiceTest {
         @Test
         fun `ターミナルを正常に登録する`() {
             // Arrange
+            val storeEntity =
+                StoreEntity().apply {
+                    this.id = storeId
+                    this.organizationId = orgId
+                    this.name = "テスト店舗"
+                }
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(storeEntity)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
             doNothing().whenever(terminalRepository).persist(any<TerminalEntity>())
 
             // Act
@@ -79,6 +87,19 @@ class TerminalServiceTest {
             assertEquals("POS-01", result.terminalCode)
             assertEquals("レジ1号機", result.name)
             assertTrue(result.isActive)
+        }
+
+        @Test
+        fun `存在しない店舗IDの場合はIllegalArgumentExceptionをスローする`() {
+            // Arrange
+            val mockQuery = mock<PanacheQuery<StoreEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(null)
+            whenever(storeRepository.find(eq("id = ?1"), eq(storeId))).thenReturn(mockQuery)
+
+            // Act & Assert
+            org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+                terminalService.register(storeId, "POS-01", "レジ1号機")
+            }
         }
     }
 
@@ -151,7 +172,9 @@ class TerminalServiceTest {
                     this.lastSyncAt = null
                     this.isActive = true
                 }
-            whenever(terminalRepository.findById(terminalId)).thenReturn(entity)
+            val mockQuery = mock<PanacheQuery<TerminalEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(entity)
+            whenever(terminalRepository.find(eq("id = ?1"), eq(terminalId))).thenReturn(mockQuery)
             doNothing().whenever(terminalRepository).persist(any<TerminalEntity>())
 
             // Act
@@ -167,7 +190,9 @@ class TerminalServiceTest {
         fun `存在しないIDの場合はnullを返す`() {
             // Arrange
             val terminalId = UUID.randomUUID()
-            whenever(terminalRepository.findById(terminalId)).thenReturn(null)
+            val mockQuery = mock<PanacheQuery<TerminalEntity>>()
+            whenever(mockQuery.firstResult()).thenReturn(null)
+            whenever(terminalRepository.find(eq("id = ?1"), eq(terminalId))).thenReturn(mockQuery)
 
             // Act
             val result = terminalService.updateSync(terminalId)

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/WebhookServiceTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/WebhookServiceTest.kt
@@ -4,9 +4,7 @@ import com.openpos.store.config.OrganizationIdHolder
 import com.openpos.store.config.TenantFilterService
 import com.openpos.store.entity.WebhookEntity
 import com.openpos.store.repository.WebhookRepository
-import io.quarkus.test.InjectMock
-import io.quarkus.test.junit.QuarkusTest
-import jakarta.inject.Inject
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -14,27 +12,35 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@QuarkusTest
+/**
+ * WebhookService の純粋ユニットテスト。
+ * update / delete は HQL クエリ (find("id = ?1", id)) を使うため
+ * PanacheQuery をモックして検証する。
+ */
 class WebhookServiceTest {
-    @Inject
-    lateinit var webhookService: WebhookService
-
-    @InjectMock
-    lateinit var webhookRepository: WebhookRepository
-
-    @InjectMock
-    lateinit var tenantFilterService: TenantFilterService
-
-    @InjectMock
-    lateinit var organizationIdHolder: OrganizationIdHolder
+    private lateinit var webhookService: WebhookService
+    private lateinit var webhookRepository: WebhookRepository
+    private lateinit var tenantFilterService: TenantFilterService
+    private lateinit var organizationIdHolder: OrganizationIdHolder
 
     private val testOrgId = UUID.randomUUID()
 
     @BeforeEach
     fun setUp() {
+        webhookRepository = mock()
+        tenantFilterService = mock()
+        organizationIdHolder = mock()
+
+        webhookService = WebhookService()
+        webhookService.webhookRepository = webhookRepository
+        webhookService.tenantFilterService = tenantFilterService
+        webhookService.organizationIdHolder = organizationIdHolder
+
         doNothing().whenever(webhookRepository).persist(any<WebhookEntity>())
         doNothing().whenever(tenantFilterService).enableFilter()
         whenever(organizationIdHolder.organizationId).thenReturn(testOrgId)
@@ -42,6 +48,7 @@ class WebhookServiceTest {
 
     @Test
     fun `create should create webhook with correct fields`() {
+        // Act
         val webhook =
             webhookService.create(
                 url = "https://example.com/webhook",
@@ -49,6 +56,7 @@ class WebhookServiceTest {
                 secret = "test-secret-key",
             )
 
+        // Assert
         assertNotNull(webhook)
         assertEquals("https://example.com/webhook", webhook.url)
         assertEquals("""["sale.completed","stock.low"]""", webhook.events)
@@ -57,6 +65,7 @@ class WebhookServiceTest {
 
     @Test
     fun `trigger should process active webhooks`() {
+        // Arrange
         val webhook =
             WebhookEntity().apply {
                 id = UUID.randomUUID()
@@ -74,6 +83,7 @@ class WebhookServiceTest {
 
     @Test
     fun `update should modify webhook fields`() {
+        // Arrange
         val webhookId = UUID.randomUUID()
         val entity =
             WebhookEntity().apply {
@@ -84,10 +94,14 @@ class WebhookServiceTest {
                 secret = "secret"
                 isActive = true
             }
-        whenever(webhookRepository.findById(webhookId)).thenReturn(entity)
+        val mockQuery = mock<PanacheQuery<WebhookEntity>>()
+        whenever(mockQuery.firstResult()).thenReturn(entity)
+        whenever(webhookRepository.find(eq("id = ?1"), eq(webhookId))).thenReturn(mockQuery)
 
+        // Act
         val result = webhookService.update(webhookId, url = "https://example.com/new", events = null, isActive = false)
 
+        // Assert
         assertNotNull(result)
         assertEquals("https://example.com/new", result?.url)
         assertEquals(false, result?.isActive)

--- a/services/store-service/src/test/kotlin/com/openpos/store/service/WebhookServiceUnitTest.kt
+++ b/services/store-service/src/test/kotlin/com/openpos/store/service/WebhookServiceUnitTest.kt
@@ -4,6 +4,8 @@ import com.openpos.store.config.OrganizationIdHolder
 import com.openpos.store.config.TenantFilterService
 import com.openpos.store.entity.WebhookEntity
 import com.openpos.store.repository.WebhookRepository
+import io.quarkus.hibernate.orm.panache.kotlin.PanacheQuery
+import org.mockito.kotlin.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -72,7 +74,9 @@ class WebhookServiceUnitTest {
                     secret = "old-secret"
                     isActive = true
                 }
-            whenever(webhookRepository.findById(webhookId)).thenReturn(entity)
+            val mockQuery1 = mock<PanacheQuery<WebhookEntity>>()
+whenever(mockQuery1.firstResult()).thenReturn(entity)
+whenever(webhookRepository.find(eq("id = ?1"), eq(webhookId))).thenReturn(mockQuery1)
 
             val result = service.update(webhookId, "https://new.com", null, false)
 
@@ -85,7 +89,9 @@ class WebhookServiceUnitTest {
         @Test
         fun `returns null when webhook not found`() {
             val id = UUID.randomUUID()
-            whenever(webhookRepository.findById(id)).thenReturn(null)
+            val mockQuery2 = mock<PanacheQuery<WebhookEntity>>()
+whenever(mockQuery2.firstResult()).thenReturn(null)
+whenever(webhookRepository.find(eq("id = ?1"), eq(id))).thenReturn(mockQuery2)
 
             val result = service.update(id, "url", null, null)
 
@@ -106,7 +112,9 @@ class WebhookServiceUnitTest {
                     events = "[]"
                     secret = "secret"
                 }
-            whenever(webhookRepository.findById(webhookId)).thenReturn(entity)
+            val mockQuery3 = mock<PanacheQuery<WebhookEntity>>()
+whenever(mockQuery3.firstResult()).thenReturn(entity)
+whenever(webhookRepository.find(eq("id = ?1"), eq(webhookId))).thenReturn(mockQuery3)
 
             val result = service.delete(webhookId)
 
@@ -117,7 +125,9 @@ class WebhookServiceUnitTest {
         @Test
         fun `returns false when webhook not found`() {
             val id = UUID.randomUUID()
-            whenever(webhookRepository.findById(id)).thenReturn(null)
+            val mockQuery4 = mock<PanacheQuery<WebhookEntity>>()
+whenever(mockQuery4.firstResult()).thenReturn(null)
+whenever(webhookRepository.find(eq("id = ?1"), eq(id))).thenReturn(mockQuery4)
 
             val result = service.delete(id)
 


### PR DESCRIPTION
## Summary

- `PanacheRepository.findById()` calls `em.find()` internally which bypasses Hibernate's `@Filter` (`organizationFilter`), enabling cross-tenant data access
- Replace all `repository.findById(id)` with `repository.find("id = ?1", id).firstResult()` which executes HQL and respects the tenant filter
- Convert broken `@QuarkusTest + @InjectMock` tests to pure unit tests where `PanacheQuery` mocking is needed (CDI proxy blocks manual mock injection)

### Affected services (production code)

| Service | Files fixed |
|---------|-------------|
| store-service | StoreService, StaffService, TerminalService, CustomerService, GiftCardService, WebhookService |
| product-service | ProductService, CategoryService, DiscountService, CouponService, TaxRateService, TaxRateScheduleService, ProductVariantService |
| inventory-service | PurchaseOrderService, StockTransferService, StocktakeService, SupplierService |
| pos-service | TransactionService, ReservationService, DiscountReasonService |
| analytics-service | ProductAlertService |

### Root cause

```kotlin
// BEFORE (bypasses @Filter — em.find() skips HQL pipeline)
val entity = repository.findById(id) ?: return null

// AFTER (respects @Filter — HQL executes through Hibernate interceptors)
val entity = repository.find("id = ?1", id).firstResult() ?: return null
```

## Test plan

- [x] All 5 backend services build and test pass locally (BUILD SUCCESSFUL)
- [x] Frontend typecheck and lint pass (`pnpm -r typecheck`, `pnpm -r lint`)
- [x] Pure unit test conversion verified: `@QuarkusTest` tests that required `PanacheQuery` mocking converted to plain JUnit 5 tests
- [x] Tenant isolation: cross-tenant `markAsRead`, `updateStatus`, `complete` return `null` / throw as expected