### PR TITLE
fix(api-gateway): Quarkus 3.37 の Kotlin data class デシリアライズ回帰を修正

### DIFF
--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -113,3 +113,9 @@ openpos.image.upload-dir=${OPENPOS_IMAGE_UPLOAD_DIR:/tmp/openpos/images}
 openpos.image.base-url=${OPENPOS_IMAGE_BASE_URL:http://localhost:8080/api/images}
 
 %prod.com.openpos.gateway.resource.ProductResource/Timeout/value=10000
+
+# Quarkus 3.37.x: リフレクションフリー・シリアライザ最適化を無効化する。
+# 全プロパティにデフォルト値を持つ Kotlin data class（AddItemBody 等）のリクエストボディが
+# JSON の値を無視してデフォルト値でバインドされる回帰があるため。
+# 再現: KotlinBodyDeserializationTest（本設定を外すと fail する）
+quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false

--- a/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/KotlinBodyDeserializationTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/openpos/gateway/resource/KotlinBodyDeserializationTest.kt
@@ -1,0 +1,103 @@
+package com.openpos.gateway.resource
+
+import io.quarkus.redis.datasource.RedisDataSource
+import io.quarkus.redis.datasource.keys.KeyCommands
+import io.quarkus.redis.datasource.value.ValueCommands
+import io.quarkus.test.InjectMock
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Quarkus REST (rest-jackson) の JSON ボディ・デシリアライズ回帰テスト。
+ *
+ * Quarkus 3.37.1 で「全プロパティにデフォルト値を持つ Kotlin data class」の
+ * リクエストボディが JSON の値を無視してデフォルト値でバインドされる回帰があり、
+ * E2E (docker-smoke) の POST /api/transactions/{id}/items が
+ * "Invalid UUID: "（空 productId）で失敗した。HTTP 層を通さない unit test では
+ * 検知できないため、本テストで実際のデシリアライズ経路を検証する。
+ */
+@Path("/__test/deser")
+class DeserializationProbeResource {
+    @POST
+    @Path("/add-item")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    fun addItem(body: AddItemBody): Map<String, Any?> =
+        mapOf(
+            "productId" to body.productId,
+            "quantity" to body.quantity,
+            "customProductName" to body.customProductName,
+        )
+
+    @POST
+    @Path("/create-transaction")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    fun createTransaction(body: CreateTransactionBody): Map<String, Any?> = mapOf("storeId" to body.storeId, "type" to body.type)
+}
+
+@QuarkusTest
+class KotlinBodyDeserializationTest {
+    @InjectMock
+    lateinit var redis: RedisDataSource
+
+    @BeforeEach
+    fun bypassRateLimit() {
+        // RateLimitFilter は Redis 障害時 fail-closed (429) のため、正常応答をモックする
+        val valueCommands = mock<ValueCommands<String, Long>>()
+        whenever(valueCommands.incr(any())).thenReturn(1L)
+        whenever(redis.value(Long::class.java)).thenReturn(valueCommands)
+        val keyCommands = mock<KeyCommands<String>>()
+        whenever(redis.key()).thenReturn(keyCommands)
+    }
+
+    @Test
+    fun `AddItemBody - 全デフォルト値付きdata classでもJSONの値がバインドされる`() {
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("""{"productId":"11111111-1111-1111-1111-111111111111","quantity":2}""")
+            .`when`()
+            .post("/__test/deser/add-item")
+            .then()
+            .statusCode(200)
+            .body("productId", `is`("11111111-1111-1111-1111-111111111111"))
+            .body("quantity", `is`(2))
+    }
+
+    @Test
+    fun `AddItemBody - 省略フィールドはデフォルト値になる`() {
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("""{"productId":"22222222-2222-2222-2222-222222222222"}""")
+            .`when`()
+            .post("/__test/deser/add-item")
+            .then()
+            .statusCode(200)
+            .body("productId", `is`("22222222-2222-2222-2222-222222222222"))
+            .body("quantity", `is`(1))
+    }
+
+    @Test
+    fun `CreateTransactionBody - デフォルト値なしdata classのバインド`() {
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("""{"storeId":"s-1","terminalId":"t-1","staffId":"u-1","type":"SALE"}""")
+            .`when`()
+            .post("/__test/deser/create-transaction")
+            .then()
+            .statusCode(200)
+            .body("storeId", `is`("s-1"))
+            .body("type", `is`("SALE"))
+    }
+}


### PR DESCRIPTION
## 問題
#1241（Quarkus 3.36.1 → 3.37.1）以降、main の E2E docker-smoke が決定的に失敗していた。
`POST /api/transactions/{id}/items` が `400 {"message":"Invalid UUID: "}`（空 productId）を返す。

## 根本原因
Quarkus 3.37 の rest-jackson **リフレクションフリー・シリアライザ最適化**（ビルド時生成デシリアライザ）が、**全プロパティにデフォルト値を持つ Kotlin data class**（`AddItemBody` 等）のリクエストボディを、JSON の値を無視してデフォルト値でバインドする。デフォルト値なしの `CreateTransactionBody` は正常なため、取引作成は成功しアイテム追加のみ失敗していた。

## 切り分け（実測）
- HTTP 層を通す再現テストで `AddItemBody` のみ fail、`CreateTransactionBody` は pass を確認
- jackson 依存ツリーは 2.22.0 で統一（バージョン不整合ではない）
- `quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false` で全テスト pass に転じることを確認

## 変更内容
- `application.properties`: 上記最適化を無効化（回帰コメント付き。上流修正後に外せる）
- `KotlinBodyDeserializationTest`: HTTP 層を通すデシリアライズ回帰テストを追加（既存 unit test は HTTP 層を通らないため本回帰を検知できなかった。本設定を外すと fail する）

## 検証
- api-gateway 全テストスイート pass（exit=0）
- 本 PR は `services/**` を変更するため CI の E2E path-filter に該当し、docker-smoke が CI 上で実走する（#1241 では `gradle/**` のみで E2E がスキップされ検知漏れした）

## 補足
Quarkus 3.36 へ戻す revert（#1253）は「3.37.1 維持」の判断によりクローズ済み。本 PR はその forward-fix。
Quarkus 上流への issue 報告は別途検討。

Refs #1241, #1253