### PR TITLE
[codex] split pos product catalog route

### DIFF
--- a/apps/pos-terminal/src/routes/products.tsx
+++ b/apps/pos-terminal/src/routes/products.tsx
@@ -1,86 +1,41 @@
-import { useEffect, useRef, useState } from 'react'
-import { Html5Qrcode } from 'html5-qrcode'
-import { z } from 'zod'
+import { useEffect, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { t } from '@/i18n'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Card } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { api } from '@/lib/api'
 import { toast } from '@/hooks/use-toast'
 import { useAuthStore } from '@/stores/auth-store'
 import { useCartStore } from '@/stores/cart-store'
+import type { Product, Stock } from '@shared-types/openpos'
+import { BarcodeScannerDialog } from './products/barcode-scanner-dialog'
 import {
-  CategorySchema,
-  formatMoney,
-  PaginatedProductsSchema,
-  PaginatedStocksSchema,
-} from '@shared-types/openpos'
-import type { Category, PaginatedResponse, Product, Stock } from '@shared-types/openpos'
+  filterProducts,
+  getChildCategories,
+  getTopLevelCategories,
+  indexCategoriesById,
+} from './products/catalog'
+import { OpenPriceDialog } from './products/open-price-dialog'
+import { ProductGrid } from './products/product-grid'
+import { useProductCatalog } from './products/use-product-catalog'
 
 const PRODUCT_PAGE_SIZE = 24
-const CATALOG_FETCH_PAGE_SIZE = 100
 
 export function ProductsPage() {
   const storeId = useAuthStore((s) => s.storeId)
-  const [products, setProducts] = useState<Product[]>([])
-  const [categories, setCategories] = useState<Category[]>([])
-  const [stocksByProductId, setStocksByProductId] = useState<Record<string, Stock>>({})
   const [selectedParentCategory, setSelectedParentCategory] = useState('all')
   const [selectedChildCategory, setSelectedChildCategory] = useState('all')
   const [search, setSearch] = useState('')
   const [page, setPage] = useState(1)
   const [scannerOpen, setScannerOpen] = useState(false)
-  const [catalogLoading, setCatalogLoading] = useState(true)
-  const [catalogError, setCatalogError] = useState<string | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
-
-  useEffect(() => {
-    let cancelled = false
-
-    async function loadCatalog() {
-      setCatalogLoading(true)
-      setCatalogError(null)
-
-      try {
-        const [loadedCategories, loadedProducts, loadedStocks] = await Promise.all([
-          api.get('/api/categories', z.array(CategorySchema)),
-          fetchAllPages<Product>('/api/products', PaginatedProductsSchema, {
-            activeOnly: true,
-            pageSize: CATALOG_FETCH_PAGE_SIZE,
-          }),
-          storeId
-            ? fetchAllPages<Stock>('/api/inventory/stocks', PaginatedStocksSchema, {
-                storeId,
-                pageSize: CATALOG_FETCH_PAGE_SIZE,
-              })
-            : Promise.resolve([]),
-        ])
-
-        if (cancelled) return
-
-        setCategories(sortCategories(loadedCategories))
-        setProducts(sortProducts(loadedProducts))
-        setStocksByProductId(indexStocksByProductId(loadedStocks))
-      } catch (error) {
-        if (cancelled) return
-        setCatalogError(getErrorMessage(error))
-      } finally {
-        if (!cancelled) {
-          setCatalogLoading(false)
-        }
-      }
-    }
-
-    void loadCatalog()
-
-    return () => {
-      cancelled = true
-    }
-  }, [reloadKey, storeId])
+  const {
+    products,
+    categories,
+    stocksByProductId,
+    loading: catalogLoading,
+    error: catalogError,
+  } = useProductCatalog(storeId, reloadKey)
 
   useEffect(() => {
     if (
@@ -260,157 +215,18 @@ export function ProductsPage() {
         )}
       </div>
 
-      {catalogLoading ? (
-        <div
-          data-testid="product-grid"
-          className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
-        >
-          {Array.from({ length: 12 }).map((_, index) => (
-            <Card key={index} className="space-y-3 p-3">
-              <div className="aspect-square animate-pulse rounded-md bg-muted" />
-              <div className="space-y-2">
-                <div className="h-4 animate-pulse rounded bg-muted" />
-                <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
-              </div>
-            </Card>
-          ))}
-        </div>
-      ) : catalogError ? (
-        <Card className="flex min-h-[240px] flex-col items-center justify-center gap-3 p-6 text-center">
-          <p className="text-lg font-semibold">商品カタログを読み込めませんでした</p>
-          <p className="max-w-md text-sm text-muted-foreground">{catalogError}</p>
-          <Button
-            onClick={() => setReloadKey((value) => value + 1)}
-            aria-label={t('accessibility.retryAction')}
-          >
-            <RefreshCw className="h-4 w-4" aria-hidden="true" />
-            再試行
-          </Button>
-        </Card>
-      ) : pagedProducts.length === 0 ? (
-        <div className="flex min-h-[320px] flex-1 items-center justify-center text-muted-foreground">
-          商品が見つかりません
-        </div>
-      ) : (
-        <div
-          data-testid="product-grid"
-          className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
-        >
-          {pagedProducts.map((product) => {
-            const category = product.categoryId ? categoryById[product.categoryId] : undefined
-            const stock = stocksByProductId[product.id]
-            const isSoldOut = stock ? stock.quantity <= 0 : false
-            const isLowStock = stock
-              ? stock.quantity > 0 && stock.quantity <= stock.lowStockThreshold
-              : false
-
-            return (
-              <Card
-                key={product.id}
-                data-testid={`product-card-${product.id}`}
-                className={`min-h-11 min-w-11 overflow-hidden p-3 transition-colors ${
-                  isSoldOut
-                    ? 'cursor-not-allowed border-dashed opacity-55'
-                    : 'cursor-pointer hover:border-primary/60 hover:bg-accent'
-                }`}
-                role="button"
-                tabIndex={0}
-                aria-disabled={isSoldOut}
-                aria-label={
-                  isSoldOut
-                    ? t('accessibility.addToCartSoldOut', {
-                        name: product.name,
-                        price: formatMoney(product.price),
-                      })
-                    : t('accessibility.addToCart', {
-                        name: product.name,
-                        price: formatMoney(product.price),
-                      })
-                }
-                onClick={() => handleAddToCart(product, stock)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    handleAddToCart(product, stock)
-                  }
-                }}
-              >
-                <div
-                  className="mb-3 h-1.5 rounded-full bg-muted"
-                  style={category?.color ? { backgroundColor: category.color } : undefined}
-                />
-                {product.imageUrl ? (
-                  <div className="mb-3 aspect-square overflow-hidden rounded-md bg-muted">
-                    <img
-                      src={product.imageUrl}
-                      alt={product.name}
-                      className="h-full w-full object-cover"
-                    />
-                  </div>
-                ) : (
-                  <div className="mb-3 flex aspect-square items-center justify-center rounded-md bg-muted text-3xl font-semibold text-muted-foreground">
-                    {product.name.charAt(0)}
-                  </div>
-                )}
-                <div className="space-y-2">
-                  <div className="flex flex-wrap items-start justify-between gap-2">
-                    <p className="line-clamp-2 text-sm font-medium leading-tight">{product.name}</p>
-                    {isSoldOut ? (
-                      <Badge variant="destructive" className="shrink-0">
-                        在庫切れ
-                      </Badge>
-                    ) : isLowStock ? (
-                      <Badge variant="secondary" className="shrink-0">
-                        残り {stock?.quantity ?? 0}
-                      </Badge>
-                    ) : null}
-                  </div>
-                  {category && (
-                    <Badge variant="outline" className="w-fit">
-                      {category.name}
-                    </Badge>
-                  )}
-                  <p className="text-sm font-bold text-primary">{formatMoney(product.price)}</p>
-                  {product.barcode && (
-                    <Badge variant="outline" className="max-w-full text-[10px]">
-                      {product.barcode}
-                    </Badge>
-                  )}
-                </div>
-              </Card>
-            )
-          })}
-        </div>
-      )}
-
-      {totalPages > 1 && (
-        <nav
-          className="flex items-center justify-center gap-2"
-          aria-label={t('accessibility.pageInfo', { current: currentPage, total: totalPages })}
-        >
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={currentPage <= 1}
-            onClick={() => setPage((value) => value - 1)}
-            aria-label={t('accessibility.previousPage')}
-          >
-            前へ
-          </Button>
-          <span className="text-sm text-muted-foreground" aria-current="page">
-            {currentPage} / {totalPages}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={currentPage >= totalPages}
-            onClick={() => setPage((value) => value + 1)}
-            aria-label={t('accessibility.nextPage')}
-          >
-            次へ
-          </Button>
-        </nav>
-      )}
+      <ProductGrid
+        loading={catalogLoading}
+        error={catalogError}
+        products={pagedProducts}
+        categoryById={categoryById}
+        stocksByProductId={stocksByProductId}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onRetry={() => setReloadKey((value) => value + 1)}
+        onAddToCart={handleAddToCart}
+        onPageChange={setPage}
+      />
 
       <BarcodeScannerDialog
         open={scannerOpen}
@@ -425,303 +241,5 @@ export function ProductsPage() {
         onSubmit={handleOpenPriceSubmit}
       />
     </div>
-  )
-}
-
-function BarcodeScannerDialog({
-  open,
-  onOpenChange,
-  onScanned,
-}: {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  onScanned: (barcode: string) => void
-}) {
-  const scannerRef = useRef<Html5Qrcode | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [manualBarcode, setManualBarcode] = useState('')
-
-  useEffect(() => {
-    if (!open) return
-
-    const scannerId = 'barcode-scanner'
-    let scanner: Html5Qrcode | null = null
-
-    const startScanner = async () => {
-      try {
-        scanner = new Html5Qrcode(scannerId)
-        scannerRef.current = scanner
-        await scanner.start(
-          { facingMode: 'environment' },
-          { fps: 10, qrbox: { width: 250, height: 150 } },
-          (decodedText) => {
-            onScanned(decodedText)
-          },
-          () => {
-            // scan failure — ignore (continuous scanning)
-          },
-        )
-      } catch {
-        setError('カメラにアクセスできません。手動でバーコードを入力してください。')
-      }
-    }
-
-    const timer = setTimeout(startScanner, 100)
-
-    return () => {
-      clearTimeout(timer)
-      if (scanner?.isScanning) {
-        scanner.stop().catch(() => {})
-      }
-      scannerRef.current = null
-      setError(null)
-    }
-  }, [open, onScanned])
-
-  function handleManualSubmit(event: React.FormEvent) {
-    event.preventDefault()
-    if (manualBarcode.trim()) {
-      onScanned(manualBarcode.trim())
-      setManualBarcode('')
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>バーコードスキャン</DialogTitle>
-        </DialogHeader>
-        <div className="flex flex-col gap-4">
-          {error ? (
-            <p className="text-sm text-destructive">{error}</p>
-          ) : (
-            <div id="barcode-scanner" className="w-full overflow-hidden rounded-md" />
-          )}
-
-          <form onSubmit={handleManualSubmit} className="flex items-end gap-2">
-            <label htmlFor="manual-barcode-input" className="sr-only">
-              {t('products.barcodeManual')}
-            </label>
-            <Input
-              id="manual-barcode-input"
-              placeholder="バーコードを手入力..."
-              value={manualBarcode}
-              onChange={(e) => setManualBarcode(e.target.value)}
-              className="flex-1"
-            />
-            <Button type="submit" variant="outline">
-              検索
-            </Button>
-          </form>
-        </div>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-async function fetchAllPages<T>(
-  path: string,
-  schema: z.ZodType<PaginatedResponse<T>>,
-  params: Record<string, string | number | boolean>,
-): Promise<T[]> {
-  const items: T[] = []
-  let nextPage = 1
-  let totalPages = 1
-
-  while (nextPage <= totalPages) {
-    const response = await api.get(path, schema, {
-      params: {
-        ...params,
-        page: nextPage,
-      },
-    })
-
-    items.push(...response.data)
-    totalPages = response.pagination.totalPages
-    nextPage += 1
-  }
-
-  return items
-}
-
-function filterProducts(
-  products: Product[],
-  categories: Category[],
-  selectedParentCategory: string,
-  selectedChildCategory: string,
-  search: string,
-): Product[] {
-  const categoryIds = getSelectedCategoryIds(
-    categories,
-    selectedParentCategory,
-    selectedChildCategory,
-  )
-  const normalizedSearch = search.trim().toLowerCase()
-
-  return sortProducts(
-    products.filter((product) => {
-      if (categoryIds && (!product.categoryId || !categoryIds.has(product.categoryId))) {
-        return false
-      }
-
-      if (!normalizedSearch) {
-        return true
-      }
-
-      return [product.name, product.barcode ?? '', product.sku ?? ''].some((value) =>
-        value.toLowerCase().includes(normalizedSearch),
-      )
-    }),
-  )
-}
-
-function getSelectedCategoryIds(
-  categories: Category[],
-  selectedParentCategory: string,
-  selectedChildCategory: string,
-): Set<string> | null {
-  if (selectedChildCategory !== 'all') {
-    return new Set([selectedChildCategory])
-  }
-
-  if (selectedParentCategory === 'all') {
-    return null
-  }
-
-  return collectDescendantCategoryIds(categories, selectedParentCategory)
-}
-
-function collectDescendantCategoryIds(categories: Category[], rootId: string): Set<string> {
-  const ids = new Set<string>([rootId])
-  const queue = [rootId]
-
-  while (queue.length > 0) {
-    const currentId = queue.shift()
-    if (!currentId) continue
-
-    for (const category of categories) {
-      if (category.parentId === currentId && !ids.has(category.id)) {
-        ids.add(category.id)
-        queue.push(category.id)
-      }
-    }
-  }
-
-  return ids
-}
-
-function getTopLevelCategories(categories: Category[]): Category[] {
-  return categories.filter((category) => category.parentId === null)
-}
-
-function getChildCategories(categories: Category[], parentId: string): Category[] {
-  if (parentId === 'all') {
-    return []
-  }
-
-  return categories.filter((category) => category.parentId === parentId)
-}
-
-function indexCategoriesById(categories: Category[]): Record<string, Category> {
-  return categories.reduce<Record<string, Category>>((result, category) => {
-    result[category.id] = category
-    return result
-  }, {})
-}
-
-function indexStocksByProductId(stocks: Stock[]): Record<string, Stock> {
-  return stocks.reduce<Record<string, Stock>>((result, stock) => {
-    result[stock.productId] = stock
-    return result
-  }, {})
-}
-
-function sortCategories(categories: Category[]): Category[] {
-  return [...categories].sort((left, right) => {
-    if (left.displayOrder !== right.displayOrder) {
-      return left.displayOrder - right.displayOrder
-    }
-    return left.name.localeCompare(right.name, 'ja')
-  })
-}
-
-function sortProducts(products: Product[]): Product[] {
-  return [...products].sort((left, right) => {
-    if (left.displayOrder !== right.displayOrder) {
-      return left.displayOrder - right.displayOrder
-    }
-    return left.name.localeCompare(right.name, 'ja')
-  })
-}
-
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) {
-    return error.message
-  }
-  return 'ネットワークまたは API の状態を確認してください。'
-}
-
-function OpenPriceDialog({
-  open,
-  onOpenChange,
-  productName,
-  onSubmit,
-}: {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  productName: string
-  onSubmit: (priceInSen: number) => void
-}) {
-  const [priceInput, setPriceInput] = useState('')
-
-  useEffect(() => {
-    if (open) {
-      setPriceInput('')
-    }
-  }, [open])
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    const yen = Number(priceInput)
-    if (!Number.isFinite(yen) || yen <= 0) return
-    onSubmit(Math.round(yen * 100))
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>価格入力 — {productName}</DialogTitle>
-        </DialogHeader>
-        <p className="text-sm text-muted-foreground">
-          オープンプライス商品です。販売価格を入力してください。
-        </p>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <label htmlFor="open-price-input" className="text-sm font-medium">
-              {t('accessibility.openPriceLabelYen')}
-            </label>
-            <Input
-              id="open-price-input"
-              type="number"
-              min="1"
-              step="1"
-              placeholder="0"
-              value={priceInput}
-              onChange={(e) => setPriceInput(e.target.value)}
-              autoFocus
-              required
-            />
-          </div>
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              キャンセル
-            </Button>
-            <Button type="submit">カートに追加</Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
   )
 }

--- a/apps/pos-terminal/src/routes/products/barcode-scanner-dialog.tsx
+++ b/apps/pos-terminal/src/routes/products/barcode-scanner-dialog.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react'
+import { Html5Qrcode } from 'html5-qrcode'
+import { t } from '@/i18n'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+
+interface BarcodeScannerDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onScanned: (barcode: string) => void
+}
+
+export function BarcodeScannerDialog({ open, onOpenChange, onScanned }: BarcodeScannerDialogProps) {
+  const scannerRef = useRef<Html5Qrcode | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [manualBarcode, setManualBarcode] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+
+    const scannerId = 'barcode-scanner'
+    let scanner: Html5Qrcode | null = null
+
+    const startScanner = async () => {
+      try {
+        scanner = new Html5Qrcode(scannerId)
+        scannerRef.current = scanner
+        await scanner.start(
+          { facingMode: 'environment' },
+          { fps: 10, qrbox: { width: 250, height: 150 } },
+          (decodedText) => {
+            onScanned(decodedText)
+          },
+          () => {
+            // scan failure — ignore (continuous scanning)
+          },
+        )
+      } catch {
+        setError('カメラにアクセスできません。手動でバーコードを入力してください。')
+      }
+    }
+
+    const timer = setTimeout(startScanner, 100)
+
+    return () => {
+      clearTimeout(timer)
+      if (scanner?.isScanning) {
+        scanner.stop().catch(() => {})
+      }
+      scannerRef.current = null
+      setError(null)
+    }
+  }, [open, onScanned])
+
+  function handleManualSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (manualBarcode.trim()) {
+      onScanned(manualBarcode.trim())
+      setManualBarcode('')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>バーコードスキャン</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          {error ? (
+            <p className="text-sm text-destructive">{error}</p>
+          ) : (
+            <div id="barcode-scanner" className="w-full overflow-hidden rounded-md" />
+          )}
+
+          <form onSubmit={handleManualSubmit} className="flex items-end gap-2">
+            <label htmlFor="manual-barcode-input" className="sr-only">
+              {t('products.barcodeManual')}
+            </label>
+            <Input
+              id="manual-barcode-input"
+              placeholder="バーコードを手入力..."
+              value={manualBarcode}
+              onChange={(event) => setManualBarcode(event.target.value)}
+              className="flex-1"
+            />
+            <Button type="submit" variant="outline">
+              検索
+            </Button>
+          </form>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/pos-terminal/src/routes/products/catalog.ts
+++ b/apps/pos-terminal/src/routes/products/catalog.ts
@@ -1,0 +1,180 @@
+import { z } from 'zod'
+import { api } from '@/lib/api'
+import {
+  CategorySchema,
+  PaginatedProductsSchema,
+  PaginatedStocksSchema,
+} from '@shared-types/openpos'
+import type { Category, PaginatedResponse, Product, Stock } from '@shared-types/openpos'
+
+const CATALOG_FETCH_PAGE_SIZE = 100
+
+export interface ProductCatalog {
+  products: Product[]
+  categories: Category[]
+  stocksByProductId: Record<string, Stock>
+}
+
+export async function loadProductCatalog(storeId: string | null): Promise<ProductCatalog> {
+  const [categories, products, stocks] = await Promise.all([
+    api.get('/api/categories', z.array(CategorySchema)),
+    fetchAllPages<Product>('/api/products', PaginatedProductsSchema, {
+      activeOnly: true,
+      pageSize: CATALOG_FETCH_PAGE_SIZE,
+    }),
+    storeId
+      ? fetchAllPages<Stock>('/api/inventory/stocks', PaginatedStocksSchema, {
+          storeId,
+          pageSize: CATALOG_FETCH_PAGE_SIZE,
+        })
+      : Promise.resolve([]),
+  ])
+
+  return {
+    categories: sortCategories(categories),
+    products: sortProducts(products),
+    stocksByProductId: indexStocksByProductId(stocks),
+  }
+}
+
+async function fetchAllPages<T>(
+  path: string,
+  schema: z.ZodType<PaginatedResponse<T>>,
+  params: Record<string, string | number | boolean>,
+): Promise<T[]> {
+  const items: T[] = []
+  let nextPage = 1
+  let totalPages = 1
+
+  while (nextPage <= totalPages) {
+    const response = await api.get(path, schema, {
+      params: {
+        ...params,
+        page: nextPage,
+      },
+    })
+
+    items.push(...response.data)
+    totalPages = response.pagination.totalPages
+    nextPage += 1
+  }
+
+  return items
+}
+
+export function filterProducts(
+  products: Product[],
+  categories: Category[],
+  selectedParentCategory: string,
+  selectedChildCategory: string,
+  search: string,
+): Product[] {
+  const categoryIds = getSelectedCategoryIds(
+    categories,
+    selectedParentCategory,
+    selectedChildCategory,
+  )
+  const normalizedSearch = search.trim().toLowerCase()
+
+  return sortProducts(
+    products.filter((product) => {
+      if (categoryIds && (!product.categoryId || !categoryIds.has(product.categoryId))) {
+        return false
+      }
+
+      if (!normalizedSearch) {
+        return true
+      }
+
+      return [product.name, product.barcode ?? '', product.sku ?? ''].some((value) =>
+        value.toLowerCase().includes(normalizedSearch),
+      )
+    }),
+  )
+}
+
+function getSelectedCategoryIds(
+  categories: Category[],
+  selectedParentCategory: string,
+  selectedChildCategory: string,
+): Set<string> | null {
+  if (selectedChildCategory !== 'all') {
+    return new Set([selectedChildCategory])
+  }
+
+  if (selectedParentCategory === 'all') {
+    return null
+  }
+
+  return collectDescendantCategoryIds(categories, selectedParentCategory)
+}
+
+function collectDescendantCategoryIds(categories: Category[], rootId: string): Set<string> {
+  const ids = new Set<string>([rootId])
+  const queue = [rootId]
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()
+    if (!currentId) continue
+
+    for (const category of categories) {
+      if (category.parentId === currentId && !ids.has(category.id)) {
+        ids.add(category.id)
+        queue.push(category.id)
+      }
+    }
+  }
+
+  return ids
+}
+
+export function getTopLevelCategories(categories: Category[]): Category[] {
+  return categories.filter((category) => category.parentId === null)
+}
+
+export function getChildCategories(categories: Category[], parentId: string): Category[] {
+  if (parentId === 'all') {
+    return []
+  }
+
+  return categories.filter((category) => category.parentId === parentId)
+}
+
+export function indexCategoriesById(categories: Category[]): Record<string, Category> {
+  return categories.reduce<Record<string, Category>>((result, category) => {
+    result[category.id] = category
+    return result
+  }, {})
+}
+
+function indexStocksByProductId(stocks: Stock[]): Record<string, Stock> {
+  return stocks.reduce<Record<string, Stock>>((result, stock) => {
+    result[stock.productId] = stock
+    return result
+  }, {})
+}
+
+function sortCategories(categories: Category[]): Category[] {
+  return [...categories].sort((left, right) => {
+    if (left.displayOrder !== right.displayOrder) {
+      return left.displayOrder - right.displayOrder
+    }
+    return left.name.localeCompare(right.name, 'ja')
+  })
+}
+
+function sortProducts(products: Product[]): Product[] {
+  return [...products].sort((left, right) => {
+    if (left.displayOrder !== right.displayOrder) {
+      return left.displayOrder - right.displayOrder
+    }
+    return left.name.localeCompare(right.name, 'ja')
+  })
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+  return 'ネットワークまたは API の状態を確認してください。'
+}

--- a/apps/pos-terminal/src/routes/products/open-price-dialog.tsx
+++ b/apps/pos-terminal/src/routes/products/open-price-dialog.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import { t } from '@/i18n'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+
+interface OpenPriceDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  productName: string
+  onSubmit: (priceInSen: number) => void
+}
+
+export function OpenPriceDialog({
+  open,
+  onOpenChange,
+  productName,
+  onSubmit,
+}: OpenPriceDialogProps) {
+  const [priceInput, setPriceInput] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      setPriceInput('')
+    }
+  }, [open])
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    const yen = Number(priceInput)
+    if (!Number.isFinite(yen) || yen <= 0) return
+    onSubmit(Math.round(yen * 100))
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>価格入力 — {productName}</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          オープンプライス商品です。販売価格を入力してください。
+        </p>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="open-price-input" className="text-sm font-medium">
+              {t('accessibility.openPriceLabelYen')}
+            </label>
+            <Input
+              id="open-price-input"
+              type="number"
+              min="1"
+              step="1"
+              placeholder="0"
+              value={priceInput}
+              onChange={(event) => setPriceInput(event.target.value)}
+              autoFocus
+              required
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              キャンセル
+            </Button>
+            <Button type="submit">カートに追加</Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/pos-terminal/src/routes/products/product-grid.tsx
+++ b/apps/pos-terminal/src/routes/products/product-grid.tsx
@@ -1,0 +1,204 @@
+import { RefreshCw } from 'lucide-react'
+import { t } from '@/i18n'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { formatMoney } from '@shared-types/openpos'
+import type { Category, Product, Stock } from '@shared-types/openpos'
+
+interface ProductGridProps {
+  loading: boolean
+  error: string | null
+  products: Product[]
+  categoryById: Record<string, Category>
+  stocksByProductId: Record<string, Stock>
+  currentPage: number
+  totalPages: number
+  onRetry: () => void
+  onAddToCart: (product: Product, stock?: Stock) => void
+  onPageChange: (page: number) => void
+}
+
+export function ProductGrid({
+  loading,
+  error,
+  products,
+  categoryById,
+  stocksByProductId,
+  currentPage,
+  totalPages,
+  onRetry,
+  onAddToCart,
+  onPageChange,
+}: ProductGridProps) {
+  if (loading) {
+    return (
+      <div
+        data-testid="product-grid"
+        className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+      >
+        {Array.from({ length: 12 }).map((_, index) => (
+          <Card key={index} className="space-y-3 p-3">
+            <div className="aspect-square animate-pulse rounded-md bg-muted" />
+            <div className="space-y-2">
+              <div className="h-4 animate-pulse rounded bg-muted" />
+              <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+            </div>
+          </Card>
+        ))}
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card className="flex min-h-[240px] flex-col items-center justify-center gap-3 p-6 text-center">
+        <p className="text-lg font-semibold">商品カタログを読み込めませんでした</p>
+        <p className="max-w-md text-sm text-muted-foreground">{error}</p>
+        <Button onClick={onRetry} aria-label={t('accessibility.retryAction')}>
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          再試行
+        </Button>
+      </Card>
+    )
+  }
+
+  if (products.length === 0) {
+    return (
+      <div className="flex min-h-[320px] flex-1 items-center justify-center text-muted-foreground">
+        商品が見つかりません
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div
+        data-testid="product-grid"
+        className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
+      >
+        {products.map((product) => (
+          <ProductGridCard
+            key={product.id}
+            product={product}
+            category={product.categoryId ? categoryById[product.categoryId] : undefined}
+            stock={stocksByProductId[product.id]}
+            onAddToCart={onAddToCart}
+          />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <nav
+          className="flex items-center justify-center gap-2"
+          aria-label={t('accessibility.pageInfo', { current: currentPage, total: totalPages })}
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={currentPage <= 1}
+            onClick={() => onPageChange(currentPage - 1)}
+            aria-label={t('accessibility.previousPage')}
+          >
+            前へ
+          </Button>
+          <span className="text-sm text-muted-foreground" aria-current="page">
+            {currentPage} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={currentPage >= totalPages}
+            onClick={() => onPageChange(currentPage + 1)}
+            aria-label={t('accessibility.nextPage')}
+          >
+            次へ
+          </Button>
+        </nav>
+      )}
+    </>
+  )
+}
+
+interface ProductGridCardProps {
+  product: Product
+  category?: Category
+  stock?: Stock
+  onAddToCart: (product: Product, stock?: Stock) => void
+}
+
+function ProductGridCard({ product, category, stock, onAddToCart }: ProductGridCardProps) {
+  const isSoldOut = stock ? stock.quantity <= 0 : false
+  const isLowStock = stock ? stock.quantity > 0 && stock.quantity <= stock.lowStockThreshold : false
+
+  return (
+    <Card
+      data-testid={`product-card-${product.id}`}
+      className={`min-h-11 min-w-11 overflow-hidden p-3 transition-colors ${
+        isSoldOut
+          ? 'cursor-not-allowed border-dashed opacity-55'
+          : 'cursor-pointer hover:border-primary/60 hover:bg-accent'
+      }`}
+      role="button"
+      tabIndex={0}
+      aria-disabled={isSoldOut}
+      aria-label={
+        isSoldOut
+          ? t('accessibility.addToCartSoldOut', {
+              name: product.name,
+              price: formatMoney(product.price),
+            })
+          : t('accessibility.addToCart', {
+              name: product.name,
+              price: formatMoney(product.price),
+            })
+      }
+      onClick={() => onAddToCart(product, stock)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onAddToCart(product, stock)
+        }
+      }}
+    >
+      <div
+        className="mb-3 h-1.5 rounded-full bg-muted"
+        style={category?.color ? { backgroundColor: category.color } : undefined}
+      />
+      {product.imageUrl ? (
+        <div className="mb-3 aspect-square overflow-hidden rounded-md bg-muted">
+          <img src={product.imageUrl} alt={product.name} className="h-full w-full object-cover" />
+        </div>
+      ) : (
+        <div className="mb-3 flex aspect-square items-center justify-center rounded-md bg-muted text-3xl font-semibold text-muted-foreground">
+          {product.name.charAt(0)}
+        </div>
+      )}
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <p className="line-clamp-2 text-sm font-medium leading-tight">{product.name}</p>
+          {isSoldOut ? (
+            <Badge variant="destructive" className="shrink-0">
+              在庫切れ
+            </Badge>
+          ) : isLowStock ? (
+            <Badge variant="secondary" className="shrink-0">
+              残り {stock?.quantity ?? 0}
+            </Badge>
+          ) : null}
+        </div>
+        {category && (
+          <Badge variant="outline" className="w-fit">
+            {category.name}
+          </Badge>
+        )}
+        <p className="text-sm font-bold text-primary">{formatMoney(product.price)}</p>
+        {product.barcode && (
+          <Badge variant="outline" className="max-w-full text-[10px]">
+            {product.barcode}
+          </Badge>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/apps/pos-terminal/src/routes/products/use-product-catalog.ts
+++ b/apps/pos-terminal/src/routes/products/use-product-catalog.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import type { Category, Product, Stock } from '@shared-types/openpos'
+import { getErrorMessage, loadProductCatalog } from './catalog'
+
+interface ProductCatalogState {
+  products: Product[]
+  categories: Category[]
+  stocksByProductId: Record<string, Stock>
+  loading: boolean
+  error: string | null
+}
+
+const INITIAL_STATE: ProductCatalogState = {
+  products: [],
+  categories: [],
+  stocksByProductId: {},
+  loading: true,
+  error: null,
+}
+
+export function useProductCatalog(storeId: string | null, reloadKey: number): ProductCatalogState {
+  const [state, setState] = useState<ProductCatalogState>(INITIAL_STATE)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function fetchCatalog() {
+      setState((current) => ({
+        ...current,
+        loading: true,
+        error: null,
+      }))
+
+      try {
+        const catalog = await loadProductCatalog(storeId)
+        if (cancelled) return
+
+        setState({
+          ...catalog,
+          loading: false,
+          error: null,
+        })
+      } catch (error) {
+        if (cancelled) return
+
+        setState((current) => ({
+          ...current,
+          loading: false,
+          error: getErrorMessage(error),
+        }))
+      }
+    }
+
+    void fetchCatalog()
+
+    return () => {
+      cancelled = true
+    }
+  }, [reloadKey, storeId])
+
+  return state
+}


### PR DESCRIPTION
## Summary
- split the large POS product catalog route into route-local modules
- extract catalog loading/filter helpers and the two dialogs from the page component
- keep ProductsPage behavior stable while reducing the main route file size

## Validation
- pnpm --filter pos-terminal exec vitest run src/routes/products.test.tsx
- pnpm --filter pos-terminal lint
- pnpm --filter pos-terminal typecheck
- pnpm --filter pos-terminal test
- pnpm --filter pos-terminal build