### PR TITLE
fix(inventory): DLQ リトライをヘッダ管理化してメッセージ肥大化・無限ループを根絶

### DIFF
--- a/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumer.kt
+++ b/services/inventory-service/src/main/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumer.kt
@@ -2,6 +2,7 @@ package com.openpos.inventory.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMetadata
 import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata
 import io.vertx.core.json.JsonObject
 import jakarta.enterprise.context.ApplicationScoped
@@ -24,6 +25,11 @@ import java.util.concurrent.CompletionStage
  *
  * バックオフは Thread.sleep ではなく RabbitMQ メッセージの expiration（TTL）で実現する。
  * TTL 付きメッセージは RabbitMQ 側で遅延後に配信されるため、スレッドをブロックしない。
+ *
+ * リトライ回数は AMQP ヘッダ [RETRY_COUNT_HEADER] で管理する。
+ * ボディ埋め込み方式はボディが JSON として parse 不能になった時点でカウントを見失い、
+ * 「再エンコードによる肥大化 × 無限リトライ」で RabbitMQ の max message size（既定 16MiB）に
+ * 到達してチャネルが恒久 DOWN する事故を起こした（#1259）。ボディは一切加工せず再送する。
  */
 @ApplicationScoped
 class DeadLetterQueueConsumer {
@@ -43,21 +49,26 @@ class DeadLetterQueueConsumer {
     companion object {
         const val MAX_RETRY_COUNT = 3
         val BACKOFF_DELAYS_MS = longArrayOf(1_000L, 5_000L, 25_000L)
+
+        /** リトライ回数を追跡する AMQP ヘッダ。 */
+        const val RETRY_COUNT_HEADER = "x-openpos-retry-count"
+
+        /**
+         * これを超えるペイロードは再送せず永久失敗として記録する（フェイルセーフ）。
+         * RabbitMQ の max_message_size（既定 16MiB）を publish 時に踏み抜くと
+         * チャネル例外で readiness が落ちるため、十分小さい値で手前で止める。
+         */
+        const val MAX_RETRY_PAYLOAD_BYTES = 1_048_576
+
+        /** 元メッセージに content_type がない場合の既定値（発行側は application/json を明示している）。 */
+        const val DEFAULT_CONTENT_TYPE = "application/json"
     }
 
     @Incoming("dlq-inventory-sale-completed")
     fun onDlqSaleCompleted(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = payloadAsString(message.payload)
-            handleDeadLetter(body, "inventory.sale-completed") { retryMessage, delayMs ->
-                val metadata =
-                    OutgoingRabbitMQMetadata
-                        .builder()
-                        .withExpiration(delayMs.toString())
-                        .build()
-                saleCompletedRetryEmitter.send(
-                    Message.of(retryMessage, Metadata.of(metadata)),
-                )
+            handleDeadLetter(message, "inventory.sale-completed") { retryMessage ->
+                saleCompletedRetryEmitter.send(retryMessage)
             }
             message.ack()
         } catch (e: Exception) {
@@ -68,16 +79,8 @@ class DeadLetterQueueConsumer {
     @Incoming("dlq-inventory-sale-voided")
     fun onDlqSaleVoided(message: IncomingRabbitMQMessage<*>): CompletionStage<Void> =
         try {
-            val body = payloadAsString(message.payload)
-            handleDeadLetter(body, "inventory.sale-voided") { retryMessage, delayMs ->
-                val metadata =
-                    OutgoingRabbitMQMetadata
-                        .builder()
-                        .withExpiration(delayMs.toString())
-                        .build()
-                saleVoidedRetryEmitter.send(
-                    Message.of(retryMessage, Metadata.of(metadata)),
-                )
+            handleDeadLetter(message, "inventory.sale-voided") { retryMessage ->
+                saleVoidedRetryEmitter.send(retryMessage)
             }
             message.ack()
         } catch (e: Exception) {
@@ -85,82 +88,130 @@ class DeadLetterQueueConsumer {
             message.nack(e)
         }
 
-    private fun payloadAsString(payload: Any?): String =
+    /**
+     * サポートする payload 型を文字列化する。サポート外の型は null を返し、呼び出し側で
+     * 永久失敗として扱う。ObjectMapper による汎用シリアライズは「元のバイト列と異なる表現」を
+     * 生み、リトライごとの再エンコード肥大化（#1259）の温床になるため行わない。
+     */
+    private fun payloadAsStringOrNull(payload: Any?): String? =
         when (payload) {
-            null -> throw IllegalArgumentException("RabbitMQ payload is null")
             is String -> payload
             is ByteArray -> String(payload, StandardCharsets.UTF_8)
             is JsonObject -> payload.encode()
-            else -> objectMapper.writeValueAsString(payload)
+            else -> null
         }
 
     private fun handleDeadLetter(
-        messageBody: String,
+        message: IncomingRabbitMQMessage<*>,
         originalQueue: String,
-        republish: (String, Long) -> Unit,
+        republish: (Message<String>) -> Unit,
     ) {
-        val retryCount = extractRetryCount(messageBody)
-        val eventId = extractField(messageBody, "eventId")
-        val eventType = extractField(messageBody, "eventType")
+        val incomingMetadata =
+            message
+                .getMetadata()
+                .get(IncomingRabbitMQMetadata::class.java)
+                .orElse(null)
+        val retryCount = retryCountOf(incomingMetadata)
+        val body = payloadAsStringOrNull(message.payload)
+        val eventId = extractField(body, "eventId")
+        val eventType = extractField(body, "eventType")
 
-        if (retryCount < MAX_RETRY_COUNT) {
-            val delayMs = BACKOFF_DELAYS_MS[retryCount]
-            log.warnf(
-                "DLQ message retry %d/%d for queue=%s, eventId=%s, eventType=%s, delay=%dms",
-                retryCount + 1,
-                MAX_RETRY_COUNT,
-                originalQueue,
-                eventId,
-                eventType,
-                delayMs,
-            )
+        when {
+            body == null -> {
+                logPermanentFailure(
+                    originalQueue,
+                    eventId,
+                    eventType,
+                    "unsupported payload type: ${message.payload?.javaClass?.name ?: "null"}",
+                )
+            }
 
-            val updatedMessage = incrementRetryCount(messageBody, retryCount)
-            republish(updatedMessage, delayMs)
-        } else {
-            log.errorf(
-                "PERMANENT FAILURE: DLQ message exceeded max retries (%d) for queue=%s, eventId=%s, eventType=%s",
-                MAX_RETRY_COUNT,
-                originalQueue,
-                eventId,
-                eventType,
-            )
-            log.debugf("PERMANENT FAILURE full payload for eventId=%s: %s", eventId, messageBody)
+            body.toByteArray(StandardCharsets.UTF_8).size > MAX_RETRY_PAYLOAD_BYTES -> {
+                logPermanentFailure(
+                    originalQueue,
+                    eventId,
+                    eventType,
+                    "payload exceeds retry size limit ($MAX_RETRY_PAYLOAD_BYTES bytes)",
+                )
+            }
+
+            retryCount >= MAX_RETRY_COUNT -> {
+                logPermanentFailure(
+                    originalQueue,
+                    eventId,
+                    eventType,
+                    "exceeded max retries ($MAX_RETRY_COUNT)",
+                )
+                log.debugf("PERMANENT FAILURE full payload for eventId=%s: %s", eventId, body)
+            }
+
+            else -> {
+                val delayMs = BACKOFF_DELAYS_MS[retryCount]
+                log.warnf(
+                    "DLQ message retry %d/%d for queue=%s, eventId=%s, eventType=%s, delay=%dms",
+                    retryCount + 1,
+                    MAX_RETRY_COUNT,
+                    originalQueue,
+                    eventId,
+                    eventType,
+                    delayMs,
+                )
+
+                val contentType =
+                    incomingMetadata?.contentType?.orElse(DEFAULT_CONTENT_TYPE) ?: DEFAULT_CONTENT_TYPE
+                val outgoingMetadata =
+                    OutgoingRabbitMQMetadata
+                        .builder()
+                        .withExpiration(delayMs.toString())
+                        .withContentType(contentType)
+                        .withHeader(RETRY_COUNT_HEADER, (retryCount + 1).toLong())
+                        .build()
+                republish(Message.of(body, Metadata.of(outgoingMetadata)))
+            }
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun extractField(
-        message: String,
-        field: String,
-    ): String =
+    /** AMQP ヘッダからリトライ回数を読む。ヘッダなし（初回 DLQ 到着）は 0。 */
+    private fun retryCountOf(metadata: IncomingRabbitMQMetadata?): Int =
         try {
-            val map = objectMapper.readValue(message, Map::class.java) as Map<String, Any>
-            map[field]?.toString() ?: "unknown"
-        } catch (e: Exception) {
-            "unknown"
-        }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun extractRetryCount(message: String): Int =
-        try {
-            val map = objectMapper.readValue(message, Map::class.java) as Map<String, Any>
-            (map["retryCount"] as? Number)?.toInt() ?: 0
-        } catch (e: Exception) {
+            metadata
+                ?.getHeader(RETRY_COUNT_HEADER, Number::class.java)
+                ?.map { it.toInt() }
+                ?.orElse(0) ?: 0
+        } catch (e: ClassCastException) {
+            log.warnf("Unreadable %s header (%s); treating as 0", RETRY_COUNT_HEADER, e.message)
             0
         }
 
+    private fun logPermanentFailure(
+        originalQueue: String,
+        eventId: String,
+        eventType: String,
+        reason: String,
+    ) {
+        log.errorf(
+            "PERMANENT FAILURE: DLQ message dropped for queue=%s, eventId=%s, eventType=%s, reason=%s",
+            originalQueue,
+            eventId,
+            eventType,
+            reason,
+        )
+    }
+
+    /** ログ用途の best-effort 抽出。parse 失敗はリトライ判断に影響しない。 */
     @Suppress("UNCHECKED_CAST")
-    private fun incrementRetryCount(
-        message: String,
-        currentRetryCount: Int,
+    private fun extractField(
+        message: String?,
+        field: String,
     ): String =
         try {
-            val map = objectMapper.readValue(message, LinkedHashMap::class.java) as MutableMap<String, Any>
-            map["retryCount"] = currentRetryCount + 1
-            objectMapper.writeValueAsString(map)
+            if (message == null) {
+                "unknown"
+            } else {
+                val map = objectMapper.readValue(message, Map::class.java) as Map<String, Any>
+                map[field]?.toString() ?: "unknown"
+            }
         } catch (e: Exception) {
-            log.warnf("Failed to increment retry count: %s", e.message)
-            message
+            "unknown"
         }
 }

--- a/services/inventory-service/src/test/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumerTest.kt
+++ b/services/inventory-service/src/test/kotlin/com/openpos/inventory/event/DeadLetterQueueConsumerTest.kt
@@ -2,10 +2,12 @@ package com.openpos.inventory.event
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMessage
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMetadata
 import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata
 import io.vertx.core.json.JsonObject
 import org.eclipse.microprofile.reactive.messaging.Emitter
 import org.eclipse.microprofile.reactive.messaging.Message
+import org.eclipse.microprofile.reactive.messaging.Metadata
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
@@ -16,6 +18,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
 class DeadLetterQueueConsumerTest {
@@ -38,120 +41,195 @@ class DeadLetterQueueConsumerTest {
             voidedField.set(c, saleVoidedRetryEmitter)
         }
 
+    /**
+     * リトライ回数は AMQP ヘッダ x-openpos-retry-count で管理される（#1259）。
+     * retryHeader=null はヘッダなし（初回 DLQ 到着）を表す。
+     */
+    private fun mockIncomingMetadata(
+        retryHeader: Long?,
+        contentType: String? = "application/json",
+    ): IncomingRabbitMQMetadata {
+        val meta = mock<IncomingRabbitMQMetadata>()
+        whenever(meta.getHeader(DeadLetterQueueConsumer.RETRY_COUNT_HEADER, Number::class.java))
+            .thenReturn(Optional.ofNullable(retryHeader as Number?))
+        whenever(meta.contentType).thenReturn(Optional.ofNullable(contentType))
+        return meta
+    }
+
     @Suppress("UNCHECKED_CAST")
-    private fun mockMessage(body: Any): IncomingRabbitMQMessage<*> {
+    private fun mockMessage(
+        body: Any,
+        incomingMetadata: IncomingRabbitMQMetadata? = mockIncomingMetadata(retryHeader = null),
+    ): IncomingRabbitMQMessage<*> {
         val message = mock<IncomingRabbitMQMessage<Any>>()
         whenever(message.payload).thenReturn(body)
+        whenever(message.metadata).thenReturn(
+            if (incomingMetadata != null) Metadata.of(incomingMetadata) else Metadata.empty(),
+        )
         whenever(message.ack()).thenReturn(CompletableFuture.completedFuture(null))
         whenever(message.nack(any<Throwable>())).thenReturn(CompletableFuture.completedFuture(null))
         return message
     }
 
-    private fun buildMessageBody(retryCount: Int? = null): String {
-        val map =
-            mutableMapOf<String, Any>(
+    private fun buildMessageBody(): String =
+        objectMapper.writeValueAsString(
+            mapOf(
                 "eventId" to "test-event-id",
                 "eventType" to "sale.completed",
                 "payload" to "{}",
-            )
-        retryCount?.let { map["retryCount"] = it }
-        return objectMapper.writeValueAsString(map)
+            ),
+        )
+
+    private fun sentMessage(emitter: Emitter<String>): Message<String> {
+        val captor = argumentCaptor<Message<String>>()
+        verify(emitter).send(captor.capture())
+        return captor.firstValue
+    }
+
+    private fun outgoingMetadataOf(msg: Message<String>): OutgoingRabbitMQMetadata {
+        val rabbitMetadata = msg.metadata.get(OutgoingRabbitMQMetadata::class.java)
+        assertTrue(rabbitMetadata.isPresent, "OutgoingRabbitMQMetadata should be present")
+        return rabbitMetadata.get()
     }
 
     @Nested
     inner class OnDlqSaleCompleted {
         @Test
-        fun `初回リトライ時はメッセージTTL付きで再送する`() {
-            // Arrange
-            val body = buildMessageBody(retryCount = 0)
-            val message = mockMessage(body)
+        fun `初回（ヘッダなし）はretry=1ヘッダとTTL1秒を付けボディ無加工で再送する`() {
+            val body = buildMessageBody()
+            val message = mockMessage(body, mockIncomingMetadata(retryHeader = null))
 
-            // Act
             consumer.onDlqSaleCompleted(message)
 
-            // Assert
-            val captor = argumentCaptor<Message<String>>()
-            verify(saleCompletedRetryEmitter).send(captor.capture())
-
-            val sentMsg = captor.firstValue
-            val sentBody = objectMapper.readValue(sentMsg.payload, Map::class.java)
-            assertTrue(sentBody["retryCount"] == 1)
-
-            // メッセージに OutgoingRabbitMQMetadata（expiration）が設定されていることを検証
-            val rabbitMetadata = sentMsg.metadata.get(OutgoingRabbitMQMetadata::class.java)
-            assertTrue(rabbitMetadata.isPresent, "OutgoingRabbitMQMetadata should be present")
-            assertEquals("1000", rabbitMetadata.get().expiration)
-
+            val sent = sentMessage(saleCompletedRetryEmitter)
+            assertEquals(body, sent.payload, "リトライボディは受信ボディと同一（無加工）でなければならない")
+            val meta = outgoingMetadataOf(sent)
+            assertEquals("1000", meta.expiration)
+            assertEquals(1L, meta.headers[DeadLetterQueueConsumer.RETRY_COUNT_HEADER])
             verify(message).ack()
         }
 
         @Test
-        fun `retryCountなしの場合は0として扱いリトライする`() {
-            // Arrange
-            val body = buildMessageBody(retryCount = null)
-            val message = mockMessage(body)
+        fun `ヘッダretry=1は2回目としてTTL5秒で再送する`() {
+            val body = buildMessageBody()
+            val message = mockMessage(body, mockIncomingMetadata(retryHeader = 1L))
 
-            // Act
             consumer.onDlqSaleCompleted(message)
 
-            // Assert
-            val captor = argumentCaptor<Message<String>>()
-            verify(saleCompletedRetryEmitter).send(captor.capture())
-
-            val sentBody = objectMapper.readValue(captor.firstValue.payload, Map::class.java)
-            assertTrue(sentBody["retryCount"] == 1)
+            val sent = sentMessage(saleCompletedRetryEmitter)
+            val meta = outgoingMetadataOf(sent)
+            assertEquals("5000", meta.expiration)
+            assertEquals(2L, meta.headers[DeadLetterQueueConsumer.RETRY_COUNT_HEADER])
             verify(message).ack()
         }
 
         @Test
-        fun `JsonObjectペイロードでもリトライできる`() {
-            val body = JsonObject(buildMessageBody(retryCount = 0))
-            val message = mockMessage(body)
+        fun `ヘッダretry=2は3回目としてTTL25秒で再送する`() {
+            val body = buildMessageBody()
+            val message = mockMessage(body, mockIncomingMetadata(retryHeader = 2L))
 
             consumer.onDlqSaleCompleted(message)
 
-            val captor = argumentCaptor<Message<String>>()
-            verify(saleCompletedRetryEmitter).send(captor.capture())
-            val sentBody = objectMapper.readValue(captor.firstValue.payload, Map::class.java)
-            assertTrue(sentBody["retryCount"] == 1)
+            val meta = outgoingMetadataOf(sentMessage(saleCompletedRetryEmitter))
+            assertEquals("25000", meta.expiration)
+            assertEquals(3L, meta.headers[DeadLetterQueueConsumer.RETRY_COUNT_HEADER])
             verify(message).ack()
         }
 
         @Test
-        fun `最大リトライ回数到達後は再送しない`() {
-            // Arrange
-            val body = buildMessageBody(retryCount = 3)
-            val message = mockMessage(body)
+        fun `ヘッダretry=3（上限到達）は再送せずackする`() {
+            val message = mockMessage(buildMessageBody(), mockIncomingMetadata(retryHeader = 3L))
 
-            // Act
             consumer.onDlqSaleCompleted(message)
 
-            // Assert
             verify(saleCompletedRetryEmitter, never()).send(any<Message<String>>())
             verify(message).ack()
         }
 
         @Test
-        fun `2回目のリトライでretryCountが正しくインクリメントされTTLが5秒に設定される`() {
-            // Arrange
-            val body = buildMessageBody(retryCount = 1)
-            val message = mockMessage(body)
+        fun `parse不能ボディでもヘッダのカウントが進み無限リトライにならない`() {
+            // #1259 の核心回帰テスト: ボディが JSON でなくてもヘッダでカウントが管理される
+            val garbled = "\"{\\\"escaped\\\": \\\"garbage\\\"}\"" // 二重エンコードで壊れたボディの例
+            val message = mockMessage(garbled, mockIncomingMetadata(retryHeader = 2L))
 
-            // Act
             consumer.onDlqSaleCompleted(message)
 
-            // Assert
-            val captor = argumentCaptor<Message<String>>()
-            verify(saleCompletedRetryEmitter).send(captor.capture())
+            val sent = sentMessage(saleCompletedRetryEmitter)
+            assertEquals(garbled, sent.payload, "parse 不能でもボディは無加工のまま")
+            assertEquals(3L, outgoingMetadataOf(sent).headers[DeadLetterQueueConsumer.RETRY_COUNT_HEADER])
+            verify(message).ack()
+        }
 
-            val sentMsg = captor.firstValue
-            val sentBody = objectMapper.readValue(sentMsg.payload, Map::class.java)
-            assertTrue(sentBody["retryCount"] == 2)
+        @Test
+        fun `parse不能ボディでもヘッダ上限到達なら再送しない`() {
+            val message = mockMessage("not valid json at all", mockIncomingMetadata(retryHeader = 3L))
 
-            val rabbitMetadata = sentMsg.metadata.get(OutgoingRabbitMQMetadata::class.java)
-            assertTrue(rabbitMetadata.isPresent)
-            assertEquals("5000", rabbitMetadata.get().expiration)
+            consumer.onDlqSaleCompleted(message)
 
+            verify(saleCompletedRetryEmitter, never()).send(any<Message<String>>())
+            verify(message).ack()
+        }
+
+        @Test
+        fun `JsonObjectペイロードでもリトライできる`() {
+            val body = JsonObject(buildMessageBody())
+            val message = mockMessage(body, mockIncomingMetadata(retryHeader = null))
+
+            consumer.onDlqSaleCompleted(message)
+
+            val sent = sentMessage(saleCompletedRetryEmitter)
+            assertEquals(body.encode(), sent.payload)
+            verify(message).ack()
+        }
+
+        @Test
+        fun `content-typeを元メッセージから引き継ぐ`() {
+            val message =
+                mockMessage(
+                    buildMessageBody(),
+                    mockIncomingMetadata(retryHeader = null, contentType = "text/plain"),
+                )
+
+            consumer.onDlqSaleCompleted(message)
+
+            assertEquals("text/plain", outgoingMetadataOf(sentMessage(saleCompletedRetryEmitter)).contentType)
+        }
+
+        @Test
+        fun `content-typeがない場合はapplication_jsonを既定にする`() {
+            val message =
+                mockMessage(
+                    buildMessageBody(),
+                    mockIncomingMetadata(retryHeader = null, contentType = null),
+                )
+
+            consumer.onDlqSaleCompleted(message)
+
+            assertEquals(
+                DeadLetterQueueConsumer.DEFAULT_CONTENT_TYPE,
+                outgoingMetadataOf(sentMessage(saleCompletedRetryEmitter)).contentType,
+            )
+        }
+
+        @Test
+        fun `サイズ上限を超えるペイロードは再送せず永久失敗として破棄する`() {
+            // フェイルセーフ: RabbitMQ の max_message_size を publish で踏み抜かない
+            val huge = "x".repeat(DeadLetterQueueConsumer.MAX_RETRY_PAYLOAD_BYTES + 1)
+            val message = mockMessage(huge, mockIncomingMetadata(retryHeader = 0L))
+
+            consumer.onDlqSaleCompleted(message)
+
+            verify(saleCompletedRetryEmitter, never()).send(any<Message<String>>())
+            verify(message).ack()
+        }
+
+        @Test
+        fun `サポート外のペイロード型は再送せず永久失敗として破棄する`() {
+            val message = mockMessage(12345, mockIncomingMetadata(retryHeader = 0L))
+
+            consumer.onDlqSaleCompleted(message)
+
+            verify(saleCompletedRetryEmitter, never()).send(any<Message<String>>())
             verify(message).ack()
         }
     }
@@ -159,23 +237,22 @@ class DeadLetterQueueConsumerTest {
     @Nested
     inner class OnDlqSaleVoided {
         @Test
-        fun `初回リトライ時はsaleVoidedRetryEmitterにメッセージTTL付きで再送する`() {
-            // Arrange
-            val body = buildMessageBody(retryCount = 0)
-            val message = mockMessage(body)
+        fun `初回はsaleVoidedRetryEmitterにretryヘッダ付きで再送する`() {
+            val body = buildMessageBody()
+            val message = mockMessage(body, mockIncomingMetadata(retryHeader = null))
 
-            // Act
             consumer.onDlqSaleVoided(message)
 
-            // Assert
-            verify(saleVoidedRetryEmitter).send(any<Message<String>>())
+            val sent = sentMessage(saleVoidedRetryEmitter)
+            assertEquals(body, sent.payload)
+            assertEquals(1L, outgoingMetadataOf(sent).headers[DeadLetterQueueConsumer.RETRY_COUNT_HEADER])
             verify(message).ack()
         }
 
         @Test
         fun `JsonObjectペイロードでもsaleVoidedRetryEmitterに再送する`() {
-            val body = JsonObject(buildMessageBody(retryCount = 0))
-            val message = mockMessage(body)
+            val body = JsonObject(buildMessageBody())
+            val message = mockMessage(body, mockIncomingMetadata(retryHeader = null))
 
             consumer.onDlqSaleVoided(message)
 
@@ -184,15 +261,11 @@ class DeadLetterQueueConsumerTest {
         }
 
         @Test
-        fun `最大リトライ回数到達後は再送しない`() {
-            // Arrange
-            val body = buildMessageBody(retryCount = 3)
-            val message = mockMessage(body)
+        fun `ヘッダ上限到達後は再送しない`() {
+            val message = mockMessage(buildMessageBody(), mockIncomingMetadata(retryHeader = 3L))
 
-            // Act
             consumer.onDlqSaleVoided(message)
 
-            // Assert
             verify(saleVoidedRetryEmitter, never()).send(any<Message<String>>())
             verify(message).ack()
         }
@@ -202,8 +275,7 @@ class DeadLetterQueueConsumerTest {
     inner class ErrorHandling {
         @Test
         fun `nacks message when emitter throws exception on sale completed`() {
-            val body = buildMessageBody(retryCount = 0)
-            val message = mockMessage(body)
+            val message = mockMessage(buildMessageBody(), mockIncomingMetadata(retryHeader = null))
             whenever(saleCompletedRetryEmitter.send(any<Message<String>>())).thenThrow(RuntimeException("send failed"))
 
             consumer.onDlqSaleCompleted(message)
@@ -213,8 +285,7 @@ class DeadLetterQueueConsumerTest {
 
         @Test
         fun `nacks message when emitter throws exception on sale voided`() {
-            val body = buildMessageBody(retryCount = 0)
-            val message = mockMessage(body)
+            val message = mockMessage(buildMessageBody(), mockIncomingMetadata(retryHeader = null))
             whenever(saleVoidedRetryEmitter.send(any<Message<String>>())).thenThrow(RuntimeException("send failed"))
 
             consumer.onDlqSaleVoided(message)
@@ -223,17 +294,20 @@ class DeadLetterQueueConsumerTest {
         }
 
         @Test
-        fun `handles invalid JSON gracefully for extractField and extractRetryCount`() {
-            val message = mockMessage("not valid json at all")
+        fun `RabbitMQメタデータ自体がない場合も初回として扱う`() {
+            val body = buildMessageBody()
+            val message = mockMessage(body, incomingMetadata = null)
 
             consumer.onDlqSaleCompleted(message)
 
+            val sent = sentMessage(saleCompletedRetryEmitter)
+            assertEquals(1L, outgoingMetadataOf(sent).headers[DeadLetterQueueConsumer.RETRY_COUNT_HEADER])
             verify(message).ack()
         }
     }
 
     @Nested
-    inner class MaxRetryCount {
+    inner class Constants {
         @Test
         fun `MAX_RETRY_COUNTは3である`() {
             assertTrue(DeadLetterQueueConsumer.MAX_RETRY_COUNT == 3)
@@ -245,6 +319,11 @@ class DeadLetterQueueConsumerTest {
             assertTrue(delays[0] == 1_000L)
             assertTrue(delays[1] == 5_000L)
             assertTrue(delays[2] == 25_000L)
+        }
+
+        @Test
+        fun `リトライサイズ上限はRabbitMQ既定の16MiBより十分小さい`() {
+            assertTrue(DeadLetterQueueConsumer.MAX_RETRY_PAYLOAD_BYTES < 16 * 1024 * 1024)
         }
     }
 }


### PR DESCRIPTION
## 問題（#1259）
長時間稼働後に inventory-service の readiness が恒久 DOWN になる。実測では 19.2MB まで肥大化したメッセージが RabbitMQ の max_message_size（16MiB）で publish 拒否され、`sale-completed-retry` チャネルが [KO] のままになっていた。

## 根本原因
リトライ回数を**メッセージボディに埋め込む方式**の構造的欠陥:
1. `extractRetryCount` はボディが JSON として parse 不能だと **0 を返す（fail-open）** → 無限リトライ
2. republish 時にボディを再シリアライズするため、payload 型によっては表現が変わり（`objectMapper.writeValueAsString` の汎用パス）、リトライごとに再エンコードで肥大化
3. 1×2 の組み合わせ = 「肥大化しながら無限リトライ」→ 16MiB 到達で publish 自体が失敗しチャネル恒久 DOWN

## 修正内容
- **リトライ回数を AMQP ヘッダ `x-openpos-retry-count` で管理**（ボディ非依存。parse 不能でもカウントが確実に進み、3回で必ず永久失敗に到達する）
- **ボディは一切加工せず再送**（肥大化が構造的に不可能に）
- **content-type を元メッセージから引き継ぐ**（なければ application/json。発行側は明示済み）
- フェイルセーフ2点: 1MiB 超ペイロードは再送せず永久失敗 / サポート外 payload 型（String・ByteArray・JsonObject 以外）は汎用シリアライズせず永久失敗

## テスト（20件、全パス）
- 核心回帰テスト: **parse 不能ボディでもヘッダのカウントが進み無限リトライにならない**
- ボディ無加工の検証（送信 payload が受信ボディと同一文字列）
- ヘッダ 0→1→2→3 の遷移と TTL（1s/5s/25s）、上限到達で再送停止
- content-type 引き継ぎ / 既定値、サイズ上限、サポート外型、メタデータ欠落、nack 系

## 検証
- inventory-service 全テスト pass / ビルド成功
- 補足: 事故当時の滞留メッセージはローカル環境リセットで除去済み。本修正により再発時も 3 回で確実に打ち止めになる

Fixes #1259