### PR TITLE
[codex] stabilize dependabot maintenance baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,38 +11,20 @@ updates:
         update-types: ['minor', 'patch']
 
   - package-ecosystem: 'npm'
-    directory: '/apps/pos-terminal'
+    directories:
+      - '/apps/pos-terminal'
+      - '/apps/admin-dashboard'
+      - '/packages/shared-types'
+      - '/e2e'
     schedule:
       interval: 'weekly'
     labels:
       - 'type:chore'
     groups:
-      npm-pos-minor:
+      npm-monorepo-minor:
+        patterns: ['*']
+        group-by: dependency-name
         update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/apps/admin-dashboard'
-    schedule:
-      interval: 'weekly'
-    labels:
-      - 'type:chore'
-    groups:
-      npm-admin-minor:
-        update-types: ['minor', 'patch']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/shared-types'
-    schedule:
-      interval: 'weekly'
-    labels:
-      - 'type:chore'
-
-  - package-ecosystem: 'npm'
-    directory: '/e2e'
-    schedule:
-      interval: 'weekly'
-    labels:
-      - 'type:chore'
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,19 +154,13 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm -r typecheck
+      - run: pnpm -r --workspace-concurrency=1 typecheck
       - run: pnpm -r lint
       - name: Unit & Functional Test with Coverage
         run: |
-          set -uo pipefail
-          pnpm --filter pos-terminal test:coverage &
-          PID1=$!
-          pnpm --filter admin-dashboard test:coverage &
-          PID2=$!
-          FAIL=0
-          wait $PID1 || FAIL=1
-          wait $PID2 || FAIL=1
-          exit $FAIL
+          set -euo pipefail
+          pnpm --filter pos-terminal test:coverage
+          pnpm --filter admin-dashboard test:coverage
       - run: pnpm -r build
       - name: Upload Coverage Reports
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,6 +21,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Dependency Manifest Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      frontend_dependencies: ${{ steps.filter.outputs.frontend_dependencies }}
+      backend_dependencies: ${{ steps.filter.outputs.backend_dependencies }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            frontend_dependencies:
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'apps/**/package.json'
+              - 'packages/**/package.json'
+              - 'e2e/package.json'
+            backend_dependencies:
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle.properties'
+              - 'gradle/**'
+              - 'services/**/build.gradle.kts'
+
   gitleaks:
     name: Secret Scanning (gitleaks)
     runs-on: ubuntu-latest
@@ -92,6 +122,7 @@ jobs:
 
   dependency-audit:
     name: Dependency Vulnerability Scan
+    needs: [changes]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -110,12 +141,44 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile
+      # PRs compare against the base branch so pre-existing monorepo vulnerabilities
+      # do not block unrelated dependency updates. Pushes and scheduled scans remain
+      # absolute gates on the current default branch state.
+      - name: pnpm audit diff against base branch (frontend)
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.frontend_dependencies == 'true' }}
+        run: |
+          set -euo pipefail
+
+          pnpm install --frozen-lockfile
+          pnpm audit --audit-level=high --json > pnpm-audit-head.json || true
+
+          git fetch origin "${{ github.event.pull_request.base.ref }}:base-compare"
+          base_dir="$(mktemp -d)"
+          cleanup() {
+            git worktree remove --force "${base_dir}"
+          }
+          trap cleanup EXIT
+
+          git worktree add --detach "${base_dir}" base-compare
+
+          (
+            cd "${base_dir}"
+            pnpm install --frozen-lockfile
+            pnpm audit --audit-level=high --json > "${GITHUB_WORKSPACE}/pnpm-audit-base.json" || true
+          )
+
+          node scripts/ci/compare-pnpm-audit.mjs \
+            --base pnpm-audit-base.json \
+            --head pnpm-audit-head.json
 
       - name: pnpm audit (frontend)
-        run: pnpm audit --audit-level=high
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm audit --audit-level=high
 
       - name: Gradle dependency verification (backend)
+        if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.backend_dependencies == 'true' }}
         run: ./gradlew dependencies
 
   container-scan:

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ help: ## Show this help
 doctor: ## Check whether the local development prerequisites are installed and usable
 	bash scripts/doctor.sh
 
-verify: ## Run the supported local quality gate (typecheck, lint, unit/functional tests)
-	pnpm -r typecheck
+verify: ## Run the supported local quality gate (CI-aligned typecheck, lint, unit/functional tests)
+	pnpm typecheck
 	$(MAKE) lint
 	$(MAKE) test-all
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ pnpm dev:admin     # Admin panel  -> http://localhost:5174
 make test          # Backend tests
 make test-apps     # Frontend unit/functional tests
 make grpc-test     # gRPC health check (against running services)
-make verify        # typecheck + lint + backend/frontend tests
+make verify        # CI-aligned local gate (serialized typecheck + lint + backend/frontend tests)
 pnpm e2e:install   # Initial Playwright browser installation
 make verify-full   # verify + docker-demo + Playwright E2E
 
@@ -199,7 +199,7 @@ make db-restore FILE=.local/backups/openpos-20260314-120000.sql
 make reset         # Recreate PostgreSQL volume + reseed
 ```
 
-`pnpm test` runs unit/functional tests for `packages/` and `apps/`. E2E tests are opt-in via `pnpm test:e2e` (does not depend on Playwright browsers).
+`pnpm test` runs unit/functional tests for `packages/` and `apps/` in a stable sequential order. E2E tests are opt-in via `pnpm test:e2e` (does not depend on Playwright browsers).
 
 ### Local Development Mode Details
 

--- a/apps/admin-dashboard/package.json
+++ b/apps/admin-dashboard/package.json
@@ -44,18 +44,19 @@
     "recharts": "^3.7.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.0.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@tailwindcss/postcss": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.0.0",
-    "@tailwindcss/postcss": "^4.2.1",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.3",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^7.0.0",
@@ -64,8 +65,7 @@
     "tailwindcss": "^4.2.1",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.57.0",
-    "vite": "^7.0.0",
-    "@vitest/coverage-v8": "^4.0.18",
+    "vite": "^7.3.2",
     "vitest": "^4.0.18"
   }
 }

--- a/apps/admin-dashboard/tsconfig.json
+++ b/apps/admin-dashboard/tsconfig.json
@@ -21,5 +21,6 @@
     },
     "baseUrl": "."
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-setup.ts"]
 }

--- a/apps/pos-terminal/package.json
+++ b/apps/pos-terminal/package.json
@@ -38,7 +38,7 @@
     "react-router": "^7.13.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.0.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.0"
   },
   "devDependencies": {
@@ -60,7 +60,7 @@
     "tailwindcss": "^4.2.1",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.57.0",
-    "vite": "^7.0.0",
+    "vite": "^7.3.2",
     "vite-plugin-pwa": "^1.0.0",
     "vitest": "^4.0.18"
   }

--- a/apps/pos-terminal/tsconfig.json
+++ b/apps/pos-terminal/tsconfig.json
@@ -20,5 +20,6 @@
     },
     "baseUrl": "."
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test-setup.ts"]
 }

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -17,7 +17,7 @@ feature/25-offline-sync
 2. **ブランチ作成**: `git checkout -b feature/12-product-crud`
 3. **前提確認**: `make doctor`
 4. **開発**: コード実装 + テスト
-5. **ローカル品質ゲート**: `make verify`
+5. **ローカル品質ゲート**: `make verify`（CI と同じ直列 typecheck / frontend app tests を含む）
 6. **必要なら E2E**: `pnpm e2e:install && make verify-full`
 7. **PR 作成**: `gh pr create`（本文に `Closes #12` を記載）
 8. **CI 通過**: GitHub Actions の全チェック通過を確認

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -84,6 +84,8 @@ make local-smoke
 make verify
 ```
 
+`make verify` は root script を利用し、frontend workspace の `typecheck` と app tests を CI と同じ順序で実行します。
+
 ## 動作確認
 
 ```bash

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -245,7 +245,7 @@ pnpm --filter pos-terminal test -- --coverage
 
 ## E2E の前提
 
-- `pnpm test` と `make test-apps` は E2E を含めない。日常の高速な回帰確認を優先する。
+- `pnpm test` と `make test-apps` は E2E を含めず、workspace 単位で直列実行する。日常の高速な回帰確認と CI との再現性を優先する。
 - E2E は `pnpm test:e2e` または `make test-e2e` で明示実行する。
 - 初回のみ `pnpm e2e:install` で Playwright 用 Chromium をインストールする。
 - `pnpm test:e2e` は `pos-terminal` と `admin-dashboard` の dev server を自動起動する。

--- a/docs/runbook/local-dev.md
+++ b/docs/runbook/local-dev.md
@@ -111,6 +111,8 @@ pnpm e2e:install
 make verify-full
 ```
 
+`make verify` は root script を経由し、frontend workspace の `typecheck` と app tests を CI と同じ直列実行で揃えます。
+
 `make doctor` は `grpcurl` が未インストールの場合に警告を出します。`make grpc-test` が `grpcurl` に依存しているためです。
 
 ## ランタイム設定ファイル

--- a/docs/runbook/release.md
+++ b/docs/runbook/release.md
@@ -20,6 +20,8 @@ pnpm install
 make verify
 ```
 
+`make verify` は CI と同じ直列 `typecheck` / frontend app tests を含むため、フロントエンド monorepo の依存更新時もローカル再現性を保ちやすくなります。
+
 5. リリースがデモフロー、フロントエンドアプリ、シードデータ、認証、または API コントラクトに影響する場合は、以下も実行する:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "prettier --write \"apps/**/*.{ts,tsx,js,jsx,json,css,md}\" \"packages/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"apps/**/*.{ts,tsx,js,jsx,json,css,md}\" \"packages/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "test": "pnpm run test:apps",
-    "test:apps": "pnpm --filter @shared-types/openpos --filter pos-terminal --filter admin-dashboard test",
+    "test:apps": "pnpm --filter @shared-types/openpos test && pnpm --filter pos-terminal test && pnpm --filter admin-dashboard test",
     "test:e2e": "pnpm --filter e2e test",
     "test:all": "pnpm run test:apps && pnpm run test:e2e",
     "e2e:install": "pnpm --filter e2e exec playwright install chromium",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:e2e": "pnpm --filter e2e test",
     "test:all": "pnpm run test:apps && pnpm run test:e2e",
     "e2e:install": "pnpm --filter e2e exec playwright install chromium",
-    "typecheck": "pnpm -r typecheck"
+    "typecheck": "pnpm -r --workspace-concurrency=1 typecheck"
   },
   "devDependencies": {
     "eslint-config-prettier": "^10.1.0",
@@ -33,6 +33,7 @@
       "@rollup/plugin-terser": "1.0.0",
       "brace-expansion": ">=5.0.5",
       "flatted": ">=3.4.2",
+      "lodash": "4.18.1",
       "picomatch": ">=4.0.4",
       "undici": "7.24.1"
     }

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -23,7 +23,7 @@
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.57.0",
     "vitest": "^4.1.0",
-    "zod": "^4.0.0"
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,8 +219,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.2.1)
       zod:
-        specifier: ^4.0.0
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.0
         version: 5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -4065,9 +4065,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
-
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -8094,8 +8091,6 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-
-  zod@4.3.6: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@rollup/plugin-terser': 1.0.0
   brace-expansion: '>=5.0.5'
   flatted: '>=3.4.2'
+  lodash: 4.18.1
   picomatch: '>=4.0.4'
   undici: 7.24.1
 
@@ -97,8 +98,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.2.1)
       zod:
-        specifier: ^4.0.0
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.0
         version: 5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -126,7 +127,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
+        version: 5.1.4(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.1))
@@ -155,8 +156,8 @@ importers:
         specifier: ^8.57.0
         version: 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       vite:
-        specifier: ^7.0.0
-        version: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
+        specifier: ^7.3.2
+        version: 7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.1)
@@ -247,7 +248,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
+        version: 5.1.4(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.1))
@@ -279,11 +280,11 @@ importers:
         specifier: ^8.57.0
         version: 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       vite:
-        specifier: ^7.0.0
-        version: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
+        specifier: ^7.3.2
+        version: 7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
       vite-plugin-pwa:
         specifier: ^1.0.0
-        version: 1.2.0(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+        version: 1.2.0(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.1)
@@ -310,10 +311,10 @@ importers:
         version: 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(jsdom@28.1.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
+        version: 4.1.0(jsdom@28.1.0)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
       zod:
-        specifier: ^4.0.0
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
 
 packages:
 
@@ -3120,8 +3121,8 @@ packages:
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -3835,8 +3836,8 @@ packages:
       '@vite-pwa/assets-generator':
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4067,6 +4068,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.11:
     resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
@@ -5851,7 +5855,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5859,7 +5863,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
+      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5895,21 +5899,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))':
+  '@vitest/mocker@4.0.18(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
+      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))':
+  '@vitest/mocker@4.1.0(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
+      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -6455,8 +6459,8 @@ snapshots:
       '@babel/parser': 7.29.0
       eslint: 10.0.3(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -7041,7 +7045,7 @@ snapshots:
 
   lodash.sortby@4.7.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -7801,18 +7805,18 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-pwa@1.2.0(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
+  vite-plugin-pwa@1.2.0(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.15
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
+      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
       workbox-build: 7.4.0(@types/babel__core@7.20.5)
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1):
+  vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7829,7 +7833,7 @@ snapshots:
   vitest@4.0.18(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
+      '@vitest/mocker': 4.0.18(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -7846,7 +7850,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
+      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       jsdom: 28.1.0
@@ -7863,10 +7867,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(jsdom@28.1.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)):
+  vitest@4.1.0(jsdom@28.1.0)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
+      '@vitest/mocker': 4.1.0(vite@7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -7883,7 +7887,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
+      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       jsdom: 28.1.0
@@ -7991,7 +7995,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       fs-extra: 9.1.0
       glob: 11.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       pretty-bytes: 5.6.0
       rollup: 2.80.0
       source-map: 0.8.0-beta.0
@@ -8087,11 +8091,13 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:

--- a/scripts/ci/compare-pnpm-audit.mjs
+++ b/scripts/ci/compare-pnpm-audit.mjs
@@ -1,0 +1,101 @@
+import fs from 'node:fs'
+
+function parseArgs(argv) {
+  const args = { base: '', head: '' }
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const current = argv[i]
+    const next = argv[i + 1]
+
+    if (current === '--base' && next) {
+      args.base = next
+      i += 1
+      continue
+    }
+
+    if (current === '--head' && next) {
+      args.head = next
+      i += 1
+      continue
+    }
+  }
+
+  if (!args.base || !args.head) {
+    throw new Error('Usage: node scripts/ci/compare-pnpm-audit.mjs --base <file> --head <file>')
+  }
+
+  return args
+}
+
+function loadReport(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function extractFindings(report) {
+  const advisories = Object.values(report.advisories ?? {})
+  const findings = []
+
+  for (const advisory of advisories) {
+    const severity = advisory.severity ?? 'unknown'
+
+    if (!['high', 'critical'].includes(severity)) {
+      continue
+    }
+
+    for (const finding of advisory.findings ?? []) {
+      for (const path of finding.paths ?? []) {
+        findings.push({
+          id: `${advisory.id}:${path}`,
+          advisoryId: advisory.id,
+          severity,
+          moduleName: advisory.module_name,
+          title: advisory.title,
+          path,
+          recommendation: advisory.recommendation,
+          url: advisory.url,
+        })
+      }
+    }
+  }
+
+  return findings
+}
+
+function indexById(findings) {
+  return new Map(findings.map((finding) => [finding.id, finding]))
+}
+
+try {
+  const { base, head } = parseArgs(process.argv)
+  const baseFindings = extractFindings(loadReport(base))
+  const headFindings = extractFindings(loadReport(head))
+  const baseIndex = indexById(baseFindings)
+  const newFindings = headFindings.filter((finding) => !baseIndex.has(finding.id))
+  const resolvedCount = baseFindings.length - headFindings.length + newFindings.length
+
+  if (newFindings.length === 0) {
+    console.log(
+      `No new high/critical pnpm audit findings compared with base branch (${headFindings.length} current, ${baseFindings.length} base).`,
+    )
+    if (resolvedCount > 0) {
+      console.log(`Resolved findings in this branch: ${resolvedCount}`)
+    }
+    process.exit(0)
+  }
+
+  console.error('New high/critical pnpm audit findings compared with base branch:')
+  for (const finding of newFindings) {
+    console.error(`- [${finding.severity}] ${finding.moduleName} at ${finding.path}`)
+    console.error(`  ${finding.title}`)
+    if (finding.recommendation) {
+      console.error(`  ${finding.recommendation}`)
+    }
+    if (finding.url) {
+      console.error(`  ${finding.url}`)
+    }
+  }
+  process.exit(1)
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- stabilize Dependabot handling across the frontend monorepo by consolidating grouped npm updates and keeping shared dependency versions aligned
- change PR-time security auditing to fail only on newly introduced high/critical frontend vulnerabilities while keeping push/schedule scans absolute
- align local verification with CI by serializing workspace typecheck and frontend app tests

## Root cause
- Dependabot PRs were split by workspace, but CI and security gates evaluated repo-wide state, so unrelated vulnerabilities and lockfile drift blocked updates
- local verification used different concurrency than CI, which hid frontend OOM/timeout behavior until PR checks ran

## Validation
- `make verify`
- `pnpm audit --audit-level=high`
- `pnpm -r build`

## Expected impact
- shared-types and frontend Dependabot PRs should stop failing for lockfile drift and local-only concurrency differences
- PR security checks should now isolate real regressions instead of blocking unrelated updates
