### PR TITLE
[codex] extract grpc helper mappings and discount resolution

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/AuxiliaryProtoMapping.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/AuxiliaryProtoMapping.kt
@@ -1,0 +1,131 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.DiscountReasonEntity
+import com.openpos.pos.entity.DrawerEntity
+import com.openpos.pos.entity.GiftCardEntity
+import com.openpos.pos.entity.JournalEntryEntity
+import com.openpos.pos.entity.ReservationEntity
+import com.openpos.pos.entity.SettlementEntity
+import openpos.pos.v1.DiscountReason
+import openpos.pos.v1.Drawer
+import openpos.pos.v1.GiftCard
+import openpos.pos.v1.JournalEntry
+import openpos.pos.v1.Reservation
+import openpos.pos.v1.Settlement
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+internal fun DrawerEntity.toProto(): Drawer =
+    Drawer
+        .newBuilder()
+        .setId(id.toString())
+        .setOrganizationId(organizationId.toString())
+        .setStoreId(storeId.toString())
+        .setTerminalId(terminalId.toString())
+        .setOpeningAmount(openingAmount)
+        .setCurrentAmount(currentAmount)
+        .setIsOpen(isOpen)
+        .setOpenedAt(openedAt?.toString().orEmpty())
+        .setClosedAt(closedAt?.toString().orEmpty())
+        .setCreatedAt(createdAt.toString())
+        .setUpdatedAt(updatedAt.toString())
+        .build()
+
+internal fun SettlementEntity.toProto(): Settlement =
+    Settlement
+        .newBuilder()
+        .setId(id.toString())
+        .setOrganizationId(organizationId.toString())
+        .setStoreId(storeId.toString())
+        .setTerminalId(terminalId.toString())
+        .setStaffId(staffId.toString())
+        .setCashExpected(cashExpected)
+        .setCashActual(cashActual)
+        .setDifference(difference)
+        .setSettledAt(settledAt.toString())
+        .setCreatedAt(createdAt.toString())
+        .setUpdatedAt(updatedAt.toString())
+        .build()
+
+internal fun JournalEntryEntity.toProto(): JournalEntry =
+    JournalEntry
+        .newBuilder()
+        .setId(id.toString())
+        .setOrganizationId(organizationId.toString())
+        .setType(type)
+        .setTransactionId(transactionId?.toString().orEmpty())
+        .setStaffId(staffId.toString())
+        .setTerminalId(terminalId.toString())
+        .setDetails(details)
+        .setCreatedAt(createdAt.toString())
+        .build()
+
+internal fun DiscountReasonEntity.toDiscountReasonProto(): DiscountReason =
+    DiscountReason
+        .newBuilder()
+        .setId(id.toString())
+        .setOrganizationId(organizationId.toString())
+        .setCode(code)
+        .setDescription(description)
+        .setIsActive(isActive)
+        .setCreatedAt(createdAt.toString())
+        .setUpdatedAt(updatedAt.toString())
+        .build()
+
+internal fun ReservationEntity.toReservationProto(): Reservation =
+    Reservation
+        .newBuilder()
+        .setId(id.toString())
+        .setOrganizationId(organizationId.toString())
+        .setStoreId(storeId.toString())
+        .setCustomerName(customerName.orEmpty())
+        .setCustomerPhone(customerPhone.orEmpty())
+        .setItems(items)
+        .setReservedUntil(reservedUntil.toString())
+        .setStatus(status)
+        .setNote(note.orEmpty())
+        .setCreatedAt(createdAt.toString())
+        .setUpdatedAt(updatedAt.toString())
+        .build()
+
+internal fun GiftCardEntity.toGiftCardProto(): GiftCard =
+    GiftCard
+        .newBuilder()
+        .setId(id.toString())
+        .setOrganizationId(organizationId.toString())
+        .setCode(code)
+        .setInitialAmount(initialAmount)
+        .setBalance(balance)
+        .setStatus(status)
+        .setIssuedAt(issuedAt.toString())
+        .apply { this@toGiftCardProto.expiresAt?.let { setExpiresAt(it.toString()) } }
+        .setCreatedAt(createdAt.toString())
+        .setUpdatedAt(updatedAt.toString())
+        .build()
+
+/**
+ * Instant 形式（ISO-8601）または日付文字列（YYYY-MM-DD）をパースして Instant を返す。
+ * 日付文字列の場合は UTC の開始時刻（00:00:00Z）に変換する。
+ */
+internal fun parseInstantOrDate(value: String): Instant =
+    try {
+        Instant.parse(value)
+    } catch (_: java.time.format.DateTimeParseException) {
+        LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant()
+    }
+
+/**
+ * endDate 用のパース関数。
+ * 日付文字列（YYYY-MM-DD）の場合は翌日の開始時刻に変換し、排他的上限として使用する。
+ */
+internal fun parseInstantOrDateExclusive(value: String): Instant =
+    try {
+        Instant.parse(value)
+    } catch (_: java.time.format.DateTimeParseException) {
+        LocalDate
+            .parse(value)
+            .plusDays(1)
+            .atStartOfDay(ZoneOffset.UTC)
+            .toInstant()
+    }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -795,53 +795,6 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         responseObserver.onCompleted()
     }
 
-    // === Drawer / Settlement Mapper Extensions ===
-
-    private fun DrawerEntity.toProto(): Drawer =
-        Drawer
-            .newBuilder()
-            .setId(id.toString())
-            .setOrganizationId(organizationId.toString())
-            .setStoreId(storeId.toString())
-            .setTerminalId(terminalId.toString())
-            .setOpeningAmount(openingAmount)
-            .setCurrentAmount(currentAmount)
-            .setIsOpen(isOpen)
-            .setOpenedAt(openedAt?.toString().orEmpty())
-            .setClosedAt(closedAt?.toString().orEmpty())
-            .setCreatedAt(createdAt.toString())
-            .setUpdatedAt(updatedAt.toString())
-            .build()
-
-    private fun SettlementEntity.toProto(): Settlement =
-        Settlement
-            .newBuilder()
-            .setId(id.toString())
-            .setOrganizationId(organizationId.toString())
-            .setStoreId(storeId.toString())
-            .setTerminalId(terminalId.toString())
-            .setStaffId(staffId.toString())
-            .setCashExpected(cashExpected)
-            .setCashActual(cashActual)
-            .setDifference(difference)
-            .setSettledAt(settledAt.toString())
-            .setCreatedAt(createdAt.toString())
-            .setUpdatedAt(updatedAt.toString())
-            .build()
-
-    private fun JournalEntryEntity.toProto(): JournalEntry =
-        JournalEntry
-            .newBuilder()
-            .setId(id.toString())
-            .setOrganizationId(organizationId.toString())
-            .setType(type)
-            .setTransactionId(transactionId?.toString().orEmpty())
-            .setStaffId(staffId.toString())
-            .setTerminalId(terminalId.toString())
-            .setDetails(details)
-            .setCreatedAt(createdAt.toString())
-            .build()
-
     // === Mapper Extensions ===
 
     private fun TransactionEntity.toFullProto(): Transaction {
@@ -1095,18 +1048,6 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         }
     }
 
-    private fun com.openpos.pos.entity.DiscountReasonEntity.toDiscountReasonProto(): openpos.pos.v1.DiscountReason =
-        openpos.pos.v1.DiscountReason
-            .newBuilder()
-            .setId(id.toString())
-            .setOrganizationId(organizationId.toString())
-            .setCode(code)
-            .setDescription(description)
-            .setIsActive(isActive)
-            .setCreatedAt(createdAt.toString())
-            .setUpdatedAt(updatedAt.toString())
-            .build()
-
     // === Reservation (#1035) ===
 
     override fun listReservations(
@@ -1220,62 +1161,4 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         }
     }
 
-    private fun com.openpos.pos.entity.ReservationEntity.toReservationProto(): openpos.pos.v1.Reservation =
-        openpos.pos.v1.Reservation
-            .newBuilder()
-            .setId(id.toString())
-            .setOrganizationId(organizationId.toString())
-            .setStoreId(storeId.toString())
-            .setCustomerName(customerName.orEmpty())
-            .setCustomerPhone(customerPhone.orEmpty())
-            .setItems(items)
-            .setReservedUntil(reservedUntil.toString())
-            .setStatus(status)
-            .setNote(note.orEmpty())
-            .setCreatedAt(createdAt.toString())
-            .setUpdatedAt(updatedAt.toString())
-            .build()
-
-    private fun GiftCardEntity.toGiftCardProto(): openpos.pos.v1.GiftCard =
-        openpos.pos.v1.GiftCard
-            .newBuilder()
-            .setId(id.toString())
-            .setOrganizationId(organizationId.toString())
-            .setCode(code)
-            .setInitialAmount(initialAmount)
-            .setBalance(balance)
-            .setStatus(status)
-            .setIssuedAt(issuedAt.toString())
-            .apply { expiresAt?.let { setExpiresAt(it.toString()) } }
-            .setCreatedAt(createdAt.toString())
-            .setUpdatedAt(updatedAt.toString())
-            .build()
-
-    /**
-     * Instant 形式（ISO-8601）または日付文字列（YYYY-MM-DD）をパースして Instant を返す。
-     * 日付文字列の場合は UTC の開始時刻（00:00:00Z）に変換する。
-     * startDate のパースに使用する（包含的下限）。
-     */
-    private fun parseInstantOrDate(value: String): Instant =
-        try {
-            Instant.parse(value)
-        } catch (_: java.time.format.DateTimeParseException) {
-            LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant()
-        }
-
-    /**
-     * endDate 用のパース関数。
-     * 日付文字列（YYYY-MM-DD）の場合は翌日の開始時刻に変換し、排他的上限として使用する。
-     * Instant 形式の場合はそのまま返す（呼び出し元が排他的上限として扱う）。
-     */
-    private fun parseInstantOrDateExclusive(value: String): Instant =
-        try {
-            Instant.parse(value)
-        } catch (_: java.time.format.DateTimeParseException) {
-            LocalDate
-                .parse(value)
-                .plusDays(1)
-                .atStartOfDay(ZoneOffset.UTC)
-                .toInstant()
-        }
 }

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/AuxiliaryProtoMappingTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/AuxiliaryProtoMappingTest.kt
@@ -1,0 +1,142 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.DiscountReasonEntity
+import com.openpos.pos.entity.DrawerEntity
+import com.openpos.pos.entity.GiftCardEntity
+import com.openpos.pos.entity.JournalEntryEntity
+import com.openpos.pos.entity.ReservationEntity
+import com.openpos.pos.entity.SettlementEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class AuxiliaryProtoMappingTest {
+    private val organizationId = UUID.fromString("00000000-0000-0000-0000-000000000000")
+
+    @Test
+    fun `auxiliary entities map to proto messages`() {
+        val drawer = drawer().toProto()
+        val settlement = settlement().toProto()
+        val journal = journalEntry().toProto()
+        val giftCard = giftCard().toGiftCardProto()
+        val discountReason = discountReason().toDiscountReasonProto()
+        val reservation = reservation().toReservationProto()
+
+        assertEquals("33333333-3333-3333-3333-333333333333", drawer.terminalId)
+        assertEquals(5000, settlement.difference)
+        assertEquals("SALE", journal.type)
+        assertEquals("GC-0001-0002-0003", giftCard.code)
+        assertTrue(giftCard.expiresAt.isNotBlank())
+        assertEquals("MANUAL", discountReason.code)
+        assertEquals("山田太郎", reservation.customerName)
+        assertEquals("RESERVED", reservation.status)
+    }
+
+    @Test
+    fun `date strings are parsed as UTC boundaries`() {
+        assertEquals(
+            Instant.parse("2026-05-07T00:00:00Z"),
+            parseInstantOrDate("2026-05-07"),
+        )
+        assertEquals(
+            Instant.parse("2026-05-08T00:00:00Z"),
+            parseInstantOrDateExclusive("2026-05-07"),
+        )
+        assertEquals(
+            Instant.parse("2026-05-07T10:15:30Z"),
+            parseInstantOrDate("2026-05-07T10:15:30Z"),
+        )
+    }
+
+    @Test
+    fun `gift card without expiry leaves expiresAt unset`() {
+        val card = giftCard(expiresAt = null).toGiftCardProto()
+
+        assertTrue(card.expiresAt.isEmpty())
+    }
+
+    private fun drawer(): DrawerEntity =
+        DrawerEntity().apply {
+            id = UUID.fromString("11111111-1111-1111-1111-111111111111")
+            organizationId = this@AuxiliaryProtoMappingTest.organizationId
+            storeId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+            terminalId = UUID.fromString("33333333-3333-3333-3333-333333333333")
+            openingAmount = 10000
+            currentAmount = 15000
+            isOpen = true
+            openedAt = Instant.parse("2026-05-07T00:00:00Z")
+            createdAt = Instant.parse("2026-05-07T00:00:00Z")
+            updatedAt = Instant.parse("2026-05-07T00:30:00Z")
+        }
+
+    private fun settlement(): SettlementEntity =
+        SettlementEntity().apply {
+            id = UUID.fromString("44444444-4444-4444-4444-444444444444")
+            organizationId = this@AuxiliaryProtoMappingTest.organizationId
+            storeId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+            terminalId = UUID.fromString("33333333-3333-3333-3333-333333333333")
+            staffId = UUID.fromString("55555555-5555-5555-5555-555555555555")
+            cashExpected = 100000
+            cashActual = 105000
+            difference = 5000
+            settledAt = Instant.parse("2026-05-07T01:00:00Z")
+            createdAt = Instant.parse("2026-05-07T01:00:00Z")
+            updatedAt = Instant.parse("2026-05-07T01:05:00Z")
+        }
+
+    private fun journalEntry(): JournalEntryEntity =
+        JournalEntryEntity().apply {
+            id = UUID.fromString("66666666-6666-6666-6666-666666666666")
+            organizationId = this@AuxiliaryProtoMappingTest.organizationId
+            type = "SALE"
+            transactionId = UUID.fromString("77777777-7777-7777-7777-777777777777")
+            staffId = UUID.fromString("55555555-5555-5555-5555-555555555555")
+            terminalId = UUID.fromString("33333333-3333-3333-3333-333333333333")
+            details = "{\"amount\":10000}"
+            createdAt = Instant.parse("2026-05-07T02:00:00Z")
+            updatedAt = Instant.parse("2026-05-07T02:00:00Z")
+        }
+
+    private fun giftCard(expiresAt: Instant? = Instant.parse("2026-12-31T23:59:59Z")): GiftCardEntity =
+        GiftCardEntity().apply {
+            id = UUID.fromString("88888888-8888-8888-8888-888888888888")
+            organizationId = this@AuxiliaryProtoMappingTest.organizationId
+            code = "GC-0001-0002-0003"
+            initialAmount = 50000
+            balance = 42000
+            status = "ACTIVE"
+            issuedAt = Instant.parse("2026-05-07T03:00:00Z")
+            this.expiresAt = expiresAt
+            createdAt = Instant.parse("2026-05-07T03:00:00Z")
+            updatedAt = Instant.parse("2026-05-07T03:00:00Z")
+        }
+
+    private fun discountReason(): DiscountReasonEntity =
+        DiscountReasonEntity().apply {
+            id = UUID.fromString("99999999-9999-9999-9999-999999999999")
+            organizationId = this@AuxiliaryProtoMappingTest.organizationId
+            code = "MANUAL"
+            description = "手動値引き"
+            isActive = true
+            createdAt = Instant.parse("2026-05-07T04:00:00Z")
+            updatedAt = Instant.parse("2026-05-07T04:00:00Z")
+        }
+
+    private fun reservation(): ReservationEntity =
+        ReservationEntity().apply {
+            id = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+            organizationId = this@AuxiliaryProtoMappingTest.organizationId
+            storeId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+            customerName = "山田太郎"
+            customerPhone = "09012345678"
+            items = """[{"sku":"P-001","qty":1}]"""
+            reservedUntil = Instant.parse("2026-05-08T00:00:00Z")
+            status = "RESERVED"
+            note = "18時受取"
+            createdAt = Instant.parse("2026-05-07T05:00:00Z")
+            updatedAt = Instant.parse("2026-05-07T05:00:00Z")
+        }
+}


### PR DESCRIPTION
## Summary
- move drawer, settlement, journal, gift card, discount reason, and reservation proto mapping into dedicated grpc helper functions
- move date-range parsing and discount request resolution out of PosGrpcService to keep request orchestration separate from formatting and lookup logic
- add unit tests for auxiliary proto mapping, discount resolution, and fix two correctness issues: gift card expires_at mapping and ApplyDiscountRequest oneof discount fields

## Validation
- ./gradlew --no-daemon -Dkotlin.incremental=false :services:pos-service:test --tests "com.openpos.pos.grpc.ReceiptFormattingTest" --tests "com.openpos.pos.grpc.TransactionProtoMappingTest" --tests "com.openpos.pos.grpc.AuxiliaryProtoMappingTest" --tests "com.openpos.pos.grpc.DiscountResolutionTest"

## Notes
- the Gradle run still emits the existing warning about unused gRPC interceptors, but compilation and tests pass.
