### PR TITLE
[codex] extract grpc sync/report support

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/GrpcRequestParsing.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/GrpcRequestParsing.kt
@@ -1,0 +1,13 @@
+package com.openpos.pos.grpc
+
+import io.grpc.Status
+import java.util.UUID
+
+internal fun String.toUUID(): UUID =
+    try {
+        UUID.fromString(this)
+    } catch (e: IllegalArgumentException) {
+        throw Status.INVALID_ARGUMENT.withDescription("Invalid UUID: $this").asRuntimeException()
+    }
+
+internal fun String.uuidOrNull(): UUID? = if (isBlank()) null else toUUID()

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/OfflineSyncSupport.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/OfflineSyncSupport.kt
@@ -1,0 +1,76 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.TransactionEntity
+import com.openpos.pos.service.OfflineItemInput
+import com.openpos.pos.service.PaymentInput
+import openpos.pos.v1.OfflineTransaction
+import openpos.pos.v1.SyncResult
+import java.time.Instant
+import java.util.UUID
+
+internal data class OfflineTransactionSyncInput(
+    val clientId: String,
+    val storeId: UUID,
+    val terminalId: UUID,
+    val staffId: UUID,
+    val items: List<OfflineItemInput>,
+    val payments: List<PaymentInput>,
+    val createdAt: Instant?,
+)
+
+internal fun syncOfflineTransactionResult(
+    offlineTransaction: OfflineTransaction,
+    syncTransaction: (OfflineTransactionSyncInput) -> TransactionEntity,
+): SyncResult =
+    try {
+        val input = offlineTransaction.toSyncInput()
+        val entity = syncTransaction(input)
+        SyncResult
+            .newBuilder()
+            .setClientId(input.clientId)
+            .setSuccess(true)
+            .setTransactionId(entity.id.toString())
+            .build()
+    } catch (e: Exception) {
+        SyncResult
+            .newBuilder()
+            .setClientId(offlineTransaction.clientId)
+            .setSuccess(false)
+            .setError(e.message ?: "Unknown error")
+            .build()
+    }
+
+private fun OfflineTransaction.toSyncInput(): OfflineTransactionSyncInput =
+    OfflineTransactionSyncInput(
+        clientId = clientId,
+        storeId = storeId.toUUID(),
+        terminalId = terminalId.toUUID(),
+        staffId = staffId.toUUID(),
+        items =
+            itemsList.map { item ->
+                OfflineItemInput(
+                    productId = item.productId.toUUID(),
+                    productName = item.productName,
+                    unitPrice = item.unitPrice,
+                    quantity = item.quantity,
+                    taxRateName = item.taxRateName,
+                    taxRate = item.taxRate,
+                    isReducedTax = item.isReducedTax,
+                )
+            },
+        payments =
+            paymentsList.map { payment ->
+                PaymentInput(
+                    method = payment.method.toDbValue(),
+                    amount = payment.amount,
+                    received = if (payment.received > 0) payment.received else null,
+                    reference = payment.reference.ifBlank { null },
+                )
+            },
+        createdAt =
+            if (createdAt.isNotBlank()) {
+                Instant.parse(createdAt)
+            } else {
+                null
+            },
+    )

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -14,7 +14,6 @@ import com.openpos.pos.service.DiscountReasonService
 import com.openpos.pos.service.DrawerService
 import com.openpos.pos.service.GiftCardService
 import com.openpos.pos.service.JournalService
-import com.openpos.pos.service.OfflineItemInput
 import com.openpos.pos.service.PaymentInput
 import com.openpos.pos.service.ReservationService
 import com.openpos.pos.service.SettlementService
@@ -57,17 +56,14 @@ import openpos.pos.v1.ListTransactionsRequest
 import openpos.pos.v1.ListTransactionsResponse
 import openpos.pos.v1.OpenDrawerRequest
 import openpos.pos.v1.OpenDrawerResponse
-import openpos.pos.v1.Payment
 import openpos.pos.v1.PaymentMethod
 import openpos.pos.v1.PosServiceGrpc
 import openpos.pos.v1.Receipt
 import openpos.pos.v1.RemoveTransactionItemRequest
 import openpos.pos.v1.RemoveTransactionItemResponse
 import openpos.pos.v1.Settlement
-import openpos.pos.v1.StaffSalesItem
 import openpos.pos.v1.SyncOfflineTransactionsRequest
 import openpos.pos.v1.SyncOfflineTransactionsResponse
-import openpos.pos.v1.SyncResult
 import openpos.pos.v1.TaxSummary
 import openpos.pos.v1.Transaction
 import openpos.pos.v1.TransactionDiscount
@@ -79,8 +75,6 @@ import openpos.pos.v1.UpdateTransactionItemResponse
 import openpos.pos.v1.VoidTransactionRequest
 import openpos.pos.v1.VoidTransactionResponse
 import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneOffset
 import java.util.UUID
 
 @GrpcService
@@ -671,57 +665,16 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         tenantHelper.setupTenantContextWithoutFilter()
         val results =
             request.transactionsList.map { offlineTx ->
-                try {
-                    val items =
-                        offlineTx.itemsList.map { item ->
-                            OfflineItemInput(
-                                productId = item.productId.toUUID(),
-                                productName = item.productName,
-                                unitPrice = item.unitPrice,
-                                quantity = item.quantity,
-                                taxRateName = item.taxRateName,
-                                taxRate = item.taxRate,
-                                isReducedTax = item.isReducedTax,
-                            )
-                        }
-                    val payments =
-                        offlineTx.paymentsList.map { p ->
-                            PaymentInput(
-                                method = p.method.toDbValue(),
-                                amount = p.amount,
-                                received = if (p.received > 0) p.received else null,
-                                reference = p.reference.ifBlank { null },
-                            )
-                        }
-                    val createdAt =
-                        if (offlineTx.createdAt.isNotBlank()) {
-                            Instant.parse(offlineTx.createdAt)
-                        } else {
-                            null
-                        }
-                    val entity =
-                        transactionService.syncOfflineTransaction(
-                            storeId = offlineTx.storeId.toUUID(),
-                            terminalId = offlineTx.terminalId.toUUID(),
-                            staffId = offlineTx.staffId.toUUID(),
-                            clientId = offlineTx.clientId,
-                            items = items,
-                            payments = payments,
-                            createdAt = createdAt,
-                        )
-                    SyncResult
-                        .newBuilder()
-                        .setClientId(offlineTx.clientId)
-                        .setSuccess(true)
-                        .setTransactionId(entity.id.toString())
-                        .build()
-                } catch (e: Exception) {
-                    SyncResult
-                        .newBuilder()
-                        .setClientId(offlineTx.clientId)
-                        .setSuccess(false)
-                        .setError(e.message ?: "Unknown error")
-                        .build()
+                syncOfflineTransactionResult(offlineTx) { input ->
+                    transactionService.syncOfflineTransaction(
+                        storeId = input.storeId,
+                        terminalId = input.terminalId,
+                        staffId = input.staffId,
+                        clientId = input.clientId,
+                        items = input.items,
+                        payments = input.payments,
+                        createdAt = input.createdAt,
+                    )
                 }
             }
         responseObserver.onNext(
@@ -749,17 +702,6 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         discounts: List<TransactionDiscountEntity>,
         taxSummaries: List<TaxSummaryEntity>,
     ): Transaction = toProto(items, payments, discounts, taxSummaries)
-
-    // === Utility Extensions ===
-
-    private fun String.toUUID(): UUID =
-        try {
-            UUID.fromString(this)
-        } catch (e: IllegalArgumentException) {
-            throw Status.INVALID_ARGUMENT.withDescription("Invalid UUID: $this").asRuntimeException()
-        }
-
-    private fun String.uuidOrNull(): UUID? = if (isBlank()) null else toUUID()
 
     // === GiftCard ===
 
@@ -868,42 +810,11 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContext()
         try {
-            require(request.storeId.isNotBlank()) { "store_id is required" }
-            require(request.hasDateRange()) { "date_range is required" }
-            require(request.dateRange.start.isNotBlank()) { "date_range.start is required" }
-            require(request.dateRange.end.isNotBlank()) { "date_range.end is required" }
-
-            val storeId = request.storeId.toUUID()
-            val startDate = parseInstantOrDate(request.dateRange.start)
-            val endDate = parseInstantOrDateExclusive(request.dateRange.end)
-
-            val aggregated = transactionService.aggregateStaffSales(storeId, startDate, endDate)
-
+            val query = resolveStaffSalesReportQuery(request)
+            val aggregated = transactionService.aggregateStaffSales(query.storeId, query.startDate, query.endDate)
             val orgId = requireNotNull(tenantHelper.organizationIdHolder.organizationId) { "organizationId is not set" }
-            val staffNameMap =
-                try {
-                    storeServiceClient.getStaffNameMap(orgId, storeId)
-                } catch (_: Exception) {
-                    emptyMap()
-                }
-
-            val items =
-                aggregated.map { row ->
-                    val staffId = row[0] as UUID
-                    val txCount = (row[1] as Long).toInt()
-                    val totalAmount = row[2] as Long
-                    val avgTx = if (txCount > 0) totalAmount / txCount else 0L
-                    val staffName = staffNameMap[staffId] ?: staffId.toString()
-
-                    StaffSalesItem
-                        .newBuilder()
-                        .setStaffId(staffId.toString())
-                        .setStaffName(staffName)
-                        .setTotalAmount(totalAmount)
-                        .setTransactionCount(txCount)
-                        .setAverageTransaction(avgTx)
-                        .build()
-                }
+            val staffNameMap = loadStaffNameMapOrEmpty(orgId, query.storeId, storeServiceClient::getStaffNameMap)
+            val items = buildStaffSalesItems(aggregated, staffNameMap)
 
             responseObserver.onNext(
                 GetStaffSalesReportResponse

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/StaffSalesReportSupport.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/StaffSalesReportSupport.kt
@@ -1,0 +1,56 @@
+package com.openpos.pos.grpc
+
+import openpos.pos.v1.GetStaffSalesReportRequest
+import openpos.pos.v1.StaffSalesItem
+import java.time.Instant
+import java.util.UUID
+
+internal data class StaffSalesReportQuery(
+    val storeId: UUID,
+    val startDate: Instant,
+    val endDate: Instant,
+)
+
+internal fun resolveStaffSalesReportQuery(request: GetStaffSalesReportRequest): StaffSalesReportQuery {
+    require(request.storeId.isNotBlank()) { "store_id is required" }
+    require(request.hasDateRange()) { "date_range is required" }
+    require(request.dateRange.start.isNotBlank()) { "date_range.start is required" }
+    require(request.dateRange.end.isNotBlank()) { "date_range.end is required" }
+
+    return StaffSalesReportQuery(
+        storeId = request.storeId.toUUID(),
+        startDate = parseInstantOrDate(request.dateRange.start),
+        endDate = parseInstantOrDateExclusive(request.dateRange.end),
+    )
+}
+
+internal fun loadStaffNameMapOrEmpty(
+    organizationId: UUID,
+    storeId: UUID,
+    loadStaffNameMap: (UUID, UUID) -> Map<UUID, String>,
+): Map<UUID, String> =
+    try {
+        loadStaffNameMap(organizationId, storeId)
+    } catch (_: Exception) {
+        emptyMap()
+    }
+
+internal fun buildStaffSalesItems(
+    aggregatedRows: List<Array<Any>>,
+    staffNameMap: Map<UUID, String>,
+): List<StaffSalesItem> =
+    aggregatedRows.map { row ->
+        val staffId = row[0] as UUID
+        val transactionCount = (row[1] as Long).toInt()
+        val totalAmount = row[2] as Long
+        val averageTransaction = if (transactionCount > 0) totalAmount / transactionCount else 0L
+
+        StaffSalesItem
+            .newBuilder()
+            .setStaffId(staffId.toString())
+            .setStaffName(staffNameMap[staffId] ?: staffId.toString())
+            .setTotalAmount(totalAmount)
+            .setTransactionCount(transactionCount)
+            .setAverageTransaction(averageTransaction)
+            .build()
+    }

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/OfflineSyncSupportTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/OfflineSyncSupportTest.kt
@@ -1,0 +1,123 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.TransactionEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import openpos.pos.v1.OfflineTransaction
+import openpos.pos.v1.OfflineTransactionItem
+import openpos.pos.v1.PaymentInput
+import openpos.pos.v1.PaymentMethod
+import java.time.Instant
+import java.util.UUID
+
+class OfflineSyncSupportTest {
+    private val storeId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val terminalId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+    private val staffId = UUID.fromString("33333333-3333-3333-3333-333333333333")
+    private val transactionId = UUID.fromString("44444444-4444-4444-4444-444444444444")
+
+    @Test
+    fun `maps offline transaction payload into sync input and success result`() {
+        var capturedInput: OfflineTransactionSyncInput? = null
+
+        val result =
+            syncOfflineTransactionResult(
+                offlineTransaction =
+                    OfflineTransaction
+                        .newBuilder()
+                        .setClientId("offline-1")
+                        .setStoreId(storeId.toString())
+                        .setTerminalId(terminalId.toString())
+                        .setStaffId(staffId.toString())
+                        .addItems(
+                            OfflineTransactionItem
+                                .newBuilder()
+                                .setProductId(UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").toString())
+                                .setProductName("Coffee")
+                                .setUnitPrice(480)
+                                .setQuantity(2)
+                                .setTaxRateName("standard")
+                                .setTaxRate("0.10")
+                                .setIsReducedTax(false)
+                                .build(),
+                        ).addPayments(
+                            PaymentInput
+                                .newBuilder()
+                                .setMethod(PaymentMethod.PAYMENT_METHOD_CASH)
+                                .setAmount(960)
+                                .setReceived(1000)
+                                .setReference("")
+                                .build(),
+                        ).setCreatedAt("2026-05-07T00:00:00Z")
+                        .build(),
+            ) { input ->
+                capturedInput = input
+                TransactionEntity().apply { id = transactionId }
+            }
+
+        assertTrue(result.success)
+        assertEquals(transactionId.toString(), result.transactionId)
+        assertEquals("offline-1", capturedInput?.clientId)
+        assertEquals(storeId, capturedInput?.storeId)
+        assertEquals(terminalId, capturedInput?.terminalId)
+        assertEquals(staffId, capturedInput?.staffId)
+        assertEquals(1, capturedInput?.items?.size)
+        assertEquals("Coffee", capturedInput?.items?.single()?.productName)
+        assertEquals("CASH", capturedInput?.payments?.single()?.method)
+        assertEquals(1000, capturedInput?.payments?.single()?.received)
+        assertEquals(Instant.parse("2026-05-07T00:00:00Z"), capturedInput?.createdAt)
+    }
+
+    @Test
+    fun `blank optional fields become nulls`() {
+        var capturedInput: OfflineTransactionSyncInput? = null
+
+        syncOfflineTransactionResult(
+            offlineTransaction =
+                OfflineTransaction
+                    .newBuilder()
+                    .setClientId("offline-2")
+                    .setStoreId(storeId.toString())
+                    .setTerminalId(terminalId.toString())
+                    .setStaffId(staffId.toString())
+                    .addPayments(
+                        PaymentInput
+                            .newBuilder()
+                            .setMethod(PaymentMethod.PAYMENT_METHOD_CREDIT_CARD)
+                            .setAmount(1200)
+                            .build(),
+                    ).build(),
+        ) { input ->
+            capturedInput = input
+            TransactionEntity().apply { id = transactionId }
+        }
+
+        assertNull(capturedInput?.createdAt)
+        assertNull(capturedInput?.payments?.single()?.received)
+        assertNull(capturedInput?.payments?.single()?.reference)
+    }
+
+    @Test
+    fun `returns failure result when sync raises`() {
+        val result =
+            syncOfflineTransactionResult(
+                offlineTransaction =
+                    OfflineTransaction
+                        .newBuilder()
+                        .setClientId("offline-3")
+                        .setStoreId(storeId.toString())
+                        .setTerminalId(terminalId.toString())
+                        .setStaffId(staffId.toString())
+                        .build(),
+            ) {
+                throw IllegalArgumentException("invalid state")
+            }
+
+        assertFalse(result.success)
+        assertEquals("offline-3", result.clientId)
+        assertEquals("invalid state", result.error)
+    }
+}

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/StaffSalesReportSupportTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/StaffSalesReportSupportTest.kt
@@ -1,0 +1,77 @@
+package com.openpos.pos.grpc
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import openpos.common.v1.DateRange
+import openpos.pos.v1.GetStaffSalesReportRequest
+import java.time.Instant
+import java.util.UUID
+
+class StaffSalesReportSupportTest {
+    private val storeId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val staffId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    @Test
+    fun `validates and parses report query`() {
+        val query =
+            resolveStaffSalesReportQuery(
+                GetStaffSalesReportRequest
+                    .newBuilder()
+                    .setStoreId(storeId.toString())
+                    .setDateRange(
+                        DateRange
+                            .newBuilder()
+                            .setStart("2026-05-01")
+                            .setEnd("2026-05-07")
+                            .build(),
+                    ).build(),
+            )
+
+        assertEquals(storeId, query.storeId)
+        assertEquals(Instant.parse("2026-05-01T00:00:00Z"), query.startDate)
+        assertEquals(Instant.parse("2026-05-08T00:00:00Z"), query.endDate)
+    }
+
+    @Test
+    fun `rejects missing required fields`() {
+        val error =
+            assertThrows(IllegalArgumentException::class.java) {
+                resolveStaffSalesReportQuery(GetStaffSalesReportRequest.getDefaultInstance())
+            }
+
+        assertEquals("store_id is required", error.message)
+    }
+
+    @Test
+    fun `builds staff sales items with average and id fallback`() {
+        val items =
+            buildStaffSalesItems(
+                aggregatedRows =
+                    listOf(
+                        arrayOf(staffId, 3L, 9000L),
+                        arrayOf(UUID.fromString("33333333-3333-3333-3333-333333333333"), 0L, 0L),
+                    ),
+                staffNameMap = mapOf(staffId to "Aiko"),
+            )
+
+        assertEquals(2, items.size)
+        assertEquals("Aiko", items[0].staffName)
+        assertEquals(3000, items[0].averageTransaction)
+        assertEquals("33333333-3333-3333-3333-333333333333", items[1].staffName)
+        assertEquals(0, items[1].averageTransaction)
+    }
+
+    @Test
+    fun `falls back to empty map when staff lookup fails`() {
+        val names =
+            loadStaffNameMapOrEmpty(
+                organizationId = UUID.fromString("44444444-4444-4444-4444-444444444444"),
+                storeId = storeId,
+            ) { _, _ ->
+                throw IllegalStateException("grpc unavailable")
+            }
+
+        assertEquals(emptyMap<UUID, String>(), names)
+    }
+}


### PR DESCRIPTION
## What changed
- extracted UUID parsing into `GrpcRequestParsing.kt`
- moved offline transaction request mapping and per-item sync result handling into `OfflineSyncSupport.kt`
- moved staff sales report request validation, staff-name fallback, and proto item mapping into `StaffSalesReportSupport.kt`
- added focused unit tests for offline sync mapping and staff sales report support helpers

## Why
`PosGrpcService` still contained request parsing and data-shaping logic for offline sync and staff sales reporting. Those paths are easier to validate as pure helpers than inside the gRPC service class, and keeping them inline was keeping the service file large.

## Impact
- `PosGrpcService` shrinks from 1102 to 1013 lines
- offline sync behavior remains per-record fault-tolerant while the parsing logic is now testable in isolation
- staff sales report validation and row-to-proto mapping are now reusable and covered by unit tests

## Validation
- `./gradlew --no-daemon -Dkotlin.incremental=false :services:pos-service:test --tests "com.openpos.pos.grpc.ReceiptFormattingTest" --tests "com.openpos.pos.grpc.TransactionProtoMappingTest" --tests "com.openpos.pos.grpc.AuxiliaryProtoMappingTest" --tests "com.openpos.pos.grpc.DiscountResolutionTest" --tests "com.openpos.pos.grpc.OfflineSyncSupportTest" --tests "com.openpos.pos.grpc.StaffSalesReportSupportTest"`