### PR TITLE
[codex] extract grpc receipt formatters

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -367,7 +367,10 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
                     payments = payments,
                     idempotencyKey = idempotencyKey,
                 )
-            val receipt = buildReceipt(entity)
+            val items = transactionService.getTransactionItems(entity.id)
+            val persistedPayments = transactionService.getTransactionPayments(entity.id)
+            val taxSummaries = transactionService.getTransactionTaxSummaries(entity.id)
+            val receipt = buildReceiptProto(entity, items, persistedPayments, taxSummaries)
             responseObserver.onNext(
                 FinalizeTransactionResponse
                     .newBuilder()
@@ -507,11 +510,14 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             require(tx.status == "COMPLETED" || tx.status == "VOIDED") {
                 "Receipt is only available for COMPLETED or VOIDED transactions"
             }
+            val items = transactionService.getTransactionItems(tx.id)
+            val payments = transactionService.getTransactionPayments(tx.id)
+            val taxSummaries = transactionService.getTransactionTaxSummaries(tx.id)
 
             responseObserver.onNext(
                 GetReceiptResponse
                     .newBuilder()
-                    .setReceipt(buildReceipt(tx))
+                    .setReceipt(buildReceiptProto(tx, items, payments, taxSummaries))
                     .build(),
             )
             responseObserver.onCompleted()
@@ -580,8 +586,13 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             val items = transactionService.getTransactionItems(tx.id)
             val payments = transactionService.getTransactionPayments(tx.id)
             val taxSummaries = transactionService.getTransactionTaxSummaries(tx.id)
+            val invoiceNumber =
+                storeServiceClient.getInvoiceNumber(tx.organizationId)
+                    ?: throw IllegalArgumentException(
+                        "Invoice registration number is not configured for organization: ${tx.organizationId}",
+                    )
 
-            val receiptData = buildInvoiceReceiptData(tx, items, payments, taxSummaries)
+            val receiptData = buildInvoiceReceiptData(tx, items, payments, taxSummaries, invoiceNumber)
             responseObserver.onNext(
                 GetInvoiceReceiptResponse
                     .newBuilder()
@@ -818,60 +829,6 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             .setUpdatedAt(updatedAt.toString())
             .build()
 
-    private fun buildInvoiceReceiptData(
-        tx: TransactionEntity,
-        items: List<TransactionItemEntity>,
-        payments: List<PaymentEntity>,
-        taxSummaries: List<TaxSummaryEntity>,
-    ): String {
-        // 組織のインボイス登録番号を store-service から取得
-        val invoiceNumber =
-            storeServiceClient.getInvoiceNumber(tx.organizationId)
-                ?: throw IllegalArgumentException(
-                    "Invoice registration number is not configured for organization: ${tx.organizationId}",
-                )
-
-        val sb = StringBuilder()
-        sb.appendLine("================================")
-        sb.appendLine("        領 収 書")
-        sb.appendLine("  （適格簡易請求書）")
-        sb.appendLine("================================")
-        sb.appendLine("取引番号: ${tx.transactionNumber}")
-        sb.appendLine("日時: ${tx.completedAt}")
-        sb.appendLine("登録番号: $invoiceNumber")
-        sb.appendLine("--------------------------------")
-        for (item in items) {
-            val reducedMark = if (item.isReducedTax) " ※" else ""
-            sb.appendLine("${item.productName}$reducedMark")
-            sb.appendLine("  ${item.unitPrice / 100}円 x ${item.quantity}  ${item.total / 100}円")
-        }
-        sb.appendLine("--------------------------------")
-        sb.appendLine("小計:     ${tx.subtotal / 100}円")
-        sb.appendLine("消費税:   ${tx.taxTotal / 100}円")
-        if (tx.discountTotal > 0) {
-            sb.appendLine("割引:    -${tx.discountTotal / 100}円")
-        }
-        sb.appendLine("合計:     ${tx.total / 100}円")
-        sb.appendLine("--------------------------------")
-        for (payment in payments) {
-            sb.appendLine("${payment.method}: ${payment.amount / 100}円")
-        }
-        sb.appendLine("--------------------------------")
-        sb.appendLine("【税率別内訳（税込）】")
-        for (summary in taxSummaries) {
-            val reducedMark = if (summary.isReduced) "※" else ""
-            sb.appendLine("$reducedMark${summary.taxRateName}")
-            sb.appendLine("  対象: ${summary.taxableAmount / 100}円  税: ${summary.taxAmount / 100}円")
-        }
-        if (taxSummaries.any { it.isReduced }) {
-            sb.appendLine("※は軽減税率(8%)対象商品")
-        }
-        sb.appendLine("================================")
-        sb.appendLine("上記正に領収いたしました")
-        sb.appendLine("================================")
-        return sb.toString()
-    }
-
     private fun JournalEntryEntity.toProto(): JournalEntry =
         JournalEntry
             .newBuilder()
@@ -884,22 +841,6 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             .setDetails(details)
             .setCreatedAt(createdAt.toString())
             .build()
-
-    private fun buildReceipt(tx: TransactionEntity): Receipt {
-        val items = transactionService.getTransactionItems(tx.id)
-        val payments = transactionService.getTransactionPayments(tx.id)
-        val taxSummaries = transactionService.getTransactionTaxSummaries(tx.id)
-
-        val receiptData = buildReceiptData(tx, items, payments, taxSummaries)
-
-        return Receipt
-            .newBuilder()
-            .setId(UUID.randomUUID().toString())
-            .setTransactionId(tx.id.toString())
-            .setReceiptData(receiptData)
-            .setCreatedAt(Instant.now().toString())
-            .build()
-    }
 
     // === Mapper Extensions ===
 
@@ -1057,52 +998,6 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             PaymentMethod.PAYMENT_METHOD_QR_CODE -> "QR_CODE"
             else -> throw Status.INVALID_ARGUMENT.withDescription("payment method is required").asRuntimeException()
         }
-
-    private fun buildReceiptData(
-        tx: TransactionEntity,
-        items: List<TransactionItemEntity>,
-        payments: List<PaymentEntity>,
-        taxSummaries: List<TaxSummaryEntity>,
-    ): String {
-        val sb = StringBuilder()
-        sb.appendLine("================================")
-        sb.appendLine("        領 収 書")
-        sb.appendLine("================================")
-        sb.appendLine("取引番号: ${tx.transactionNumber}")
-        sb.appendLine("日時: ${tx.completedAt}")
-        sb.appendLine("--------------------------------")
-        for (item in items) {
-            val reducedMark = if (item.isReducedTax) " ※" else ""
-            sb.appendLine("${item.productName}$reducedMark")
-            sb.appendLine("  ${item.unitPrice / 100}円 x ${item.quantity}  ${item.total / 100}円")
-        }
-        sb.appendLine("--------------------------------")
-        sb.appendLine("小計:     ${tx.subtotal / 100}円")
-        sb.appendLine("消費税:   ${tx.taxTotal / 100}円")
-        if (tx.discountTotal > 0) {
-            sb.appendLine("割引:    -${tx.discountTotal / 100}円")
-        }
-        sb.appendLine("合計:     ${tx.total / 100}円")
-        sb.appendLine("--------------------------------")
-        for (payment in payments) {
-            sb.appendLine("${payment.method}: ${payment.amount / 100}円")
-            val changeVal = payment.change ?: 0
-            if (payment.method == "CASH" && changeVal > 0) {
-                sb.appendLine("お釣り: ${changeVal / 100}円")
-            }
-        }
-        sb.appendLine("--------------------------------")
-        sb.appendLine("【税率別内訳】")
-        for (summary in taxSummaries) {
-            val reducedMark = if (summary.isReduced) "※" else ""
-            sb.appendLine("$reducedMark${summary.taxRateName}: 対象${summary.taxableAmount / 100}円 税${summary.taxAmount / 100}円")
-        }
-        if (taxSummaries.any { it.isReduced }) {
-            sb.appendLine("※は軽減税率対象商品")
-        }
-        sb.appendLine("================================")
-        return sb.toString()
-    }
 
     // === GiftCard ===
 

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ReceiptFormatting.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ReceiptFormatting.kt
@@ -1,0 +1,119 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.PaymentEntity
+import com.openpos.pos.entity.TaxSummaryEntity
+import com.openpos.pos.entity.TransactionEntity
+import com.openpos.pos.entity.TransactionItemEntity
+import openpos.pos.v1.Receipt
+import java.time.Instant
+import java.util.UUID
+
+internal fun buildReceiptProto(
+    tx: TransactionEntity,
+    items: List<TransactionItemEntity>,
+    payments: List<PaymentEntity>,
+    taxSummaries: List<TaxSummaryEntity>,
+    now: Instant = Instant.now(),
+    receiptId: String = UUID.randomUUID().toString(),
+): Receipt =
+    Receipt
+        .newBuilder()
+        .setId(receiptId)
+        .setTransactionId(tx.id.toString())
+        .setReceiptData(buildReceiptData(tx, items, payments, taxSummaries))
+        .setCreatedAt(now.toString())
+        .build()
+
+internal fun buildInvoiceReceiptData(
+    tx: TransactionEntity,
+    items: List<TransactionItemEntity>,
+    payments: List<PaymentEntity>,
+    taxSummaries: List<TaxSummaryEntity>,
+    invoiceNumber: String,
+): String {
+    val sb = StringBuilder()
+    sb.appendLine("================================")
+    sb.appendLine("        領 収 書")
+    sb.appendLine("  （適格簡易請求書）")
+    sb.appendLine("================================")
+    sb.appendLine("取引番号: ${tx.transactionNumber}")
+    sb.appendLine("日時: ${tx.completedAt}")
+    sb.appendLine("登録番号: $invoiceNumber")
+    sb.appendLine("--------------------------------")
+    for (item in items) {
+        val reducedMark = if (item.isReducedTax) " ※" else ""
+        sb.appendLine("${item.productName}$reducedMark")
+        sb.appendLine("  ${item.unitPrice / 100}円 x ${item.quantity}  ${item.total / 100}円")
+    }
+    sb.appendLine("--------------------------------")
+    sb.appendLine("小計:     ${tx.subtotal / 100}円")
+    sb.appendLine("消費税:   ${tx.taxTotal / 100}円")
+    if (tx.discountTotal > 0) {
+        sb.appendLine("割引:    -${tx.discountTotal / 100}円")
+    }
+    sb.appendLine("合計:     ${tx.total / 100}円")
+    sb.appendLine("--------------------------------")
+    for (payment in payments) {
+        sb.appendLine("${payment.method}: ${payment.amount / 100}円")
+    }
+    sb.appendLine("--------------------------------")
+    sb.appendLine("【税率別内訳（税込）】")
+    for (summary in taxSummaries) {
+        val reducedMark = if (summary.isReduced) "※" else ""
+        sb.appendLine("$reducedMark${summary.taxRateName}")
+        sb.appendLine("  対象: ${summary.taxableAmount / 100}円  税: ${summary.taxAmount / 100}円")
+    }
+    if (taxSummaries.any { it.isReduced }) {
+        sb.appendLine("※は軽減税率(8%)対象商品")
+    }
+    sb.appendLine("================================")
+    sb.appendLine("上記正に領収いたしました")
+    sb.appendLine("================================")
+    return sb.toString()
+}
+
+internal fun buildReceiptData(
+    tx: TransactionEntity,
+    items: List<TransactionItemEntity>,
+    payments: List<PaymentEntity>,
+    taxSummaries: List<TaxSummaryEntity>,
+): String {
+    val sb = StringBuilder()
+    sb.appendLine("================================")
+    sb.appendLine("        領 収 書")
+    sb.appendLine("================================")
+    sb.appendLine("取引番号: ${tx.transactionNumber}")
+    sb.appendLine("日時: ${tx.completedAt}")
+    sb.appendLine("--------------------------------")
+    for (item in items) {
+        val reducedMark = if (item.isReducedTax) " ※" else ""
+        sb.appendLine("${item.productName}$reducedMark")
+        sb.appendLine("  ${item.unitPrice / 100}円 x ${item.quantity}  ${item.total / 100}円")
+    }
+    sb.appendLine("--------------------------------")
+    sb.appendLine("小計:     ${tx.subtotal / 100}円")
+    sb.appendLine("消費税:   ${tx.taxTotal / 100}円")
+    if (tx.discountTotal > 0) {
+        sb.appendLine("割引:    -${tx.discountTotal / 100}円")
+    }
+    sb.appendLine("合計:     ${tx.total / 100}円")
+    sb.appendLine("--------------------------------")
+    for (payment in payments) {
+        sb.appendLine("${payment.method}: ${payment.amount / 100}円")
+        val changeVal = payment.change ?: 0
+        if (payment.method == "CASH" && changeVal > 0) {
+            sb.appendLine("お釣り: ${changeVal / 100}円")
+        }
+    }
+    sb.appendLine("--------------------------------")
+    sb.appendLine("【税率別内訳】")
+    for (summary in taxSummaries) {
+        val reducedMark = if (summary.isReduced) "※" else ""
+        sb.appendLine("$reducedMark${summary.taxRateName}: 対象${summary.taxableAmount / 100}円 税${summary.taxAmount / 100}円")
+    }
+    if (taxSummaries.any { it.isReduced }) {
+        sb.appendLine("※は軽減税率対象商品")
+    }
+    sb.appendLine("================================")
+    return sb.toString()
+}

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/ReceiptFormattingTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/ReceiptFormattingTest.kt
@@ -1,0 +1,156 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.PaymentEntity
+import com.openpos.pos.entity.TaxSummaryEntity
+import com.openpos.pos.entity.TransactionEntity
+import com.openpos.pos.entity.TransactionItemEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class ReceiptFormattingTest {
+    private val organizationId = UUID.fromString("00000000-0000-0000-0000-000000000000")
+    private val transactionId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+
+    @Test
+    fun `buildReceiptData includes change and reduced tax note`() {
+        val receiptData = buildReceiptData(transaction(), items(), payments(), taxSummaries())
+
+        assertTrue(receiptData.contains("取引番号: T-2026-000001"))
+        assertTrue(receiptData.contains("お釣り: 50円"))
+        assertTrue(receiptData.contains("※軽減税率8%: 対象150円 税12円"))
+        assertTrue(receiptData.contains("※は軽減税率対象商品"))
+        assertFalse(receiptData.contains("割引:"))
+    }
+
+    @Test
+    fun `buildInvoiceReceiptData includes invoice number and inclusive breakdown`() {
+        val invoiceReceipt =
+            buildInvoiceReceiptData(
+                tx = transaction(discountTotal = 1000, total = 32500),
+                items = items(),
+                payments = payments(),
+                taxSummaries = taxSummaries(),
+                invoiceNumber = "T1234567890123",
+            )
+
+        assertTrue(invoiceReceipt.contains("（適格簡易請求書）"))
+        assertTrue(invoiceReceipt.contains("登録番号: T1234567890123"))
+        assertTrue(invoiceReceipt.contains("割引:    -10円"))
+        assertTrue(invoiceReceipt.contains("【税率別内訳（税込）】"))
+        assertTrue(invoiceReceipt.contains("※は軽減税率(8%)対象商品"))
+        assertTrue(invoiceReceipt.contains("上記正に領収いたしました"))
+    }
+
+    @Test
+    fun `buildReceiptProto populates receipt metadata and data`() {
+        val createdAt = Instant.parse("2026-05-07T00:45:00Z")
+        val receipt =
+            buildReceiptProto(
+                tx = transaction(),
+                items = items(),
+                payments = payments(),
+                taxSummaries = taxSummaries(),
+                now = createdAt,
+                receiptId = "receipt-123",
+            )
+
+        assertEquals("receipt-123", receipt.id)
+        assertEquals(transactionId.toString(), receipt.transactionId)
+        assertEquals(createdAt.toString(), receipt.createdAt)
+        assertTrue(receipt.receiptData.contains("テスト商品A"))
+    }
+
+    private fun transaction(
+        discountTotal: Long = 0,
+        total: Long = 33500,
+    ): TransactionEntity =
+        TransactionEntity().apply {
+            id = transactionId
+            organizationId = this@ReceiptFormattingTest.organizationId
+            storeId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+            terminalId = UUID.fromString("33333333-3333-3333-3333-333333333333")
+            staffId = UUID.fromString("44444444-4444-4444-4444-444444444444")
+            transactionNumber = "T-2026-000001"
+            status = "COMPLETED"
+            subtotal = 30000
+            taxTotal = 3500
+            this.discountTotal = discountTotal
+            this.total = total
+            completedAt = Instant.parse("2026-05-07T00:30:00Z")
+            createdAt = Instant.parse("2026-05-07T00:20:00Z")
+            updatedAt = Instant.parse("2026-05-07T00:30:00Z")
+        }
+
+    private fun items(): List<TransactionItemEntity> =
+        listOf(
+            TransactionItemEntity().apply {
+                id = UUID.fromString("55555555-5555-5555-5555-555555555555")
+                organizationId = this@ReceiptFormattingTest.organizationId
+                transactionId = this@ReceiptFormattingTest.transactionId
+                productId = UUID.fromString("66666666-6666-6666-6666-666666666666")
+                productName = "テスト商品A"
+                unitPrice = 15000
+                quantity = 1
+                taxRateName = "標準税率10%"
+                taxRate = "0.10"
+                subtotal = 15000
+                taxAmount = 1500
+                total = 16500
+            },
+            TransactionItemEntity().apply {
+                id = UUID.fromString("77777777-7777-7777-7777-777777777777")
+                organizationId = this@ReceiptFormattingTest.organizationId
+                transactionId = this@ReceiptFormattingTest.transactionId
+                productId = UUID.fromString("88888888-8888-8888-8888-888888888888")
+                productName = "軽減商品B"
+                unitPrice = 15000
+                quantity = 1
+                taxRateName = "軽減税率8%"
+                taxRate = "0.08"
+                isReducedTax = true
+                subtotal = 15000
+                taxAmount = 1200
+                total = 16200
+            },
+        )
+
+    private fun payments(): List<PaymentEntity> =
+        listOf(
+            PaymentEntity().apply {
+                id = UUID.fromString("99999999-9999-9999-9999-999999999999")
+                organizationId = this@ReceiptFormattingTest.organizationId
+                transactionId = this@ReceiptFormattingTest.transactionId
+                method = "CASH"
+                amount = 33500
+                received = 38500
+                change = 5000
+            },
+        )
+
+    private fun taxSummaries(): List<TaxSummaryEntity> =
+        listOf(
+            TaxSummaryEntity().apply {
+                id = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                organizationId = this@ReceiptFormattingTest.organizationId
+                transactionId = this@ReceiptFormattingTest.transactionId
+                taxRateName = "標準税率10%"
+                taxRate = "0.10"
+                taxableAmount = 15000
+                taxAmount = 1500
+            },
+            TaxSummaryEntity().apply {
+                id = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+                organizationId = this@ReceiptFormattingTest.organizationId
+                transactionId = this@ReceiptFormattingTest.transactionId
+                taxRateName = "軽減税率8%"
+                taxRate = "0.08"
+                isReduced = true
+                taxableAmount = 15000
+                taxAmount = 1200
+            },
+        )
+}


### PR DESCRIPTION
## Summary
- move POS receipt and invoice receipt formatting into a dedicated grpc receipt helper
- keep PosGrpcService focused on relation loading, invoice-number lookup, and gRPC response wiring
- add unit tests for receipt rendering and Receipt proto generation

## Validation
- ./gradlew --no-daemon -Dkotlin.incremental=false :services:pos-service:test --tests "com.openpos.pos.grpc.ReceiptFormattingTest"

## Notes
- the Gradle run still emits the existing Quarkus warning about unused gRPC interceptors, but the test suite and main compilation pass.
