### PR TITLE
[codex] align public status and release planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-95%25+-brightgreen)]()
 [![Tests](https://img.shields.io/badge/tests-1800+-blue)]()
 
-A production-ready, universal POS (Point of Sale) system featuring multi-tenant and offline-capable microservice architecture.
+A production-oriented, self-hostable POS (Point of Sale) reference implementation featuring a multi-tenant and offline-capable microservice architecture.
 
 ### Why this project?
 
@@ -23,6 +23,7 @@ A production-ready, universal POS (Point of Sale) system featuring multi-tenant 
 
 ## Project Status
 
+- **Repository posture**: self-hostable beta / release-candidate baseline, not a managed SaaS with staffed 24/7 operations
 - **Demo flow**: `make local-demo` / `make docker-demo`
 - **Quality gates**: CI, dependency audit, secret scanning, CodeQL, Playwright E2E
 - **Authentication**: ORY Hydra v2.2 (OIDC/PKCE) + RBAC (Owner / Manager / Cashier)
@@ -108,7 +109,7 @@ See [docs/guides/demo-assets.md](docs/guides/demo-assets.md) for details.
 
 | Category | Technology |
 | --- | --- |
-| Backend | Kotlin 2.3 / Quarkus 3.34 / GraalVM CE 21 / Gradle 9.4 |
+| Backend | Kotlin 2.3 / Quarkus 3.34 / GraalVM CE 21 / Gradle 9.5 |
 | Frontend | React 19 / TypeScript / Vite 7 / Tailwind CSS + shadcn/ui |
 | Database | PostgreSQL 17 (schema isolation, Flyway migrations) |
 | Cache | Redis 7 (Lettuce, cache-aside pattern) |

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -1,458 +1,116 @@
 # open-pos Product Roadmap
 
-> **Last Updated**: 2026-03-05
+> **Last Updated**: 2026-05-07
 > **Status**: Active
-> **Owner**: Product Team
+> **Owner**: Repository maintainer
 
 ## Overview
 
-open-pos は汎用 POS システムのモノリポプロジェクト。Kotlin/Quarkus + React で構築する、マルチテナント・オフライン対応の SaaS 型 POS。
-
-本ロードマップは [Harness Engineering](https://openai.com/index/harness-engineering/) の原則に基づき設計:
-- **Phase = Milestone** — 各フェーズは GitHub Milestone に対応
-- **1 Phase = 1 つのデリバリー可能な価値** — 各フェーズ完了時にデモ可能
-- **依存関係の明示** — Phase 間の依存を最小化、Phase 内は並列可能
-- **機械的に検証可能** — 各 Phase に CI/テストの完了条件
-
----
-
-## Phase Summary
-
-| Phase | Name | Target | Key Deliverable |
-|-------|------|--------|-----------------|
-| ~~1~~ | ~~Foundation~~ | ~~Done~~ | ~~Proto, Store/Product, CI~~ |
-| **1.5** | **Development Infrastructure** | 2026-03-19 | テスト基盤・CI/CD・品質ゲート |
-| **2** | **Core POS Engine** | 2026-04-30 | 取引エンジン・在庫・イベント駆動 |
-| **3** | **Frontend Integration** | 2026-06-15 | POS端末・管理画面のAPI接続 |
-| **4** | **Auth & Security** | 2026-07-31 | 認証・認可・セキュリティ強化 |
-| **5** | **Analytics & Reporting** | 2026-08-31 | 売上分析・精算・レポート |
-| **6** | **Operations & Observability** | 2026-09-30 | 監視・CI/CD・デプロイ |
-| **7** | **Business Features** | 2026-11-30 | オフライン・帳票・在庫高度化 |
-| **8** | **Scale & Polish** | 2027-01-31 | 性能・a11y・i18n・クラウド |
-| **9** | **Enterprise** | 2027-03-31 | 顧客管理・ポイント・SaaS化 |
-
----
-
-## Phase 1.5: Development Infrastructure (〜2026-03-19)
-
-**ゴール**: Phase 2 開発を安全に開始できるテスト基盤・CI/CD・品質ゲートが整う
-
-**背景**: リポジトリ網羅的レビューにより、テスト基盤 25%・品質ゲート 0% が判明。Phase 2 開始前の基盤整備が必須。
-
-### 1.5.1 即時対応（P0）
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #232 | 未コミットファイルの確定（testing docs, branching strategy, CLAUDE.md, CI workflow） | P0 |
-| #233 | CLAUDE.md 強化（トラブルシューティング、レイヤー図、テナント実装例、rules参照） | P0 |
-| #240 | Testcontainers 結合テスト基盤構築（PostgreSQL + Redis + RabbitMQ） | P0 |
-| #234 | JaCoCo + Vitest カバレッジ計測基盤（80%品質ゲート） | P0 |
-| #241 | Playwright E2E テスト基盤構築（Page Object Model + 5シナリオ） | P0 |
-
-### 1.5.2 品質ゲート（P1）
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #235 | GitHub ブランチ保護ルール設定（テスト pass + approve 必須） | P1 |
-| #236 | CI パイプライン拡張（機能/結合テスト step + カバレッジ PR コメント） | P1 |
-| #237 | Docker Compose 認証情報の外部化（.env + .env.example） | P1 |
-| #238 | テストテンプレート作成（単体/機能/結合/E2E 実装例） | P1 |
-
-### 1.5.3 改善（P2）
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #239 | Dependabot 設定最適化（directory拡張 + grouping） | P2 |
-
-**依存グラフ**:
-```
-#232 → #233 (未コミット確定 → CLAUDE.md 強化)
-#240 → #236 (Testcontainers → CI パイプライン拡張)
-#234 → #236 (カバレッジ計測 → CI パイプライン拡張)
-#241 → #236 (E2E 基盤 → CI パイプライン拡張)
-#236 → #235 (CI 拡張 → ブランチ保護)
-```
-
-**完了条件**:
-- [ ] `./gradlew test -Dquarkus.test.profile=integration` で結合テスト pass
-- [ ] `pnpm --filter e2e test` で E2E テスト pass
-- [ ] JaCoCo/Vitest カバレッジレポート生成
-- [ ] CI で全テストレベルが自動実行
-- [ ] main ブランチ保護ルール有効
-
----
-
-## Phase 2: Core POS Engine (〜2026-04-30)
-
-**ゴール**: gRPCurl で取引フルフロー（作成→明細追加→確定→レシート→在庫減算）が実行できる
-
-### 2.1 取引エンジン（pos-service）
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #40 | Transaction エンティティ + Flyway マイグレーション | P1 |
-| #49 | 税額計算エンジン（標準10%/軽減8%） | P1 |
-| #41 | CreateTransaction + AddTransactionItem RPC | P1 |
-| #42 | UpdateTransactionItem + RemoveTransactionItem RPC | P1 |
-| #43 | ApplyDiscount RPC | P1 |
-| #44 | FinalizeTransaction RPC（支払処理・取引確定） | P1 |
-| #45 | VoidTransaction RPC（取引無効化・返品） | P1 |
-| #46 | GetTransaction + ListTransactions RPC | P2 |
-| #47 | GetReceipt RPC（レシート生成） | P1 |
-
-### 2.2 在庫管理（inventory-service）
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #50 | Stock エンティティ + Flyway マイグレーション | P1 |
-| #51 | GetStock + ListStocks + AdjustStock RPC | P1 |
-| #52 | ListStockMovements RPC（在庫移動履歴） | P2 |
-
-### 2.3 イベント駆動基盤
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #89 | RabbitMQ Exchange/Queue 定義 + SaleCompletedEvent Publisher | P1 |
-| #90 | SaleVoidedEvent + ProductUpdatedEvent Publisher | P1 |
-| #92 | イベント冪等性フレームワーク（ProcessedEvent テーブル） | P1 |
-| #54 | SaleCompletedEvent 購読 → 在庫自動減算 | P1 |
-| #55 | SaleVoidedEvent 購読 → 在庫自動戻し | P1 |
-
-### 2.4 API Gateway 拡張
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #62 | POS取引 REST エンドポイント追加 | P1 |
-| #63 | 在庫管理 REST エンドポイント追加 | P2 |
-
-### 2.5 テスト・DX
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #96 | pos-service ユニット/統合テスト | P1 |
-| #97 | inventory-service ユニット/統合テスト | P1 |
-| #119 | CI パイプライン改善（全サービステスト + キャッシュ） | P2 |
-| #151 | 開発用シードデータ | P2 |
-| #169 | Makefile コマンド拡充 | P2 |
-
-**依存グラフ**:
-```
-#40 → #49 → #41 → #42,#43 → #44 → #45,#46,#47
-#89 → #92 → #54,#55
-#50 → #51 → #54
-#44 → #89 (FinalizeTransaction が SaleCompletedEvent を発行)
-```
-
-**完了条件**:
-- [ ] `make test` で pos-service, inventory-service 全テスト pass
-- [ ] gRPCurl で取引フルフローが実行可能
-- [ ] RabbitMQ 経由で在庫が自動減算される
-
----
-
-## Phase 3: Frontend Integration (〜2026-06-15)
-
-**ゴール**: POS 端末で実際に取引操作できる、管理画面で商品・店舗管理ができる
-
-### 3.1 POS 端末
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #37 | 商品グリッド + バーコードスキャン | P1 |
-| #65 | 商品グリッド表示 + カテゴリナビゲーション | P1 |
-| #66 | バーコードスキャナー統合（html5-qrcode） | P1 |
-| #67 | カート管理UI（数量変更・削除・合計表示） | P1 |
-| #68 | 支払処理画面（現金・クレジット・QR） | P1 |
-| #69 | レシート表示・印刷画面 | P1 |
-| #70 | 取引履歴画面（一覧・詳細・返品） | P2 |
-| #163 | レスポンシブデザイン（タブレット/デスクトップ） | P2 |
-| #165 | エラーハンドリング統一（トースト・エラーページ） | P2 |
-| #166 | 確認ダイアログ統一（破壊的操作） | P2 |
-
-### 3.2 管理画面
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #35 | 商品管理画面 | P1 |
-| #74 | 商品管理画面（CRUD + 一括操作） | P1 |
-| #75 | カテゴリ管理画面（ツリービュー） | P2 |
-| #76 | 税率管理画面 | P2 |
-| #36 | 店舗・スタッフ管理画面 | P1 |
-| #78 | 店舗管理画面 | P1 |
-| #79 | スタッフ管理画面（RBAC） | P1 |
-| #164 | レスポンシブサイドバーナビゲーション | P2 |
-
-### 3.3 テスト
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #102 | pos-terminal コンポーネントテスト拡充 | P2 |
-| #103 | admin-dashboard コンポーネントテスト | P2 |
-| #99 | api-gateway REST 統合テスト拡充 | P2 |
-
-**完了条件**:
-- [ ] POS 端末で商品選択→カート→支払→レシート表示が可能
-- [ ] 管理画面で商品 CRUD / 店舗・スタッフ管理が可能
-- [ ] フロントエンド全テスト pass
-
----
-
-## Phase 4: Auth & Security (〜2026-07-31)
-
-**ゴール**: PIN ログインでPOS操作、ロールベースのアクセス制御が機能する
-
-### 4.1 認証基盤
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #85 | ORY Hydra OAuth2 クライアント登録 | P1 |
-| #86 | スタッフログインフロー（PIN → Hydra トークン発行） | P1 |
-| #87 | API Gateway 認証ミドルウェア（JWT 検証） | P1 |
-| #88 | フロントエンド認証フロー（PKCE + トークン管理） | P1 |
-| #72 | POS端末 PIN ログイン画面 + スタッフセッション管理 | P1 |
-
-### 4.2 セキュリティ強化
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #105 | 入力バリデーション強化（全gRPCサービス） | P1 |
-| #106 | gRPC メタデータサニタイゼーション | P1 |
-| #108 | CORS 設定（api-gateway） | P2 |
-| #107 | API レートリミット（api-gateway） | P2 |
-| #110 | リクエストサイズ制限 + タイムアウト | P2 |
-| #111 | Content Security Policy + セキュリティヘッダー | P2 |
-| #109 | 監査ログ（重要操作の記録） | P2 |
-| #167 | Dependabot / Renovate Bot 設定 | P2 |
-
-### 4.3 コンプライアンス
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #124 | 適格請求書（インボイス）制度完全対応 | P1 |
-| #126 | 個人情報保護（スタッフ・顧客データ） | P2 |
-
-**完了条件**:
-- [ ] PIN ログイン → POS 操作 → ログアウト が動作する
-- [ ] CASHIER ロールでスタッフ管理 API にアクセスすると 403
-- [ ] OWASP Top 10 の主要項目をカバー
-
----
-
-## Phase 5: Analytics & Reporting (〜2026-08-31)
-
-**ゴール**: 管理画面で売上分析・精算が可能
-
-### 5.1 Analytics Service
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #57 | 売上集計エンティティ + Flyway マイグレーション | P1 |
-| #58 | SaleCompletedEvent 購読 → 売上集計更新 | P1 |
-| #59 | SaleVoidedEvent 購読 → 売上集計ロールバック | P1 |
-| #60 | GetDailySales + GetSalesSummary RPC | P1 |
-| #61 | GetProductSales + GetHourlySales RPC | P2 |
-| #64 | 売上分析 REST エンドポイント追加 | P2 |
-| #98 | analytics-service ユニット/統合テスト | P1 |
-
-### 5.2 精算・レポート
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #127 | 精算（レジ締め）機能 | P1 |
-| #128 | つり銭準備金管理 | P2 |
-| #129 | 日報・月報レポート生成 | P2 |
-| #130 | CSV/Excel エクスポート | P2 |
-| #82 | 管理画面 売上ダッシュボード（日次チャート・KPI） | P1 |
-
-### 5.3 補助
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #77 | 管理画面 割引・クーポン管理画面 | P2 |
-| #80 | 管理画面 端末管理画面 | P2 |
-| #81 | 管理画面 組織設定画面 | P2 |
-
-**完了条件**:
-- [ ] 管理画面に売上ダッシュボード表示
-- [ ] レジ締め（精算）が POS 端末から実行可能
-- [ ] CSV エクスポートが動作する
-
----
-
-## Phase 6: Operations & Observability (〜2026-09-30)
-
-**ゴール**: 本番運用に必要な可観測性・CI/CD・インフラが整う
-
-### Issues
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #112 | 構造化ログ（JSON + 相関ID） | P1 |
-| #113 | 分散トレーシング（OpenTelemetry） | P2 |
-| #114 | メトリクス収集（Micrometer + Prometheus） | P2 |
-| #115 | Grafana ダッシュボード | P2 |
-| #116 | ヘルスチェック改善（深いヘルスチェック） | P2 |
-| #117 | データベースインデックス戦略 | P2 |
-| #122 | データベースバックアップ戦略 | P2 |
-| #123 | シークレット管理（GCP Secret Manager） | P2 |
-| #198 | Flyway マイグレーション CI 検証 | P2 |
-| #91 | Dead Letter Queue ハンドリング + リトライ | P2 |
-| #56 | StockLowEvent 発行（低在庫アラート） | P2 |
-| #100 | 取引フルフロー E2E テスト | P1 |
-| #150 | OpenAPI / Swagger ドキュメント自動生成 | P2 |
-| #177 | アーキテクチャドキュメント更新 | P2 |
-| #211 | 開発環境セットアップ自動化スクリプト | P2 |
-| #185 | OWASP Top 10 セキュリティ監査 | P2 |
-
-**完了条件**:
-- [ ] Grafana で全サービスの監視ダッシュボード表示
-- [ ] E2E テストが CI で pass
-- [ ] OpenAPI ドキュメントが生成される
-
----
-
-## Phase 7: Business Features (〜2026-11-30)
-
-**ゴール**: 実店舗で運用可能な業務機能が揃う
-
-### Issues
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #71 | オフラインモード（Dexie + Service Worker） | P1 |
-| #48 | SyncOfflineTransactions RPC | P1 |
-| #73 | 割引・クーポン適用UI | P2 |
-| #197 | レシートプリンター連携（ESC/POS） | P2 |
-| #194 | 領収書発行機能 | P2 |
-| #179 | レシート再発行機能 | P2 |
-| #180 | 部分返品（明細単位） | P2 |
-| #181 | 保留取引（パーキング） | P2 |
-| #136 | オープンプライス商品 | P2 |
-| #131 | 商品CSVインポート | P2 |
-| #53 | 発注管理 CRUD RPC | P2 |
-| #83 | 管理画面 在庫管理画面 | P2 |
-| #84 | 管理画面 発注管理画面 | P2 |
-| #146 | 棚卸し（在庫実査）機能 | P2 |
-| #217 | 商品のソフトデリート（論理削除） | P2 |
-| #218 | 楽観的ロック（同時更新の競合防止） | P2 |
-| #204 | システム設定管理（テナントレベル） | P2 |
-| #209 | 電子ジャーナル（取引ジャーナル保存） | P2 |
-| #125 | 電子帳簿保存法対応 | P2 |
-| #101 | オフライン同期 E2E テスト | P2 |
-| #93 | product-service Redis キャッシュ層 | P2 |
-| #94 | store-service Redis キャッシュ層 | P2 |
-| #95 | api-gateway Redis レスポンスキャッシュ | P2 |
-| #154 | タッチターゲットサイズ最適化 | P2 |
-
-**完了条件**:
-- [ ] オフラインで取引作成→オンライン復帰で同期
-- [ ] レシートプリンターで印刷可能
-- [ ] 棚卸し・発注管理が動作する
-
----
-
-## Phase 8: Scale & Polish (〜2027-01-31)
-
-**ゴール**: 本番デプロイ可能な品質と性能
-
-### Issues
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #157 | フロントエンドバンドル最適化 | P2 |
-| #158 | gRPC 接続プーリング + keep-alive | P2 |
-| #159 | N+1 クエリ防止の検証・最適化 | P2 |
-| #118 | pgBouncer 接続プーリング | P3 |
-| #104 | 負荷テスト（取引処理スループット） | P3 |
-| #120 | GKE / Cloud Run デプロイ設定 | P3 |
-| #121 | CD パイプライン（ステージング→本番） | P3 |
-| #178 | Quarkus ネイティブビルド対応 | P3 |
-| #168 | コンテナセキュリティスキャン | P3 |
-| #153 | POS端末 キーボードナビゲーション | P3 |
-| #155 | ハイコントラストモード + フォントサイズ調整 | P3 |
-| #156 | 多言語対応基盤（i18n） | P3 |
-| #160 | カーソルベースページネーション | P3 |
-| #190 | ログ集約（Loki + Grafana） | P3 |
-| #210 | データアーカイブ・パーティショニング | P3 |
-| #182 | 売上予測・トレンド分析 | P3 |
-| #183 | ABC 分析 | P3 |
-| #184 | 粗利管理（原価登録・粗利レポート） | P3 |
-| #152 | Postman / gRPCurl コレクション | P3 |
-| #212 | gRPC リフレクション有効化 | P3 |
-| #215 | Docker Compose プロファイル分離 | P3 |
-| #202 | 災害復旧計画（DR） | P3 |
-| #221 | Proto ドキュメント自動生成 | P3 |
-
-**完了条件**:
-- [ ] 負荷テストで性能目標を達成（p99 < 500ms）
-- [ ] Cloud Run へデプロイ可能
-- [ ] Lighthouse Performance > 90
-
----
-
-## Phase 9: Enterprise (〜2027-03-31)
-
-**ゴール**: 多業態・多店舗展開に対応する SaaS 機能
-
-### Issues
-| Issue | Title | Priority |
-|-------|-------|----------|
-| #140 | 顧客管理基盤 | P3 |
-| #141 | ポイント/ロイヤルティシステム | P3 |
-| #142 | ギフトカード / プリペイドカード | P3 |
-| #132 | 電子レシート（メール送信） | P3 |
-| #133 | 商品バリアント（サイズ・カラー） | P3 |
-| #134 | セット商品（バンドル販売） | P3 |
-| #135 | 計量販売商品（重量/量り売り） | P3 |
-| #138 | 年齢確認プロンプト | P3 |
-| #139 | トレーニングモード | P3 |
-| #143 | タイムセール / 時間帯別価格 | P3 |
-| #144 | 仕入先管理 | P3 |
-| #145 | 多店舗間在庫移動 | P3 |
-| #147 | バーコードラベル印刷 | P3 |
-| #148 | 免税販売対応 | P3 |
-| #149 | レシートカスタマイズ | P3 |
-| #161 | ダークモード | P3 |
-| #162 | サウンドフィードバック | P3 |
-| #170 | 複数通貨対応 | P3 |
-| #171 | 勤怠管理 | P3 |
-| #172 | シフト管理 | P3 |
-| #173 | 商品画像管理 | P3 |
-| #174 | 通知システム | P3 |
-| #175 | WebSocket / SSE リアルタイム更新 | P3 |
-| #176 | マルチテナント プラン・課金管理 | P3 |
-| #186 | 外部決済端末連携 | P3 |
-| #187 | スタッフ活動ログ | P3 |
-| #188 | お気に入り商品 | P3 |
-| #189 | 在庫自動発注 | P3 |
-| #191 | テナント オンボーディングウィザード | P3 |
-| #192 | マルチ端末カート共有 | P3 |
-| #193 | 予約注文・取り置き | P3 |
-| #195 | 会計ソフト連携 | P3 |
-| #196 | ドロワー連携 | P3 |
-| #199 | 在庫有効期限管理 | P3 |
-| #200 | テーブルオーダー / 飲食店モード | P3 |
-| #201 | セルフレジモード | P3 |
-| #203 | Webhook 連携 | P3 |
-| #205 | 売上速報メール | P3 |
-| #206 | サービスメッシュ検討 | P3 |
-| #207 | 商品アラート | P3 |
-| #208 | API バージョニング戦略 | P3 |
-| #213 | 顧客表示ディスプレイ | P3 |
-| #214 | 売上目標管理 | P3 |
-| #216 | 値引き理由コード管理 | P3 |
-| #219 | 税率変更スケジューリング | P3 |
-| #220 | テナント データエクスポート | P3 |
-| #222 | スタンプカード | P3 |
-| #223 | POS端末 マルチウィンドウ | P3 |
-| #137 | 取引メモ・備考 | P3 |
-
-**完了条件**:
-- [ ] 顧客管理 + ポイントシステムが動作
-- [ ] 飲食店モード（テーブルオーダー）が使用可能
-- [ ] 外部決済端末と連携可能
-
----
-
-## Principles (Harness Engineering)
-
-### 1. Delegate-Review-Own
-- **Delegate**: 明確な仕様のタスク → AI エージェントに委任
-- **Review**: PR レビュー → 品質・整合性の人間検証
-- **Own**: アーキテクチャ・戦略的決定 → 人間が所有
-
-### 2. Golden Principles
-- 金額は **BIGINT 銭単位**（浮動小数点禁止）
-- 全テーブルに **organization_id**（テナント分離）
-- イベントは **EventEnvelope** でラップ（冪等性キー付き）
-- テストは **Red → Green**（実装前に失敗確認）
-
-### 3. Session Protocol
-1. 作業ディレクトリ確認
-2. Git ログ + 進捗ファイル読み取り
-3. 未完了の最優先タスク選択
-4. 既存不具合を先に修正
-5. 1 セッション = 1 機能に集中
-
-### 4. Branching Strategy
-→ [docs/guides/branching-strategy.md](../guides/branching-strategy.md)
+open-pos は、Kotlin/Quarkus のマイクロサービスと React フロントエンドで構成された、マルチテナント・オフライン対応の POS モノリポです。
+
+2026-03 時点の phase-based 計画は、現在の実装速度と実際の到達点に対して stale になりました。現時点では、固定日付のフェーズよりも「いま何を出荷品質まで持っていくか」を軸に運用した方が正確です。
+
+このファイルは、現在の delivery stream と exit criteria を示します。個別の実装タスクは GitHub issue / PR を source of truth とします。
+
+## Current Position
+
+### Delivered Baseline
+
+- 6 backend services + 2 frontend apps が同一モノリポで動作
+- `make local-demo` / `make docker-demo` によるローカル再現可能なデモフロー
+- ORY Hydra を使った OIDC/PKCE 認証、RBAC、マルチテナント境界
+- POS / inventory / analytics / admin dashboard の主要フロー
+- CI, CodeQL, dependency audit, secret scanning, Playwright E2E を含む品質ゲート
+
+### Current Posture
+
+- リポジトリは「production-ready SaaS」ではなく、「self-hostable beta / release-candidate baseline」として扱う
+- 実装面の中核機能は揃っている
+- 残課題は、運用整備、公開ドキュメント整合、最終的な release verification に集中している
+
+## Active Delivery Streams
+
+| Stream | Status | Why it matters | Exit criteria |
+| --- | --- | --- | --- |
+| Release & Repository Hygiene | In progress | 公開リポジトリとしての説明責任を満たす | README / roadmap / runbook が現行実装と一致する |
+| Security & Operational Readiness | In progress | 実装済みでも運用体制が曖昧だと本番運用できない | 秘密情報運用、インシデント責任分界、環境変数/デプロイ文書が揃う |
+| Business Correctness & Resilience | In progress | POS としての信頼性を担保する | 重要フローの再検証、障害時のグレースフルデグレーション確認 |
+| Maintainability & Hotspot Reduction | Planned | 実装速度と安全な変更容易性を維持する | 巨大ファイル/サービス境界の分割方針を実装に落とす |
+
+## Stream Details
+
+### 1. Release & Repository Hygiene
+
+**Goal**: 公開ドキュメントと実際の挙動のズレをなくし、初見の開発者や利用者が誤解しない状態にする。
+
+**Current work**:
+
+- README のプロジェクト表現を「managed production SaaS」相当から現実的な表現へ補正
+- 古い phase roadmap を current-state ベースへ更新
+- stale な release planning document を release readiness ベースへ更新
+- incident runbook から placeholder を除去し、現行サポートモデルに合わせる
+
+**Exit criteria**:
+
+- README の status / stack / supported workflows が実装と一致する
+- roadmap / v1 release doc が stale issue list ではなく current delivery stream を説明する
+- runbook に空欄や TODO placeholder が残らない
+
+### 2. Security & Operational Readiness
+
+**Goal**: 実装済み機能を「安全に運用できるか」で評価し、残る本番ブロッカーを明確にする。
+
+**Focus**:
+
+- 秘密情報ローテーションと履歴スキャン
+- デプロイ先ごとの責任分界の明文化
+- インシデント時の連絡経路と復旧コマンドの整備
+- dependency maintenance を継続可能な運用に維持
+
+**Exit criteria**:
+
+- secret handling policy が文書化され、履歴スキャン手順がある
+- incident ownership が maintainer-owned か deployer-owned か明記されている
+- setup / release / incident docs が同じ前提を共有している
+
+### 3. Business Correctness & Resilience
+
+**Goal**: POS としての重要フローが、平常時だけでなく障害時にも期待どおりかを詰める。
+
+**Focus**:
+
+- offline transaction / sync conflict の再検証
+- oversell, idempotency, timeout, analytics consistency の回帰確認
+- Redis / RabbitMQ 障害時の degradation path を明確化
+
+**Exit criteria**:
+
+- 主要な取引フローに対する回帰確認が文書化されている
+- 障害時に「止まる機能」と「継続できる機能」が整理されている
+
+### 4. Maintainability & Hotspot Reduction
+
+**Goal**: 大きすぎるファイルや責務過多の層を分割し、依存更新や機能追加のコストを下げる。
+
+**Current hotspots**:
+
+- `services/pos-service` の gRPC / transaction service 層
+- `apps/pos-terminal` の商品一覧/カート周辺
+- frontend 認証・API クライアントの重複
+
+**Exit criteria**:
+
+- 分割対象ごとに write scope が明確な実装タスクへ落とし込まれている
+- 次の変更が大型ファイルをさらに肥大化させない
+
+## Non-Goals For This Roadmap
+
+- 古い日付ベース phase 計画の維持
+- issue 番号を網羅した static backlog の複製
+- 実装済みの項目を「未着手」のまま残すこと
+
+## Source Of Truth
+
+- 実装の正否: code + CI + local verification
+- 個別作業: GitHub issues / pull requests
+- この文書: 現在の delivery priority と exit criteria

--- a/docs/plans/v1-release-roadmap.md
+++ b/docs/plans/v1-release-roadmap.md
@@ -1,152 +1,89 @@
-# open-pos v1.0.0 ロードマップ
+# open-pos v1.0 Release Readiness
 
-> **マイルストーン**: [v1.0.0](https://github.com/akaitigo/open-pos/milestone/18)
-> **全65件のイシューを全てクローズすれば v1.0 マイルストーン達成**
-> **作成**: 2026-03-16 / Claude + Gemini + Codex による包括レビュー
+> **Last Updated**: 2026-05-07
+> **Status**: Living document
+> **Purpose**: stale issue backlog ではなく、現時点の v1 release readiness を判定する
 
-## 実行フェーズと依存関係
+## Executive Summary
 
-### Phase 0: ブロッカー解除（他の全作業の前提）
-> **目的**: CI green化とリポジトリの衛生確保。これが完了しないと他のフェーズが検証不能。
+open-pos は、v1 に必要な実装の多くをすでに持っています。特に、frontend integration、OIDC/PKCE auth、analytics、tenant-aware data access、CI/security baseline は「未実装」ではありません。
 
-| # | 優先度 | タイトル | 依存 | PR状態 |
-|---|--------|---------|------|--------|
-| **#350** | P0 | security: dev-private-key.pem の Git 追跡削除とローテーション | なし | 未着手 |
-| **#358** | P0 | verify: git 全履歴の秘密情報スキャン | #350 | 未着手 |
-| **#315** | P1 | fix(infra): Flyway 版番号衝突 + RabbitMQ ポート | なし | PR #316 |
-| **#311** | P1 | fix(e2e): Docker ビルド依存解決 | なし | PR #313 |
-| **#351** | P1 | chore: JVM クラッシュログ除去と .gitignore 追加 | なし | 未着手 |
-| **#331** | P1 | fix(infra): CI build cache 無効化の解除 | なし | 未着手 |
+一方で、まだ v1 の一般公開を断言しづらい理由は、機能不足よりも運用整備と最終 verification にあります。したがって、この文書では「何が未着手か」ではなく、「何が release gate としてまだ弱いか」を管理します。
 
-**マージ順序**: #315 → #311 → #350 → #351 → #331 → #358
+## Current Release Posture
 
----
+- **Product posture**: self-hostable beta / release-candidate baseline
+- **Not yet claimed**: staffed production operations, managed SaaS support, 24/7 on-call
+- **What is already true**: local demo, CI/security gates, multi-tenant auth, analytics, offline-capable frontend baseline
 
-### Phase 1: セキュリティ基盤（公開前必須）
-> **目的**: マルチテナント分離と認証フローの堅牢化。公開リポジトリとして最低限の安全性。
+## What Is Already Implemented
 
-| # | 優先度 | タイトル | 依存 |
-|---|--------|---------|------|
-| **#329** | P0 | fix(backend): analytics-service のテナントフィルタ適用漏れ | Phase 0 |
-| **#328** | P0 | security: PKCE state パラメータ検証の欠落（CSRF） | なし |
-| **#322** | P0 | security: マルチテナント RLS の網羅性検証 | #329 |
-| **#362** | P0 | verify: マルチテナント境界の実行確認（cross-tenant leak） | #329, #322 |
-| **#339** | P1 | fix(frontend): トークンリフレッシュの無限ループリスク | #328 |
-| **#360** | P0 | verify: 依存脆弱性スキャン実行と Critical/High ゼロ化 | Phase 0 |
-| **#333** | P1 | security: 依存脆弱性 audit の CI 失敗連動 | #360 |
-| **#323** | P1 | security: CI/CD ワークフローのセキュリティ強化 | なし |
-| **#332** | P1 | fix(infra): Dockerfile の非 root ユーザー実行 | なし |
+### Authentication And Tenant Boundary
 
----
+- ORY Hydra based OIDC/PKCE flow is implemented
+- frontend stores and validates OAuth2 `state` to mitigate CSRF
+- RBAC roles are wired through the current auth surface
+- analytics / gateway / service layer already carry organization-aware access patterns
 
-### Phase 2: ビジネスロジック正確性（POSとしての信頼性）
-> **目的**: 金額計算・決済・在庫がPOSとして正しく動作することを保証。
+### Reliability Baseline
 
-| # | 優先度 | タイトル | 依存 |
-|---|--------|---------|------|
-| **#361** | P0 | verify: 金額計算の正確性（端数処理 FE/BE 一致） | Phase 0 |
-| **#334** | P0 | fix(pos): 在庫 Race Condition — オーバーセル防止 | Phase 0 |
-| **#320** | P0 | fix(pos): gRPC deadline 未設定による連鎖障害リスク | Phase 0 |
-| **#321** | P0 | security: 決済処理の冪等性キーとリカバリ機構 | #320 |
-| **#375** | P1 | fix(pos): 割引額バリデーション欠落 | なし |
-| **#376** | P1 | fix(pos): 複数決済のオーバーペイ・返金仕様 | なし |
-| **#366** | P1 | fix: 割引クーポンの FE/BE 実装差分 | #375 |
-| **#364** | P1 | fix: Analytics API 契約の不一致 | なし |
-| **#365** | P1 | fix: void 取消時の analytics 集計ロールバック日付バグ | #364 |
-| **#363** | P1 | fix: タイムゾーン処理の不一貫 | なし |
-| **#356** | P1 | compliance: インボイス制度対応（適格請求書要件） | #377 |
-| **#377** | P1 | fix(pos): インボイス登録番号のハードコード除去 | なし |
+- gRPC client deadlines are configured in `api-gateway` and downstream clients
+- CI includes frontend/backend validation, security scanning, CodeQL, and Playwright E2E
+- dependency hygiene is actively maintained and the current audit gate is green for high/critical issues
 
----
+### Product Surface
 
-### Phase 3: 耐障害性・運用基盤
-> **目的**: 本番運用に耐えるメッセージング・キャッシュ・DB接続の整備。
+- POS terminal, admin dashboard, analytics, inventory, and product/store management are present
+- `make local-demo` and `make docker-demo` provide reproducible demo paths
 
-| # | 優先度 | タイトル | 依存 |
-|---|--------|---------|------|
-| **#330** | P1 | fix(backend): RabbitMQ メッセージの明示的 ack/nack | なし |
-| **#318** | P1 | feat(resilience): Transactional Outbox パターン | #330 |
-| **#335** | P1 | fix(backend): Redis cache-aside パターン違反 | なし |
-| **#317** | P1 | fix(infra): PgBouncer が未使用 | なし |
-| **#343** | P1 | fix(infra): Flyway migrate-at-start を本番で無効化 | なし |
-| **#344** | P0 | fix(infra): K8s Secrets 管理 | なし |
-| **#346** | P1 | feat(infra): K8s 本番構成 | #344 |
-| **#349** | P1 | security: 監査ログの完全性 | なし |
-| **#370** | P1 | verify: Redis/RabbitMQ ダウン時のグレースフルデグレーション | #330, #335 |
+## Remaining Release Gates
 
----
+| Gate | Status | What is missing |
+| --- | --- | --- |
+| Documentation accuracy | In progress | README / roadmap / runbook must consistently describe the current posture |
+| Secret handling | Needs work | secret rotation and history scan procedures must be explicit |
+| Incident ownership | Needs work | maintainer/deployer escalation path must be defined without placeholders |
+| Production deployment guidance | Needs work | environment docs and release docs must cover the supported deployment model |
+| End-to-end resilience verification | Needs work | offline sync conflict handling and degraded-mode expectations should be documented and re-verified |
+| Business/legal verification | Needs work | invoice/privacy/compliance claims need final release-oriented confirmation |
 
-### Phase 4: ドキュメント・検証
-> **目的**: ドキュメント整備と最終動作確認。
+## Release Decision Framework
 
-| # | 優先度 | タイトル | 依存 |
-|---|--------|---------|------|
-| **#352** | P1 | docs: README/SECURITY/アーキテクチャのバージョン整合 | Phase 2 |
-| **#353** | P1 | docs: 環境変数の完全ドキュメント (.env.example) | なし |
-| **#354** | P1 | docs: 本番デプロイガイドの作成 | Phase 3 |
-| **#355** | P2 | docs: API ドキュメントの完全化（OpenAPI + Proto docs） | Phase 2 |
-| **#357** | P2 | chore: サードパーティライセンスの確認と公開 | なし |
-| **#359** | P0 | verify: make docker-demo の動作確認と E2E green 化 | Phase 0-3 |
-| **#367** | P1 | verify: オフライン取引の完全同期確認 | Phase 2 |
-| **#368** | P1 | verify: make db-backup / db-restore の実行確認 | Phase 0 |
-| **#369** | P1 | verify: README clone→動作の新規開発者体験検証 | #352, #353 |
-| **#374** | P2 | verify: 全 API エンドポイントのスモークテスト | Phase 2 |
-| **#342** | P1 | fix(frontend): オフライン同期の競合解決戦略 | #367 |
+### Eligible To Call "v1.0"
 
----
+The repository can be tagged as `v1.0` when all of the following are true:
 
-### Phase 5: 品質向上
-> **目的**: v1.0 の品質水準を上げる。必須ではないが望ましい。
+- the public docs match the actual product and operating model
+- CI/security gates are green on `main`
+- release-critical secrets and history scans are complete
+- incident response ownership is documented
+- local/demo/release verification flows are reproducible by another engineer
 
-| # | 優先度 | タイトル |
-|---|--------|---------|
-| **#312** | P2 | chore(test): カバレッジ閾値を元の水準に復元 |
-| **#319** | P2 | chore: Stabilization — placeholder API の整理 |
-| **#324** | P2 | feat(observability): 分散トレーシング (OpenTelemetry) |
-| **#325** | P2 | chore(perf): 負荷テスト (k6) 導入 |
-| **#326** | P2 | fix(infra): Gradle メモリ設定の最適化 |
-| **#327** | P2 | security(privacy): GDPR/個人情報保護対応 |
-| **#336** | P2 | fix(backend): N+1 クエリリスク |
-| **#337** | P2 | fix(backend): gRPC Status Code の統一 |
-| **#338** | P3 | fix(frontend): as 型アサーション 87箇所の削減 |
-| **#340** | P2 | chore(frontend): バンドルサイズ最適化 |
-| **#341** | P2 | fix(frontend): console.log 残存 |
-| **#345** | P2 | fix(infra): ヘルスチェックエンドポイントの統一 |
-| **#347** | P2 | feat(infra): CD パイプライン完成 |
-| **#348** | P2 | fix(observability): ログ構造化の完成 |
-| **#371** | P2 | verify: ログに PII が含まれていないか |
-| **#372** | P2 | verify: i18n 翻訳の網羅性 |
-| **#373** | P2 | verify: DB スキーマ整合性 |
-| **#378** | P2 | fix: buf breaking 検証の設定修正 |
+### Not A Blocker By Itself
 
----
+The following are not, by themselves, reasons to block `v1.0`:
 
-## 既存 PR の状態
+- the existence of future-looking enhancement issues
+- the absence of managed SaaS operations
+- large but known-maintainable files, as long as correctness and release verification are intact
 
-| PR | イシュー | 内容 | CI |
-|----|---------|------|-----|
-| #313 | #311 | Docker ビルド依存解決修正 | Backend/FE パス, E2E 失敗(#315が原因) |
-| #314 | #312 | 341テスト追加+閾値引き上げ | CI修正プッシュ済み |
-| #316 | #315 | Flyway版番号衝突+RabbitMQポート修正 | CI実行中 |
+## Changes From The March 2026 Review
 
-## 調査ソース
+The earlier review document treated several items as open that are now implemented in code:
 
-| ソース | 分析手法 | 主な発見 |
-|--------|---------|---------|
-| Claude (5 Agent) | コード品質、テナント漏れ、CI設定、OSS完成度、実証検証 | analytics テナントフィルタ漏れ、JVMクラッシュログ |
-| Gemini | POS ビジネスリスク、法的要件、OSS完了条件 | インボイス制度、Race Condition、GDPR |
-| Codex | FE/BE実装差分、具体的コード箇所特定 | void日付バグ、Analytics API不一致、PgBouncer未使用 |
-| ビジネスロジック Agent | 金額計算・決済・在庫の正確性検証 | 割引バリデーション欠落、複数決済オーバーペイ |
-| 実証検証 Agent | git history、依存脆弱性、DB スキーマ、i18n | pnpm audit クリーン、i18n完全同期 |
+- PKCE `state` validation
+- analytics tenant-scoped access patterns
+- gRPC deadline configuration
+- CI-linked dependency audit and dependency grouping baseline
+- frontend/admin analytics and management surfaces
 
-## 検証済み「問題なし」項目
+Those items should no longer be tracked as "missing features". They are now part of the verified baseline and should only reappear here if regression evidence is found.
 
-| 項目 | 検証方法 | 結果 |
-|------|---------|------|
-| 金額の型 (Float/Double使用) | 全ソースgrep | BIGINT/Long で統一、問題なし |
-| TODO/FIXME コメント | 全ソースgrep | 検出ゼロ |
-| ハードコード URL/ポート | 全ソースgrep | 環境変数化済み |
-| i18n 翻訳漏れ | ja.json/en.json 行数比較 | 完全同期 |
-| 依存脆弱性 | pnpm audit 実行 | ゼロ |
-| as unknown as / as any | 全ソースgrep | 検出ゼロ |
-| console.log 残存 | 全ソースgrep（test除外） | 検出ゼロ |
+## Operational Recommendation
+
+Treat the current repository as:
+
+- **good enough for self-hosted evaluation and controlled rollout**
+- **not yet something to market as a fully managed production SaaS**
+
+That distinction keeps the public messaging honest while still recognizing the implementation maturity already present in the codebase.

--- a/docs/runbook/incident-response.md
+++ b/docs/runbook/incident-response.md
@@ -1,66 +1,102 @@
-# インシデント対応手順（SOP）
+# Incident Response SOP
 
-## オンコール体制
+> **Scope**: self-hosted / pre-production deployments of open-pos
+> **Support model**: maintainer-led; this repository does not currently provide a staffed 24/7 on-call rotation
 
-| 役割 | 担当 | 連絡先 |
-|------|------|--------|
-| Primary on-call | (要設定) | (要設定) |
-| Secondary on-call | (要設定) | (要設定) |
-| エスカレーション先 | (要設定) | (要設定) |
+## Ownership
 
-> **TODO**: 本番デプロイ前に上記を埋めること。
+| Role | Current owner | Contact path |
+| --- | --- | --- |
+| Incident commander | Repository maintainer | GitHub `@akaitigo` or the team operating the deployment |
+| Technical backup | Deployment owner | Your internal pager/chat/on-call system |
+| Security escalation | Deployment owner + repository maintainer | GitHub Security Advisory or private security contact configured by the deployer |
 
-## 重大度レベル
+## Severity Levels
 
-| レベル | 定義 | 対応時間 | 例 |
-|--------|------|---------|-----|
-| **SEV1** | 全サービス停止 | 15分以内に対応開始 | DB障害、api-gatewayダウン |
-| **SEV2** | 主要機能停止 | 30分以内に対応開始 | POS決済不可、認証障害 |
-| **SEV3** | 一部機能劣化 | 4時間以内に対応開始 | analytics遅延、キャッシュ不整合 |
-| **SEV4** | 軽微な問題 | 次営業日に対応 | UIバグ、ログ欠損 |
+| Level | Definition | Response target | Examples |
+| --- | --- | --- | --- |
+| `SEV1` | Full service outage or cross-tenant/security incident | Start within 15 minutes | API gateway outage, data leak suspicion, auth failure across tenants |
+| `SEV2` | Core workflow unavailable for part of the product | Start within 30 minutes | Checkout blocked, login broken, message broker unavailable |
+| `SEV3` | Partial degradation with workaround | Start within 4 hours | Analytics delay, cache inconsistency, non-critical admin page failure |
+| `SEV4` | Minor defect or cosmetic issue | Next business day | Small UI bug, missing log field, flaky local script |
 
-## 対応フロー
+## Detection Sources
 
-### 1. 検知・通知
-- Grafana アラート → Slack 通知（要設定）
-- ユーザー報告 → サポート窓口
+- GitHub Actions failures on `main`
+- `make local-smoke` / `make grpc-test` failures
+- Docker Compose health or container restart loops
+- application logs from `make logs` / `make logs-pos`
+- operator or user reports from the deployment owner
 
-### 2. 初動対応（15分以内）
-1. アラート内容を確認
-2. 影響範囲を特定（テナント単体 or 全体）
-3. Slack の `#incident` チャンネルでインシデント宣言
-4. 重大度レベルを決定
+## Initial Response
 
-### 3. 調査
-1. **Grafana ダッシュボード** でメトリクス確認
-   - `http://grafana:3000/d/openpos-overview`
-2. **ログ確認**
-   ```bash
-   kubectl logs -n openpos deployment/{service-name} --tail=100
-   ```
-3. **gRPC トレース** で Correlation ID (`x-request-id`) を追跡
+1. Record the incident start time and the observed symptom.
+2. Decide whether the impact is tenant-scoped or system-wide.
+3. Classify severity (`SEV1`-`SEV4`).
+4. Open a dedicated incident channel/thread in the deployer's chat system.
+5. Avoid posting live access tokens, PKCE artifacts, or customer data into public issues or logs.
 
-### 4. 対応
-- **スケールアウト**: `kubectl scale deployment/{service} -n openpos --replicas=3`
-- **ロールバック**: `kubectl rollout undo deployment/{service} -n openpos`
-- **サービス再起動**: `kubectl rollout restart deployment/{service} -n openpos`
+## Local / Docker Compose Triage
 
-### 5. 復旧確認
-1. ヘルスチェック: `kubectl get pods -n openpos`
-2. E2E スモークテスト実行
-3. Grafana でエラー率が正常に戻ったことを確認
+### Health And Logs
 
-### 6. ポストモーテム
-- インシデント発生後 3営業日以内に作成
-- テンプレート: `docs/templates/postmortem.md`
-- ブレームレス、根本原因分析、再発防止策
+```bash
+docker compose -f infra/compose.yml ps
+make logs
+make logs-pos
+make local-smoke
+make grpc-test
+```
 
-## よくある障害と対応
+### Fast Recovery Actions
 
-| 障害 | 確認方法 | 対応 |
-|------|---------|------|
-| DB接続断 | `kubectl logs` で `Connection refused` | PostgreSQL Pod確認、pgBouncer再起動 |
-| Redis接続断 | メトリクスでcache miss急増 | Redis Pod確認、再起動 |
-| RabbitMQ溢れ | Management UI でキュー深度確認 | コンシューマースケールアウト |
-| OOM Kill | `kubectl describe pod` で `OOMKilled` | リソースlimits引き上げ |
-| E2Eテスト的な503 | api-gateway ログ | Readiness probe確認、依存サービス確認 |
+```bash
+docker compose -f infra/compose.yml restart postgres redis rabbitmq hydra
+make local-down
+make local-up-fast
+```
+
+### If The Demo Stack Is Suspect
+
+```bash
+make docker-down-core
+make docker-demo
+```
+
+## Kubernetes Deployments
+
+If you run open-pos on Kubernetes, use your platform's rollout and secret-management conventions. The repository does not define a single production Kubernetes control plane, so the deployer is responsible for the exact commands.
+
+Typical checks:
+
+```bash
+kubectl get pods -n openpos
+kubectl logs -n openpos deployment/<service> --tail=100
+kubectl rollout restart deployment/<service> -n openpos
+kubectl rollout undo deployment/<service> -n openpos
+```
+
+## Service-Specific Hints
+
+| Symptom | First checks | Common actions |
+| --- | --- | --- |
+| API failures / 5xx | `api-gateway` logs, Hydra reachability, gRPC downstream health | restart gateway, verify OIDC config, inspect gRPC deadlines/timeouts |
+| Checkout blocked | `pos-service` logs, Redis/RabbitMQ reachability, product/store gRPC clients | verify downstream services, restart broker/cache, run smoke flow |
+| Analytics stale | `analytics-service` logs, RabbitMQ queue depth | inspect event consumer lag, replay/restart consumer if needed |
+| Cache anomalies | Redis logs, cache key patterns, fallback behavior | confirm read-through/fallback path, restart Redis if safe |
+| E2E-only failure | `make docker-demo`, Playwright artifacts, frontend env files | rebuild demo stack, inspect generated `demo-config.json` |
+
+## Recovery Validation
+
+1. Confirm container or pod health.
+2. Re-run `make local-smoke` or the environment-equivalent smoke test.
+3. Re-run `make grpc-test` if backend reachability is involved.
+4. Confirm the user-visible flow that triggered the incident.
+5. Capture whether the system degraded gracefully or failed hard.
+
+## Aftercare
+
+- Create a postmortem within 3 business days for `SEV1`/`SEV2`.
+- Link the incident to the fixing PRs and follow-up issues.
+- If secrets or tokens may have leaked, rotate them before closing the incident.
+- Update this runbook when the incident exposed a missing operational step.


### PR DESCRIPTION
## Summary
- align README messaging with the current self-hostable release-candidate posture
- replace stale roadmap documents with current delivery-stream and release-readiness views
- remove placeholder incident-response ownership and make the runbook match the current support model