### PR TITLE
[codex] extract grpc discount resolution

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/DiscountResolution.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/DiscountResolution.kt
@@ -1,0 +1,90 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.TransactionEntity
+import openpos.pos.v1.ApplyDiscountRequest
+import java.util.UUID
+
+internal data class ResolvedDiscountApplication(
+    val transactionId: UUID,
+    val transactionItemId: UUID?,
+    val discountId: UUID?,
+    val name: String,
+    val discountType: String,
+    val value: String,
+    val amount: Long,
+)
+
+private sealed interface DiscountSpecifier {
+    data class Coupon(val code: String) : DiscountSpecifier
+
+    data class DiscountId(val id: UUID) : DiscountSpecifier
+}
+
+internal fun resolveDiscountApplication(
+    request: ApplyDiscountRequest,
+    transactionId: UUID,
+    transactionItemId: UUID?,
+    loadTransaction: (UUID) -> TransactionEntity,
+    validateCoupon: (String, UUID) -> CouponValidationResult,
+    getDiscount: (UUID, UUID) -> DiscountInfo,
+): ResolvedDiscountApplication {
+    val tx = loadTransaction(transactionId)
+    val specifier = request.resolveDiscountSpecifier()
+
+    return when (specifier) {
+        is DiscountSpecifier.Coupon -> {
+            val couponResult = validateCoupon(specifier.code, tx.organizationId)
+            if (!couponResult.isValid) {
+                throw IllegalArgumentException("Coupon is not valid: ${couponResult.reason}")
+            }
+
+            ResolvedDiscountApplication(
+                transactionId = transactionId,
+                transactionItemId = transactionItemId,
+                discountId = couponResult.discountId,
+                name = couponResult.discountName,
+                discountType = couponResult.discountType,
+                value = couponResult.discountValue,
+                amount = computeDiscountAmount(couponResult.discountType, couponResult.discountValue, tx.subtotal),
+            )
+        }
+
+        is DiscountSpecifier.DiscountId -> {
+            val discountInfo = getDiscount(specifier.id, tx.organizationId)
+            ResolvedDiscountApplication(
+                transactionId = transactionId,
+                transactionItemId = transactionItemId,
+                discountId = specifier.id,
+                name = discountInfo.name,
+                discountType = discountInfo.discountType,
+                value = discountInfo.value,
+                amount = computeDiscountAmount(discountInfo.discountType, discountInfo.value, tx.subtotal),
+            )
+        }
+    }
+}
+
+internal fun computeDiscountAmount(
+    discountType: String,
+    discountValue: String,
+    subtotal: Long,
+): Long =
+    when (discountType) {
+        "PERCENTAGE" -> {
+            val percentage = discountValue.toBigDecimal()
+            (subtotal.toBigDecimal() * percentage / 100.toBigDecimal()).toLong()
+        }
+
+        "FIXED_AMOUNT" -> discountValue.toLong()
+
+        else -> 0L
+    }
+
+private fun ApplyDiscountRequest.resolveDiscountSpecifier(): DiscountSpecifier =
+    when {
+        applyCouponCode.isNotBlank() -> DiscountSpecifier.Coupon(applyCouponCode)
+        applyDiscountId.isNotBlank() -> DiscountSpecifier.DiscountId(UUID.fromString(applyDiscountId))
+        couponCode.isNotBlank() -> DiscountSpecifier.Coupon(couponCode)
+        discountId.isNotBlank() -> DiscountSpecifier.DiscountId(UUID.fromString(discountId))
+        else -> throw IllegalArgumentException("Either coupon_code or discount_id must be specified")
+    }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -249,61 +249,25 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         tenantHelper.setupTenantContext()
         try {
             val transactionId = request.transactionId.toUUID()
-            val couponCode = request.couponCode.ifBlank { null }
-            val discountId = request.discountId.uuidOrNull()
-
-            val resolvedName: String
-            val resolvedType: String
-            val resolvedValue: String
-            val resolvedAmount: Long
-            val resolvedDiscountId: UUID?
-
-            if (couponCode != null) {
-                // クーポンコード経由: product-service に問い合わせて割引情報を取得
-                val tx = transactionService.getTransaction(transactionId)
-                val couponResult = productServiceClient.validateCoupon(couponCode, tx.organizationId)
-                if (!couponResult.isValid) {
-                    throw IllegalArgumentException(
-                        "Coupon is not valid: ${couponResult.reason}",
-                    )
-                }
-                resolvedDiscountId = couponResult.discountId
-                resolvedName = couponResult.discountName
-                resolvedType = couponResult.discountType
-                resolvedValue = couponResult.discountValue
-                resolvedAmount =
-                    computeDiscountAmount(
-                        couponResult.discountType,
-                        couponResult.discountValue,
-                        transactionId,
-                    )
-            } else if (discountId != null) {
-                // discount_id 直接指定: product-service から割引マスタ取得
-                val tx = transactionService.getTransaction(transactionId)
-                val discountInfo = productServiceClient.getDiscount(discountId, tx.organizationId)
-                resolvedDiscountId = discountId
-                resolvedName = discountInfo.name
-                resolvedType = discountInfo.discountType
-                resolvedValue = discountInfo.value
-                resolvedAmount =
-                    computeDiscountAmount(
-                        discountInfo.discountType,
-                        discountInfo.value,
-                        transactionId,
-                    )
-            } else {
-                throw IllegalArgumentException("Either coupon_code or discount_id must be specified")
-            }
+            val resolved =
+                resolveDiscountApplication(
+                    request = request,
+                    transactionId = transactionId,
+                    transactionItemId = request.transactionItemId.uuidOrNull(),
+                    loadTransaction = transactionService::getTransaction,
+                    validateCoupon = productServiceClient::validateCoupon,
+                    getDiscount = productServiceClient::getDiscount,
+                )
 
             val entity =
                 transactionService.applyDiscount(
-                    transactionId = transactionId,
-                    discountId = resolvedDiscountId,
-                    name = resolvedName,
-                    discountType = resolvedType,
-                    value = resolvedValue,
-                    amount = resolvedAmount,
-                    transactionItemId = request.transactionItemId.uuidOrNull(),
+                    transactionId = resolved.transactionId,
+                    discountId = resolved.discountId,
+                    name = resolved.name,
+                    discountType = resolved.discountType,
+                    value = resolved.value,
+                    amount = resolved.amount,
+                    transactionItemId = resolved.transactionItemId,
                 )
             responseObserver.onNext(
                 ApplyDiscountResponse
@@ -316,32 +280,6 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             throw mapToGrpcException(e)
         }
     }
-
-    /**
-     * 割引タイプと値から実際の割引金額（銭単位）を計算する。
-     * PERCENTAGE の場合は取引小計に対するパーセンテージ、
-     * FIXED_AMOUNT の場合はそのまま値を返す。
-     */
-    private fun computeDiscountAmount(
-        discountType: String,
-        discountValue: String,
-        transactionId: UUID,
-    ): Long =
-        when (discountType) {
-            "PERCENTAGE" -> {
-                val tx = transactionService.getTransaction(transactionId)
-                val percentage = discountValue.toBigDecimal()
-                (tx.subtotal.toBigDecimal() * percentage / 100.toBigDecimal()).toLong()
-            }
-
-            "FIXED_AMOUNT" -> {
-                discountValue.toLong()
-            }
-
-            else -> {
-                0L
-            }
-        }
 
     // === Finalize ===
 

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/DiscountResolutionTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/DiscountResolutionTest.kt
@@ -1,0 +1,131 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.TransactionEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import openpos.pos.v1.ApplyDiscountRequest
+import java.util.UUID
+
+class DiscountResolutionTest {
+    private val organizationId = UUID.fromString("00000000-0000-0000-0000-000000000000")
+    private val transactionId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val discountId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    @Test
+    fun `resolves oneof coupon path and computes percentage amount from subtotal`() {
+        val result =
+            resolveDiscountApplication(
+                request =
+                    ApplyDiscountRequest
+                        .newBuilder()
+                        .setTransactionId(transactionId.toString())
+                        .setApplyCouponCode("SPRING10")
+                        .build(),
+                transactionId = transactionId,
+                transactionItemId = null,
+                loadTransaction = { transaction(subtotal = 20000) },
+                validateCoupon = { code, orgId ->
+                    assertEquals("SPRING10", code)
+                    assertEquals(organizationId, orgId)
+                    CouponValidationResult(
+                        isValid = true,
+                        discountId = discountId,
+                        discountName = "春セール",
+                        discountType = "PERCENTAGE",
+                        discountValue = "10",
+                    )
+                },
+                getDiscount = { _, _ -> error("getDiscount should not be called") },
+            )
+
+        assertEquals(discountId, result.discountId)
+        assertEquals("春セール", result.name)
+        assertEquals(2000, result.amount)
+    }
+
+    @Test
+    fun `falls back to legacy discount_id path`() {
+        val result =
+            resolveDiscountApplication(
+                request =
+                    ApplyDiscountRequest
+                        .newBuilder()
+                        .setTransactionId(transactionId.toString())
+                        .setDiscountId(discountId.toString())
+                        .build(),
+                transactionId = transactionId,
+                transactionItemId = UUID.fromString("33333333-3333-3333-3333-333333333333"),
+                loadTransaction = { transaction(subtotal = 50000) },
+                validateCoupon = { _, _ -> error("validateCoupon should not be called") },
+                getDiscount = { id, orgId ->
+                    assertEquals(discountId, id)
+                    assertEquals(organizationId, orgId)
+                    DiscountInfo(
+                        name = "固定値引き",
+                        discountType = "FIXED_AMOUNT",
+                        value = "1500",
+                    )
+                },
+            )
+
+        assertEquals(1500, result.amount)
+        assertEquals("固定値引き", result.name)
+        assertEquals("FIXED_AMOUNT", result.discountType)
+        assertEquals(UUID.fromString("33333333-3333-3333-3333-333333333333"), result.transactionItemId)
+    }
+
+    @Test
+    fun `invalid coupon surfaces a validation error`() {
+        val error =
+            assertThrows(IllegalArgumentException::class.java) {
+                resolveDiscountApplication(
+                    request =
+                        ApplyDiscountRequest
+                            .newBuilder()
+                            .setTransactionId(transactionId.toString())
+                            .setCouponCode("BAD")
+                            .build(),
+                    transactionId = transactionId,
+                    transactionItemId = null,
+                    loadTransaction = { transaction(subtotal = 10000) },
+                    validateCoupon = { _, _ ->
+                        CouponValidationResult(isValid = false, reason = "expired")
+                    },
+                    getDiscount = { _, _ -> error("getDiscount should not be called") },
+                )
+            }
+
+        assertEquals("Coupon is not valid: expired", error.message)
+    }
+
+    @Test
+    fun `missing discount source is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            resolveDiscountApplication(
+                request =
+                    ApplyDiscountRequest
+                        .newBuilder()
+                        .setTransactionId(transactionId.toString())
+                        .build(),
+                transactionId = transactionId,
+                transactionItemId = null,
+                loadTransaction = { transaction(subtotal = 10000) },
+                validateCoupon = { _, _ -> error("validateCoupon should not be called") },
+                getDiscount = { _, _ -> error("getDiscount should not be called") },
+            )
+        }
+    }
+
+    @Test
+    fun `unknown discount type returns zero amount`() {
+        assertEquals(0L, computeDiscountAmount("UNKNOWN", "10", 10000))
+    }
+
+    private fun transaction(subtotal: Long): TransactionEntity =
+        TransactionEntity().apply {
+            id = transactionId
+            organizationId = this@DiscountResolutionTest.organizationId
+            this.subtotal = subtotal
+        }
+}


### PR DESCRIPTION
## What changed
- extracted discount request resolution and amount calculation out of `PosGrpcService`
- added `DiscountResolution.kt` to handle coupon/direct-discount lookup and subtotal-based amount calculation
- added focused unit tests for oneof discount handling, legacy fallback paths, and invalid input cases

## Why
`PosGrpcService.applyDiscount` still mixed gRPC request parsing, coupon validation, discount lookup, and amount calculation. That made the RPC harder to test and left the newer `ApplyDiscountRequest.discount` oneof fields effectively unsupported.

## Impact
- `ApplyDiscountRequest` now correctly supports `apply_coupon_code` and `apply_discount_id`
- the remaining RPC body is smaller and easier to change safely
- regression coverage was added around discount resolution behavior

## Validation
- `./gradlew --no-daemon -Dkotlin.incremental=false :services:pos-service:test --tests "com.openpos.pos.grpc.ReceiptFormattingTest" --tests "com.openpos.pos.grpc.TransactionProtoMappingTest" --tests "com.openpos.pos.grpc.AuxiliaryProtoMappingTest" --tests "com.openpos.pos.grpc.DiscountResolutionTest"`