### PR TITLE
fix(deps): revert Quarkus 3.37.1 → 3.36.1 (E2E docker-smoke regression)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.4.0"
-quarkus = "3.37.1"
+quarkus = "3.36.1"
 mockito-kotlin = "6.3.0"
 testcontainers = "2.0.5"
 owasp-depcheck = "12.2.2"


### PR DESCRIPTION
## 概要
`#1241`（gradle-minor group）で入った **Quarkus 3.36.1→3.37.1** が、取引アイテム追加エンドポイントのJSONリクエストボディのデシリアライズを壊し、E2E docker-smoke（`make docker-smoke` → `scripts/seed.sh`）を失敗させていたため 3.36.1 に戻します。

## 症状
```
POST /api/transactions/{id}/items failed (400): {"error":"Bad Request","message":"Invalid UUID: "}
渋谷店 現金会計 has unexpected transaction status:
make: *** [Makefile:124: docker-smoke] Error 1
```
- 全製品・店舗・スタッフ・在庫はUUID付きで正常にシード済み（`.id`読み取りは機能）
- 取引は作成成功（UUID取得済み）だが、アイテム追加POSTで **productId が空** になり、pos-service が `Invalid UUID: ` を返す

## 根本原因
- `api-gateway` `TransactionResource.addItem(@PathParam id, body: AddItemBody)` が `body.productId` をgRPCへ渡すが、Quarkus 3.37.1 で Kotlin data class（`AddItemBody`）の `quarkus-rest-jackson` によるボディ・デシリアライズが空になる
- E2Eが最後に成功したのは main `351d150`（Quarkus **3.36.1**）。以降のバックエンド実行時変更は #1241 のQuarkusバンプのみ（他は Actions / frontend `apps/**` で、バックエンドのリクエストバインディングに影響し得ない）
- 見逃した理由: E2Eジョブは `gradle/**` 変更に対して path-filter でスキップされ、かつ Free ランナーのDockerタイムアウトのため **非必須（informational）** チェック（プロジェクト方針）。#1241 マージ時にE2Eは実行されず、必須の `CI Success` は緑だった

## 変更
- `gradle/libs.versions.toml`: `quarkus = "3.37.1"` → `"3.36.1"`（E2E最終成功時と同一の既知良好バージョンへ復元）
- gradle wrapper 9.6.1 はビルド専用で実行時に無関係のため保持

## 検証
- 本PRのCIは **Backend Build & Test（必須）** でコンパイル/単体テストを検証
- ⚠️ E2Eは `gradle/**` 変更のため path-filter でスキップされる。3.36.1 は 351d150 でE2Eが通ったバージョンそのものだが、完全なE2E再検証は `make docker-demo` のローカル実行推奨

## フォローアップ（別タスク）
1. Quarkus 3.37.x への前向き修正（`quarkus-rest-jackson` のKotlin data classデシリアライズ変更の調査 + ローカルE2E検証）
2. CIギャップ修正の検討: `gradle/**`（バックエンド依存）変更時もE2Eが走るようにするか（Freeランナーコストとのトレードオフ要判断）