### PR TITLE
[codex] extract grpc receipt access support

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -401,18 +401,19 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContext()
         try {
-            val tx = transactionService.getTransaction(request.transactionId.toUUID())
-            require(tx.status == "COMPLETED" || tx.status == "VOIDED") {
-                "Receipt is only available for COMPLETED or VOIDED transactions"
-            }
-            val items = transactionService.getTransactionItems(tx.id)
-            val payments = transactionService.getTransactionPayments(tx.id)
-            val taxSummaries = transactionService.getTransactionTaxSummaries(tx.id)
+            val receipt =
+                loadReceiptTransactionView(
+                    transactionId = request.transactionId.toUUID(),
+                    loadTransaction = transactionService::getTransaction,
+                    loadItems = transactionService::getTransactionItems,
+                    loadPayments = transactionService::getTransactionPayments,
+                    loadTaxSummaries = transactionService::getTransactionTaxSummaries,
+                )
 
             responseObserver.onNext(
                 GetReceiptResponse
                     .newBuilder()
-                    .setReceipt(buildReceiptProto(tx, items, payments, taxSummaries))
+                    .setReceipt(receipt.toReceiptProto())
                     .build(),
             )
             responseObserver.onCompleted()
@@ -449,25 +450,20 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContext()
         try {
-            val tx = transactionService.getTransaction(request.transactionId.toUUID())
-            require(tx.status == "COMPLETED") {
-                "Invoice receipt is only available for COMPLETED transactions"
-            }
+            val invoiceReceipt =
+                loadInvoiceReceiptView(
+                    transactionId = request.transactionId.toUUID(),
+                    loadTransaction = transactionService::getTransaction,
+                    loadItems = transactionService::getTransactionItems,
+                    loadPayments = transactionService::getTransactionPayments,
+                    loadTaxSummaries = transactionService::getTransactionTaxSummaries,
+                    getInvoiceNumber = storeServiceClient::getInvoiceNumber,
+                )
 
-            val items = transactionService.getTransactionItems(tx.id)
-            val payments = transactionService.getTransactionPayments(tx.id)
-            val taxSummaries = transactionService.getTransactionTaxSummaries(tx.id)
-            val invoiceNumber =
-                storeServiceClient.getInvoiceNumber(tx.organizationId)
-                    ?: throw IllegalArgumentException(
-                        "Invoice registration number is not configured for organization: ${tx.organizationId}",
-                    )
-
-            val receiptData = buildInvoiceReceiptData(tx, items, payments, taxSummaries, invoiceNumber)
             responseObserver.onNext(
                 GetInvoiceReceiptResponse
                     .newBuilder()
-                    .setReceiptData(receiptData)
+                    .setReceiptData(invoiceReceipt.toReceiptData())
                     .setReceiptType("INVOICE")
                     .build(),
             )

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ReceiptAccessSupport.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ReceiptAccessSupport.kt
@@ -1,0 +1,91 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.PaymentEntity
+import com.openpos.pos.entity.TaxSummaryEntity
+import com.openpos.pos.entity.TransactionEntity
+import com.openpos.pos.entity.TransactionItemEntity
+import openpos.pos.v1.Receipt
+import java.util.UUID
+
+internal data class ReceiptTransactionView(
+    val transaction: TransactionEntity,
+    val items: List<TransactionItemEntity>,
+    val payments: List<PaymentEntity>,
+    val taxSummaries: List<TaxSummaryEntity>,
+)
+
+internal data class InvoiceReceiptView(
+    val receipt: ReceiptTransactionView,
+    val invoiceNumber: String,
+)
+
+internal fun ReceiptTransactionView.toReceiptProto(): Receipt =
+    buildReceiptProto(
+        transaction,
+        items,
+        payments,
+        taxSummaries,
+    )
+
+internal fun InvoiceReceiptView.toReceiptData(): String =
+    buildInvoiceReceiptData(
+        receipt.transaction,
+        receipt.items,
+        receipt.payments,
+        receipt.taxSummaries,
+        invoiceNumber,
+    )
+
+internal fun loadReceiptTransactionView(
+    transactionId: UUID,
+    loadTransaction: (UUID) -> TransactionEntity,
+    loadItems: (UUID) -> List<TransactionItemEntity>,
+    loadPayments: (UUID) -> List<PaymentEntity>,
+    loadTaxSummaries: (UUID) -> List<TaxSummaryEntity>,
+): ReceiptTransactionView {
+    val transaction = loadTransaction(transactionId)
+    require(transaction.status == "COMPLETED" || transaction.status == "VOIDED") {
+        "Receipt is only available for COMPLETED or VOIDED transactions"
+    }
+
+    return hydrateReceiptTransactionView(transaction, loadItems, loadPayments, loadTaxSummaries)
+}
+
+internal fun loadInvoiceReceiptView(
+    transactionId: UUID,
+    loadTransaction: (UUID) -> TransactionEntity,
+    loadItems: (UUID) -> List<TransactionItemEntity>,
+    loadPayments: (UUID) -> List<PaymentEntity>,
+    loadTaxSummaries: (UUID) -> List<TaxSummaryEntity>,
+    getInvoiceNumber: (UUID) -> String?,
+): InvoiceReceiptView {
+    val transaction = loadTransaction(transactionId)
+    require(transaction.status == "COMPLETED") {
+        "Invoice receipt is only available for COMPLETED transactions"
+    }
+
+    val receipt = hydrateReceiptTransactionView(transaction, loadItems, loadPayments, loadTaxSummaries)
+    val invoiceNumber =
+        getInvoiceNumber(transaction.organizationId)
+            ?: throw IllegalArgumentException(
+                "Invoice registration number is not configured for organization: ${transaction.organizationId}",
+            )
+
+    return InvoiceReceiptView(
+        receipt = receipt,
+        invoiceNumber = invoiceNumber,
+    )
+}
+
+private fun hydrateReceiptTransactionView(
+    transaction: TransactionEntity,
+    loadItems: (UUID) -> List<TransactionItemEntity>,
+    loadPayments: (UUID) -> List<PaymentEntity>,
+    loadTaxSummaries: (UUID) -> List<TaxSummaryEntity>,
+): ReceiptTransactionView =
+    ReceiptTransactionView(
+        transaction = transaction,
+        items = loadItems(transaction.id),
+        payments = loadPayments(transaction.id),
+        taxSummaries = loadTaxSummaries(transaction.id),
+    )

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/ReceiptAccessSupportTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/ReceiptAccessSupportTest.kt
@@ -1,0 +1,119 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.PaymentEntity
+import com.openpos.pos.entity.TaxSummaryEntity
+import com.openpos.pos.entity.TransactionEntity
+import com.openpos.pos.entity.TransactionItemEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class ReceiptAccessSupportTest {
+    private val organizationId = UUID.fromString("00000000-0000-0000-0000-000000000000")
+    private val transactionId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+
+    @Test
+    fun `loads receipt transaction view for completed transaction`() {
+        val items = listOf(TransactionItemEntity())
+        val payments = listOf(PaymentEntity())
+        val taxSummaries = listOf(TaxSummaryEntity())
+
+        val view =
+            loadReceiptTransactionView(
+                transactionId = transactionId,
+                loadTransaction = { transaction(status = "COMPLETED") },
+                loadItems = {
+                    assertEquals(transactionId, it)
+                    items
+                },
+                loadPayments = { payments },
+                loadTaxSummaries = { taxSummaries },
+            )
+
+        assertEquals("COMPLETED", view.transaction.status)
+        assertSame(items, view.items)
+        assertSame(payments, view.payments)
+        assertSame(taxSummaries, view.taxSummaries)
+    }
+
+    @Test
+    fun `rejects receipt access for draft transaction`() {
+        val error =
+            assertThrows(IllegalArgumentException::class.java) {
+                loadReceiptTransactionView(
+                    transactionId = transactionId,
+                    loadTransaction = { transaction(status = "DRAFT") },
+                    loadItems = { emptyList() },
+                    loadPayments = { emptyList() },
+                    loadTaxSummaries = { emptyList() },
+                )
+            }
+
+        assertEquals("Receipt is only available for COMPLETED or VOIDED transactions", error.message)
+    }
+
+    @Test
+    fun `loads invoice receipt view and resolves invoice number`() {
+        val invoiceView =
+            loadInvoiceReceiptView(
+                transactionId = transactionId,
+                loadTransaction = { transaction(status = "COMPLETED") },
+                loadItems = { emptyList() },
+                loadPayments = { emptyList() },
+                loadTaxSummaries = { emptyList() },
+                getInvoiceNumber = { orgId ->
+                    assertEquals(organizationId, orgId)
+                    "T1234567890123"
+                },
+            )
+
+        assertEquals("T1234567890123", invoiceView.invoiceNumber)
+        assertEquals("COMPLETED", invoiceView.receipt.transaction.status)
+    }
+
+    @Test
+    fun `rejects invoice receipt access for non completed transaction`() {
+        val error =
+            assertThrows(IllegalArgumentException::class.java) {
+                loadInvoiceReceiptView(
+                    transactionId = transactionId,
+                    loadTransaction = { transaction(status = "VOIDED") },
+                    loadItems = { emptyList() },
+                    loadPayments = { emptyList() },
+                    loadTaxSummaries = { emptyList() },
+                    getInvoiceNumber = { "T1234567890123" },
+                )
+            }
+
+        assertEquals("Invoice receipt is only available for COMPLETED transactions", error.message)
+    }
+
+    @Test
+    fun `requires invoice registration number`() {
+        val error =
+            assertThrows(IllegalArgumentException::class.java) {
+                loadInvoiceReceiptView(
+                    transactionId = transactionId,
+                    loadTransaction = { transaction(status = "COMPLETED") },
+                    loadItems = { emptyList() },
+                    loadPayments = { emptyList() },
+                    loadTaxSummaries = { emptyList() },
+                    getInvoiceNumber = { null },
+                )
+            }
+
+        assertEquals(
+            "Invoice registration number is not configured for organization: $organizationId",
+            error.message,
+        )
+    }
+
+    private fun transaction(status: String): TransactionEntity =
+        TransactionEntity().apply {
+            id = transactionId
+            organizationId = this@ReceiptAccessSupportTest.organizationId
+            this.status = status
+        }
+}


### PR DESCRIPTION
## What changed
- extracted receipt/invoice transaction loading and status validation into `ReceiptAccessSupport.kt`
- added focused unit tests for receipt accessibility, invoice-only constraints, and invoice number lookup failures
- simplified `PosGrpcService` receipt endpoints to orchestrate helper calls and response construction only

## Why
`getReceipt` and `getInvoiceReceipt` were still mixing request parsing, transaction status validation, relation loading, and invoice registration lookup inline. That logic is easier to validate as pure helpers than inside the gRPC service class.

## Impact
- `PosGrpcService` shrinks from 935 to 931 lines
- receipt and invoice access rules are now covered by dedicated unit tests
- invoice registration lookup failures remain explicit and unchanged in behavior

## Validation
- `./gradlew --no-daemon -Dkotlin.incremental=false :services:pos-service:test --tests "com.openpos.pos.grpc.ReceiptFormattingTest" --tests "com.openpos.pos.grpc.ReceiptAccessSupportTest" --tests "com.openpos.pos.grpc.TransactionProtoMappingTest" --tests "com.openpos.pos.grpc.AuxiliaryProtoMappingTest" --tests "com.openpos.pos.grpc.DiscountResolutionTest" --tests "com.openpos.pos.grpc.OfflineSyncSupportTest" --tests "com.openpos.pos.grpc.QuerySupportTest" --tests "com.openpos.pos.grpc.StaffSalesReportSupportTest"`