### PR TITLE
[codex] extract grpc query and hydration support

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -4,12 +4,8 @@ import com.openpos.pos.config.OrganizationIdInterceptor
 import com.openpos.pos.entity.DrawerEntity
 import com.openpos.pos.entity.GiftCardEntity
 import com.openpos.pos.entity.JournalEntryEntity
-import com.openpos.pos.entity.PaymentEntity
 import com.openpos.pos.entity.SettlementEntity
-import com.openpos.pos.entity.TaxSummaryEntity
-import com.openpos.pos.entity.TransactionDiscountEntity
 import com.openpos.pos.entity.TransactionEntity
-import com.openpos.pos.entity.TransactionItemEntity
 import com.openpos.pos.service.DiscountReasonService
 import com.openpos.pos.service.DrawerService
 import com.openpos.pos.service.GiftCardService
@@ -23,7 +19,6 @@ import io.grpc.stub.StreamObserver
 import io.quarkus.grpc.GrpcService
 import io.smallrye.common.annotation.Blocking
 import jakarta.inject.Inject
-import openpos.common.v1.PaginationResponse
 import openpos.pos.v1.AddTransactionItemRequest
 import openpos.pos.v1.AddTransactionItemResponse
 import openpos.pos.v1.ApplyDiscountRequest
@@ -68,7 +63,6 @@ import openpos.pos.v1.TaxSummary
 import openpos.pos.v1.Transaction
 import openpos.pos.v1.TransactionDiscount
 import openpos.pos.v1.TransactionItem
-import openpos.pos.v1.TransactionStatus
 import openpos.pos.v1.TransactionType
 import openpos.pos.v1.UpdateTransactionItemRequest
 import openpos.pos.v1.UpdateTransactionItemResponse
@@ -134,7 +128,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         responseObserver.onNext(
             CreateTransactionResponse
                 .newBuilder()
-                .setTransaction(entity.toFullProto())
+                .setTransaction(entity.toFullProto(transactionService))
                 .build(),
         )
         responseObserver.onCompleted()
@@ -178,7 +172,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             responseObserver.onNext(
                 AddTransactionItemResponse
                     .newBuilder()
-                    .setTransaction(entity.toFullProto())
+                    .setTransaction(entity.toFullProto(transactionService))
                     .build(),
             )
             responseObserver.onCompleted()
@@ -202,7 +196,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             responseObserver.onNext(
                 UpdateTransactionItemResponse
                     .newBuilder()
-                    .setTransaction(entity.toFullProto())
+                    .setTransaction(entity.toFullProto(transactionService))
                     .build(),
             )
             responseObserver.onCompleted()
@@ -225,7 +219,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             responseObserver.onNext(
                 RemoveTransactionItemResponse
                     .newBuilder()
-                    .setTransaction(entity.toFullProto())
+                    .setTransaction(entity.toFullProto(transactionService))
                     .build(),
             )
             responseObserver.onCompleted()
@@ -266,7 +260,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             responseObserver.onNext(
                 ApplyDiscountResponse
                     .newBuilder()
-                    .setTransaction(entity.toFullProto())
+                    .setTransaction(entity.toFullProto(transactionService))
                     .build(),
             )
             responseObserver.onCompleted()
@@ -306,7 +300,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             responseObserver.onNext(
                 FinalizeTransactionResponse
                     .newBuilder()
-                    .setTransaction(entity.toFullProto())
+                    .setTransaction(entity.toFullProto(transactionService))
                     .setReceipt(receipt)
                     .build(),
             )
@@ -332,7 +326,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             responseObserver.onNext(
                 VoidTransactionResponse
                     .newBuilder()
-                    .setTransaction(entity.toFullProto())
+                    .setTransaction(entity.toFullProto(transactionService))
                     .build(),
             )
             responseObserver.onCompleted()
@@ -353,7 +347,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
             responseObserver.onNext(
                 GetTransactionResponse
                     .newBuilder()
-                    .setTransaction(entity.toFullProto())
+                    .setTransaction(entity.toFullProto(transactionService))
                     .build(),
             )
             responseObserver.onCompleted()
@@ -367,41 +361,17 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         responseObserver: StreamObserver<ListTransactionsResponse>,
     ) {
         tenantHelper.setupTenantContext()
-        val page = if (request.hasPagination()) request.pagination.page - 1 else 0
-        val pageSize = if (request.hasPagination() && request.pagination.pageSize > 0) request.pagination.pageSize.coerceAtMost(100) else 20
-
-        val statusFilter =
-            when (request.status) {
-                TransactionStatus.TRANSACTION_STATUS_DRAFT -> "DRAFT"
-                TransactionStatus.TRANSACTION_STATUS_COMPLETED -> "COMPLETED"
-                TransactionStatus.TRANSACTION_STATUS_VOIDED -> "VOIDED"
-                else -> null
-            }
-
-        val startDate =
-            if (request.hasDateRange() && request.dateRange.start.isNotBlank()) {
-                Instant.parse(request.dateRange.start)
-            } else {
-                null
-            }
-        val endDate =
-            if (request.hasDateRange() && request.dateRange.end.isNotBlank()) {
-                Instant.parse(request.dateRange.end)
-            } else {
-                null
-            }
-
+        val query = resolveTransactionListQuery(request)
         val (transactions, totalCount) =
             transactionService.listTransactions(
-                storeId = request.storeId.uuidOrNull(),
-                terminalId = request.terminalId.uuidOrNull(),
-                status = statusFilter,
-                startDate = startDate,
-                endDate = endDate,
-                page = page,
-                pageSize = pageSize,
+                storeId = query.storeId,
+                terminalId = query.terminalId,
+                status = query.status,
+                startDate = query.startDate,
+                endDate = query.endDate,
+                page = query.page,
+                pageSize = query.pageSize,
             )
-        val totalPages = if (totalCount > 0) ((totalCount + pageSize - 1) / pageSize).toInt() else 0
 
         val relations = transactionService.batchLoadRelations(transactions.map { it.id })
 
@@ -417,15 +387,8 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
                             taxSummaries = relations.taxSummaries[tx.id] ?: emptyList(),
                         )
                     },
-                ).setPagination(
-                    PaginationResponse
-                        .newBuilder()
-                        .setPage(page + 1)
-                        .setPageSize(pageSize)
-                        .setTotalCount(totalCount)
-                        .setTotalPages(totalPages)
-                        .build(),
-                ).build(),
+                ).setPagination(buildPaginationResponse(query.page, query.pageSize, totalCount))
+                .build(),
         )
         responseObserver.onCompleted()
     }
@@ -465,39 +428,15 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         responseObserver: StreamObserver<ListJournalEntriesResponse>,
     ) {
         tenantHelper.setupTenantContext()
-        val page = if (request.hasPagination()) request.pagination.page - 1 else 0
-        val pageSize = if (request.hasPagination() && request.pagination.pageSize > 0) request.pagination.pageSize.coerceAtMost(100) else 20
-
-        val typeFilter = request.type.ifBlank { null }
-        val startDate =
-            if (request.hasDateRange() && request.dateRange.start.isNotBlank()) {
-                Instant.parse(request.dateRange.start)
-            } else {
-                null
-            }
-        val endDate =
-            if (request.hasDateRange() && request.dateRange.end.isNotBlank()) {
-                Instant.parse(request.dateRange.end)
-            } else {
-                null
-            }
-
-        val (entries, totalCount) = journalService.listEntries(typeFilter, startDate, endDate, page, pageSize)
-        val totalPages = if (totalCount > 0) ((totalCount + pageSize - 1) / pageSize).toInt() else 0
+        val query = resolveJournalEntriesQuery(request)
+        val (entries, totalCount) = journalService.listEntries(query.type, query.startDate, query.endDate, query.page, query.pageSize)
 
         responseObserver.onNext(
             ListJournalEntriesResponse
                 .newBuilder()
                 .addAllEntries(entries.map { it.toProto() })
-                .setPagination(
-                    PaginationResponse
-                        .newBuilder()
-                        .setPage(page + 1)
-                        .setPageSize(pageSize)
-                        .setTotalCount(totalCount)
-                        .setTotalPages(totalPages)
-                        .build(),
-                ).build(),
+                .setPagination(buildPaginationResponse(query.page, query.pageSize, totalCount))
+                .build(),
         )
         responseObserver.onCompleted()
     }
@@ -685,23 +624,6 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
         )
         responseObserver.onCompleted()
     }
-
-    // === Mapper Extensions ===
-
-    private fun TransactionEntity.toFullProto(): Transaction {
-        val items = transactionService.getTransactionItems(id)
-        val payments = transactionService.getTransactionPayments(id)
-        val discounts = transactionService.getTransactionDiscounts(id)
-        val taxSummaries = transactionService.getTransactionTaxSummaries(id)
-        return toProto(items, payments, discounts, taxSummaries)
-    }
-
-    private fun TransactionEntity.toBatchProto(
-        items: List<TransactionItemEntity>,
-        payments: List<PaymentEntity>,
-        discounts: List<TransactionDiscountEntity>,
-        taxSummaries: List<TaxSummaryEntity>,
-    ): Transaction = toProto(items, payments, discounts, taxSummaries)
 
     // === GiftCard ===
 

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/QuerySupport.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/QuerySupport.kt
@@ -1,0 +1,119 @@
+package com.openpos.pos.grpc
+
+import openpos.common.v1.PaginationResponse
+import openpos.pos.v1.ListJournalEntriesRequest
+import openpos.pos.v1.ListTransactionsRequest
+import openpos.pos.v1.TransactionStatus
+import java.time.Instant
+import java.util.UUID
+
+internal data class TransactionListQuery(
+    val storeId: UUID?,
+    val terminalId: UUID?,
+    val status: String?,
+    val startDate: Instant?,
+    val endDate: Instant?,
+    val page: Int,
+    val pageSize: Int,
+)
+
+internal data class JournalEntriesQuery(
+    val type: String?,
+    val startDate: Instant?,
+    val endDate: Instant?,
+    val page: Int,
+    val pageSize: Int,
+)
+
+internal fun resolveTransactionListQuery(request: ListTransactionsRequest): TransactionListQuery {
+    val pagination = request.resolvePaginationWindow()
+
+    return TransactionListQuery(
+        storeId = request.storeId.uuidOrNull(),
+        terminalId = request.terminalId.uuidOrNull(),
+        status =
+            when (request.status) {
+                TransactionStatus.TRANSACTION_STATUS_DRAFT -> "DRAFT"
+                TransactionStatus.TRANSACTION_STATUS_COMPLETED -> "COMPLETED"
+                TransactionStatus.TRANSACTION_STATUS_VOIDED -> "VOIDED"
+                else -> null
+            },
+        startDate = request.resolveStartDate(),
+        endDate = request.resolveEndDate(),
+        page = pagination.page,
+        pageSize = pagination.pageSize,
+    )
+}
+
+internal fun resolveJournalEntriesQuery(request: ListJournalEntriesRequest): JournalEntriesQuery {
+    val pagination = request.resolvePaginationWindow()
+
+    return JournalEntriesQuery(
+        type = request.type.ifBlank { null },
+        startDate = request.resolveStartDate(),
+        endDate = request.resolveEndDate(),
+        page = pagination.page,
+        pageSize = pagination.pageSize,
+    )
+}
+
+internal fun buildPaginationResponse(
+    page: Int,
+    pageSize: Int,
+    totalCount: Long,
+): PaginationResponse {
+    val totalPages = if (totalCount > 0) ((totalCount + pageSize - 1) / pageSize).toInt() else 0
+
+    return PaginationResponse
+        .newBuilder()
+        .setPage(page + 1)
+        .setPageSize(pageSize)
+        .setTotalCount(totalCount)
+        .setTotalPages(totalPages)
+        .build()
+}
+
+private data class PaginationWindow(
+    val page: Int,
+    val pageSize: Int,
+)
+
+private fun ListTransactionsRequest.resolvePaginationWindow(): PaginationWindow =
+    PaginationWindow(
+        page = if (hasPagination()) pagination.page - 1 else 0,
+        pageSize = if (hasPagination() && pagination.pageSize > 0) pagination.pageSize.coerceAtMost(100) else 20,
+    )
+
+private fun ListJournalEntriesRequest.resolvePaginationWindow(): PaginationWindow =
+    PaginationWindow(
+        page = if (hasPagination()) pagination.page - 1 else 0,
+        pageSize = if (hasPagination() && pagination.pageSize > 0) pagination.pageSize.coerceAtMost(100) else 20,
+    )
+
+private fun ListTransactionsRequest.resolveStartDate(): Instant? =
+    if (hasDateRange() && dateRange.start.isNotBlank()) {
+        Instant.parse(dateRange.start)
+    } else {
+        null
+    }
+
+private fun ListTransactionsRequest.resolveEndDate(): Instant? =
+    if (hasDateRange() && dateRange.end.isNotBlank()) {
+        Instant.parse(dateRange.end)
+    } else {
+        null
+    }
+
+private fun ListJournalEntriesRequest.resolveStartDate(): Instant? =
+    if (hasDateRange() && dateRange.start.isNotBlank()) {
+        Instant.parse(dateRange.start)
+    } else {
+        null
+    }
+
+private fun ListJournalEntriesRequest.resolveEndDate(): Instant? =
+    if (hasDateRange() && dateRange.end.isNotBlank()) {
+        Instant.parse(dateRange.end)
+    } else {
+        null
+    }

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/TransactionHydration.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/TransactionHydration.kt
@@ -1,0 +1,24 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.PaymentEntity
+import com.openpos.pos.entity.TaxSummaryEntity
+import com.openpos.pos.entity.TransactionDiscountEntity
+import com.openpos.pos.entity.TransactionEntity
+import com.openpos.pos.entity.TransactionItemEntity
+import com.openpos.pos.service.TransactionService
+import openpos.pos.v1.Transaction
+
+internal fun TransactionEntity.toFullProto(transactionService: TransactionService): Transaction {
+    val items = transactionService.getTransactionItems(id)
+    val payments = transactionService.getTransactionPayments(id)
+    val discounts = transactionService.getTransactionDiscounts(id)
+    val taxSummaries = transactionService.getTransactionTaxSummaries(id)
+    return toProto(items, payments, discounts, taxSummaries)
+}
+
+internal fun TransactionEntity.toBatchProto(
+    items: List<TransactionItemEntity>,
+    payments: List<PaymentEntity>,
+    discounts: List<TransactionDiscountEntity>,
+    taxSummaries: List<TaxSummaryEntity>,
+): Transaction = toProto(items, payments, discounts, taxSummaries)

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/QuerySupportTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/QuerySupportTest.kt
@@ -1,0 +1,102 @@
+package com.openpos.pos.grpc
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import openpos.common.v1.DateRange
+import openpos.common.v1.PaginationRequest
+import openpos.pos.v1.ListJournalEntriesRequest
+import openpos.pos.v1.ListTransactionsRequest
+import openpos.pos.v1.TransactionStatus
+import java.time.Instant
+import java.util.UUID
+
+class QuerySupportTest {
+    private val storeId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val terminalId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    @Test
+    fun `resolves transaction list query filters and pagination`() {
+        val query =
+            resolveTransactionListQuery(
+                ListTransactionsRequest
+                    .newBuilder()
+                    .setStoreId(storeId.toString())
+                    .setTerminalId(terminalId.toString())
+                    .setStatus(TransactionStatus.TRANSACTION_STATUS_COMPLETED)
+                    .setPagination(
+                        PaginationRequest
+                            .newBuilder()
+                            .setPage(3)
+                            .setPageSize(200)
+                            .build(),
+                    ).setDateRange(
+                        DateRange
+                            .newBuilder()
+                            .setStart("2026-05-01T00:00:00Z")
+                            .setEnd("2026-05-02T00:00:00Z")
+                            .build(),
+                    ).build(),
+            )
+
+        assertEquals(storeId, query.storeId)
+        assertEquals(terminalId, query.terminalId)
+        assertEquals("COMPLETED", query.status)
+        assertEquals(2, query.page)
+        assertEquals(100, query.pageSize)
+        assertEquals(Instant.parse("2026-05-01T00:00:00Z"), query.startDate)
+        assertEquals(Instant.parse("2026-05-02T00:00:00Z"), query.endDate)
+    }
+
+    @Test
+    fun `uses default transaction list pagination and optional filters`() {
+        val query = resolveTransactionListQuery(ListTransactionsRequest.getDefaultInstance())
+
+        assertNull(query.storeId)
+        assertNull(query.terminalId)
+        assertNull(query.status)
+        assertNull(query.startDate)
+        assertNull(query.endDate)
+        assertEquals(0, query.page)
+        assertEquals(20, query.pageSize)
+    }
+
+    @Test
+    fun `resolves journal entry query filters and pagination`() {
+        val query =
+            resolveJournalEntriesQuery(
+                ListJournalEntriesRequest
+                    .newBuilder()
+                    .setType("SALE")
+                    .setPagination(
+                        PaginationRequest
+                            .newBuilder()
+                            .setPage(2)
+                            .setPageSize(50)
+                            .build(),
+                    ).setDateRange(
+                        DateRange
+                            .newBuilder()
+                            .setStart("2026-05-03T00:00:00Z")
+                            .setEnd("2026-05-04T00:00:00Z")
+                            .build(),
+                    ).build(),
+            )
+
+        assertEquals("SALE", query.type)
+        assertEquals(1, query.page)
+        assertEquals(50, query.pageSize)
+        assertEquals(Instant.parse("2026-05-03T00:00:00Z"), query.startDate)
+        assertEquals(Instant.parse("2026-05-04T00:00:00Z"), query.endDate)
+    }
+
+    @Test
+    fun `builds pagination response with total pages`() {
+        val response = buildPaginationResponse(page = 1, pageSize = 20, totalCount = 45)
+
+        assertEquals(2, response.page)
+        assertEquals(20, response.pageSize)
+        assertEquals(45, response.totalCount)
+        assertEquals(3, response.totalPages)
+    }
+}


### PR DESCRIPTION
## What changed
- extracted transaction and journal query parsing into `QuerySupport.kt`
- extracted `TransactionEntity` hydration helpers into `TransactionHydration.kt`
- moved pagination response construction out of `PosGrpcService`
- added focused unit tests for transaction/journal query parsing and pagination building

## Why
`PosGrpcService` still carried inline pagination parsing, date-range parsing, status mapping, and transaction hydration helpers. Those are cross-cutting service concerns rather than RPC-specific logic, and keeping them inline was still making the service harder to change safely.

## Impact
- `PosGrpcService` shrinks from 1013 to 935 lines
- transaction and journal listing logic now shares the same pagination response builder
- transaction hydration is reusable outside the service class and query parsing is covered by pure unit tests

## Validation
- `./gradlew --no-daemon -Dkotlin.incremental=false :services:pos-service:test --tests "com.openpos.pos.grpc.ReceiptFormattingTest" --tests "com.openpos.pos.grpc.TransactionProtoMappingTest" --tests "com.openpos.pos.grpc.AuxiliaryProtoMappingTest" --tests "com.openpos.pos.grpc.DiscountResolutionTest" --tests "com.openpos.pos.grpc.OfflineSyncSupportTest" --tests "com.openpos.pos.grpc.StaffSalesReportSupportTest" --tests "com.openpos.pos.grpc.QuerySupportTest"`