### PR TITLE
[codex] extract grpc reservation support

### DIFF
--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/PosGrpcService.kt
@@ -823,9 +823,8 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContext()
         try {
-            val storeId = request.storeId.toUUID()
-            val status = request.status.ifBlank { null }
-            val (reservations, _) = reservationService.listByStoreId(storeId, status, 0, 100)
+            val query = resolveReservationListQuery(request)
+            val (reservations, _) = reservationService.listByStoreId(query.storeId, query.status, 0, 100)
             responseObserver.onNext(
                 openpos.pos.v1.ListReservationsResponse
                     .newBuilder()
@@ -844,14 +843,15 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContextWithoutFilter()
         try {
+            val input = resolveReservationCreateInput(request)
             val entity =
                 reservationService.create(
-                    storeId = request.storeId.toUUID(),
-                    customerName = request.customerName.ifBlank { null },
-                    customerPhone = request.customerPhone.ifBlank { null },
-                    items = request.items,
-                    reservedUntil = Instant.parse(request.reservedUntil),
-                    note = request.note.ifBlank { null },
+                    storeId = input.storeId,
+                    customerName = input.customerName,
+                    customerPhone = input.customerPhone,
+                    items = input.items,
+                    reservedUntil = input.reservedUntil,
+                    note = input.note,
                 )
             responseObserver.onNext(
                 openpos.pos.v1.CreateReservationResponse
@@ -871,9 +871,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContext()
         try {
-            val entity =
-                reservationService.findById(request.id.toUUID())
-                    ?: throw Status.NOT_FOUND.withDescription("Reservation not found: ${request.id}").asRuntimeException()
+            val entity = requireReservation(request.id.toUUID(), reservationService::findById)
             responseObserver.onNext(
                 openpos.pos.v1.GetReservationResponse
                     .newBuilder()
@@ -892,9 +890,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContext()
         try {
-            val entity =
-                reservationService.fulfill(request.id.toUUID())
-                    ?: throw Status.NOT_FOUND.withDescription("Reservation not found: ${request.id}").asRuntimeException()
+            val entity = requireReservation(request.id.toUUID(), reservationService::fulfill)
             responseObserver.onNext(
                 openpos.pos.v1.FulfillReservationResponse
                     .newBuilder()
@@ -913,9 +909,7 @@ class PosGrpcService : PosServiceGrpc.PosServiceImplBase() {
     ) {
         tenantHelper.setupTenantContext()
         try {
-            val entity =
-                reservationService.cancel(request.id.toUUID())
-                    ?: throw Status.NOT_FOUND.withDescription("Reservation not found: ${request.id}").asRuntimeException()
+            val entity = requireReservation(request.id.toUUID(), reservationService::cancel)
             responseObserver.onNext(
                 openpos.pos.v1.CancelReservationResponse
                     .newBuilder()

--- a/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ReservationSupport.kt
+++ b/services/pos-service/src/main/kotlin/com/openpos/pos/grpc/ReservationSupport.kt
@@ -1,0 +1,44 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.ReservationEntity
+import openpos.pos.v1.CreateReservationRequest
+import openpos.pos.v1.ListReservationsRequest
+import java.time.Instant
+import java.util.UUID
+
+internal data class ReservationListQuery(
+    val storeId: UUID,
+    val status: String?,
+)
+
+internal data class ReservationCreateInput(
+    val storeId: UUID,
+    val customerName: String?,
+    val customerPhone: String?,
+    val items: String,
+    val reservedUntil: Instant,
+    val note: String?,
+)
+
+internal fun resolveReservationListQuery(request: ListReservationsRequest): ReservationListQuery =
+    ReservationListQuery(
+        storeId = request.storeId.toUUID(),
+        status = request.status.ifBlank { null },
+    )
+
+internal fun resolveReservationCreateInput(request: CreateReservationRequest): ReservationCreateInput =
+    ReservationCreateInput(
+        storeId = request.storeId.toUUID(),
+        customerName = request.customerName.ifBlank { null },
+        customerPhone = request.customerPhone.ifBlank { null },
+        items = request.items,
+        reservedUntil = Instant.parse(request.reservedUntil),
+        note = request.note.ifBlank { null },
+    )
+
+internal fun requireReservation(
+    reservationId: UUID,
+    loadReservation: (UUID) -> ReservationEntity?,
+): ReservationEntity =
+    loadReservation(reservationId)
+        ?: throw ResourceNotFoundException("Reservation not found: $reservationId")

--- a/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/ReservationSupportTest.kt
+++ b/services/pos-service/src/test/kotlin/com/openpos/pos/grpc/ReservationSupportTest.kt
@@ -1,0 +1,84 @@
+package com.openpos.pos.grpc
+
+import com.openpos.pos.entity.ReservationEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import openpos.pos.v1.CreateReservationRequest
+import openpos.pos.v1.ListReservationsRequest
+import java.time.Instant
+import java.util.UUID
+
+class ReservationSupportTest {
+    private val storeId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val reservationId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    @Test
+    fun `resolves reservation list query with optional status`() {
+        val withStatus =
+            resolveReservationListQuery(
+                ListReservationsRequest
+                    .newBuilder()
+                    .setStoreId(storeId.toString())
+                    .setStatus("PENDING")
+                    .build(),
+            )
+        val withoutStatus =
+            resolveReservationListQuery(
+                ListReservationsRequest
+                    .newBuilder()
+                    .setStoreId(storeId.toString())
+                    .setStatus("")
+                    .build(),
+            )
+
+        assertEquals(storeId, withStatus.storeId)
+        assertEquals("PENDING", withStatus.status)
+        assertEquals(storeId, withoutStatus.storeId)
+        assertNull(withoutStatus.status)
+    }
+
+    @Test
+    fun `resolves reservation create input and normalizes blanks`() {
+        val input =
+            resolveReservationCreateInput(
+                CreateReservationRequest
+                    .newBuilder()
+                    .setStoreId(storeId.toString())
+                    .setCustomerName("")
+                    .setCustomerPhone("")
+                    .setItems("{\"sku\":\"coffee\"}")
+                    .setReservedUntil("2026-05-10T09:00:00Z")
+                    .setNote("")
+                    .build(),
+            )
+
+        assertEquals(storeId, input.storeId)
+        assertNull(input.customerName)
+        assertNull(input.customerPhone)
+        assertEquals("{\"sku\":\"coffee\"}", input.items)
+        assertEquals(Instant.parse("2026-05-10T09:00:00Z"), input.reservedUntil)
+        assertNull(input.note)
+    }
+
+    @Test
+    fun `requires reservation to exist`() {
+        val reservation = ReservationEntity().apply { id = reservationId }
+
+        val resolved = requireReservation(reservationId) { reservation }
+
+        assertSame(reservation, resolved)
+    }
+
+    @Test
+    fun `raises resource not found when reservation is absent`() {
+        val error =
+            assertThrows(ResourceNotFoundException::class.java) {
+                requireReservation(reservationId) { null }
+            }
+
+        assertEquals("Reservation not found: $reservationId", error.message)
+    }
+}


### PR DESCRIPTION
## What changed
- extracted reservation list/create request parsing into `ReservationSupport.kt`
- extracted reservation not-found resolution into a reusable helper
- added focused unit tests for reservation request normalization and missing-reservation handling

## Why
The reservation RPCs still duplicated UUID parsing, blank-field normalization, and not-found handling inline. Those behaviors are easier to validate as pure helpers and keeping them inline was still adding boilerplate to `PosGrpcService`.

## Impact
- `PosGrpcService` shrinks from 931 to 925 lines
- reservation not-found behavior now flows through the shared gRPC exception mapper
- reservation request parsing is covered by dedicated unit tests

## Validation
- `./gradlew --no-daemon -Dkotlin.incremental=false :services:pos-service:test --tests "com.openpos.pos.grpc.ReservationSupportTest" --tests "com.openpos.pos.grpc.ReceiptAccessSupportTest" --tests "com.openpos.pos.grpc.ReceiptFormattingTest" --tests "com.openpos.pos.grpc.QuerySupportTest" --tests "com.openpos.pos.grpc.OfflineSyncSupportTest" --tests "com.openpos.pos.grpc.StaffSalesReportSupportTest" --tests "com.openpos.pos.grpc.DiscountResolutionTest" --tests "com.openpos.pos.grpc.TransactionProtoMappingTest" --tests "com.openpos.pos.grpc.AuxiliaryProtoMappingTest"`