### PR TITLE
ci: E2E を逐次ビルド化して CI で実走可能にし、gradle/** の検知漏れを塞ぐ

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -189,7 +189,8 @@ pnpm -r run test        # ユニット/機能テスト
 pnpm -r build           # ビルド確認
 
 # E2E テスト（必須 — CI では informational のためローカルで必ず実行）
-# GitHub Free ランナーでは Docker ビルドがタイムアウトするため、CI の required check から除外している。
+# CI の E2E は逐次ビルド（docker-demo-serial）で実走するが遅いため informational（required check 外）。
+# 低リソース環境でビルドが落ちる場合は make docker-demo-serial を使う（詳細: #1257）。
 # PR 作成前にローカルで pass を確認すること。
 make docker-demo && pnpm --filter e2e test
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
               - 'infra/**'
               - 'e2e/**'
               - 'Makefile'
+              # バックエンド依存バンプ（Quarkus 等）の回帰を E2E で検知する（#1241 は
+              # gradle/** がフィルタ外だったため検知漏れした）。詳細: #1257
+              - 'gradle/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle.properties'
 
   proto-lint:
     name: Proto Lint
@@ -170,15 +176,17 @@ jobs:
         if: ${{ !cancelled() }}
 
   # E2E is informational (not required for merge).
-  # Reason: GitHub Free runners cannot reliably complete the full Docker build
-  # within the 45-min timeout. E2E MUST be run locally before creating a PR.
-  # See CLAUDE.md "PR 作成前のローカル CI 検証" for the required local command.
+  # 2コアランナーでは 5 サービス並列の docker build が Gradle Worker Daemon の
+  # 起動タイムアウトを誘発するため、逐次ビルド（docker-demo-serial）で実行する。
+  # 逐次化により完走はするが遅い（60-80分想定）ため timeout は 90 分。
+  # E2E MUST still be run locally before creating a PR（往復が速いため）.
+  # See CLAUDE.md "PR 作成前のローカル CI 検証" for the required local command. 詳細: #1257
   e2e:
     name: E2E Test (Playwright)
     needs: [changes]
     if: ${{ needs.changes.outputs.e2e == 'true' && (github.event_name != 'pull_request' || !startsWith(github.event.pull_request.title, 'docs:')) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -205,8 +213,8 @@ jobs:
             pnpm --filter e2e exec playwright install --with-deps chromium &
           fi
           PW_PID=$!
-          # Start demo stack in foreground
-          OPENPOS_AUTH_ENABLED=false make docker-demo
+          # Start demo stack in foreground (serial build: see #1257)
+          OPENPOS_AUTH_ENABLED=false make docker-demo-serial
           # Wait for Playwright install
           wait $PW_PID
       - name: Run E2E Tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help doctor verify verify-full up up-all up-dev down logs logs-pos \
        dev-gateway dev-product dev-store dev-pos dev-inventory dev-analytics dev-backend dev-backend-stop \
        local-build local-up local-up-fast local-down local-seed local-smoke local-demo reset \
-       docker-build docker-build-core docker-up-core docker-down-core docker-smoke docker-demo \
+       docker-build docker-build-core docker-build-core-serial docker-up-core docker-down-core docker-smoke docker-demo docker-demo-serial \
        demo-up demo-down \
        build build-apps build-services \
        test test-apps test-backend test-frontend test-e2e test-all grpc-test load-test \
@@ -114,6 +114,14 @@ docker-build: ## Build all backend service container images in parallel
 docker-build-core: ## Build the supported local backend container images in parallel
 	docker compose -f infra/compose.yml build product-service store-service pos-service inventory-service api-gateway
 
+# 低リソース環境（CI Free ランナー / 2コア級マシン）向け。並列ビルドは各イメージ内の
+# Gradle + Quarkus augmentation が同時に走り、Gradle Worker Daemon の起動が
+# 120 秒タイムアウトで失敗する（"build machine is extremely loaded"）。詳細: #1257
+docker-build-core-serial: ## Build the backend container images one at a time (for low-resource environments)
+	for svc in product-service store-service pos-service inventory-service api-gateway; do \
+		docker compose -f infra/compose.yml build $$svc || exit 1; \
+	done
+
 docker-up-core: up local-down ## Start the supported local backend services in containers
 	docker compose -f infra/compose.yml up -d --wait product-service store-service pos-service inventory-service api-gateway
 
@@ -125,6 +133,9 @@ docker-smoke: ## Seed demo data and verify the containerized core stack via the 
 	bash scripts/local-demo-smoke.sh
 
 docker-demo: docker-build-core docker-up-core docker-smoke ## Build, start, seed, and verify the containerized core stack
+	@echo "Container demo data is ready. Reload the browser to pick up the latest demo-config.json."
+
+docker-demo-serial: docker-build-core-serial docker-up-core docker-smoke ## docker-demo with serial image builds (for low-resource environments)
 	@echo "Container demo data is ready. Reload the browser to pick up the latest demo-config.json."
 
 # === Build ===

--- a/services/api-gateway/src/main/resources/application.properties
+++ b/services/api-gateway/src/main/resources/application.properties
@@ -118,4 +118,5 @@ openpos.image.base-url=${OPENPOS_IMAGE_BASE_URL:http://localhost:8080/api/images
 # 全プロパティにデフォルト値を持つ Kotlin data class（AddItemBody 等）のリクエストボディが
 # JSON の値を無視してデフォルト値でバインドされる回帰があるため。
 # 再現: KotlinBodyDeserializationTest（本設定を外すと fail する）
+# 上流報告: https://github.com/quarkusio/quarkus/issues/55341（修正リリース後に本設定を外す）
 quarkus.rest.jackson.optimization.enable-reflection-free-serializers=false


### PR DESCRIPTION
## 概要
#1257 の対応。E2E job が Free ランナーで完走できない問題と、バックエンド依存バンプが E2E をトリガーしない検知漏れを解消する。

## 変更内容
1. **Makefile**: `docker-build-core-serial` / `docker-demo-serial` を追加（サービスごとの逐次 docker build）。2コア級環境では5サービス並列ビルドが Gradle Worker Daemon の起動タイムアウト（"build machine is extremely loaded"）で決定的に失敗するため
2. **ci.yml (e2e job)**: `make docker-demo-serial` を使用、timeout 45→90分（逐次化で完走するが遅いため。public リポなので Actions 時間は無料）
3. **ci.yml (path-filter)**: e2e フィルタに `gradle/**` / `build.gradle.kts` / `settings.gradle.kts` / `gradle.properties` を追加 — #1241（Quarkus 3.37.1 バンプ）の回帰が E2E をトリガーせず検知漏れした穴を塞ぐ
4. **CLAUDE.md / application.properties**: 記述の現行化と上流 issue（quarkusio/quarkus#55341）リンク追記

## 検証
- actionlint パス / `make -n docker-demo-serial` で展開確認
- ローカルで `OPENPOS_AUTH_ENABLED=false make docker-demo-serial` 完走（smoke 全項目 OK）+ Playwright E2E **54 passed**
- 本 PR は Makefile を変更するため e2e path-filter に該当し、**CI 上で E2E job が逐次ビルドで実走する**（これが本改修の実地検証になる）

## 補足
E2E は引き続き informational（required check 外）。実走実績を積んでから required 化を判断する。

Refs #1257, #1241