### PR TITLE
docs: align Redis cache key format rule with P0-1 tenant isolation

### DIFF
--- a/.claude/rules/service.md
+++ b/.claude/rules/service.md
@@ -28,6 +28,7 @@ com.openpos.{service}/
 - 失敗時: nack → DLQ
 
 ## Redis キャッシュ
-- キー形式: `openpos:{service}:{entity}:{id}`
+- キー形式: `openpos:{service}:{orgId}:{entity}:{id}` — **orgId 必須**（テナント間キャッシュ漏えい防止。セキュリティ評価 P0-1 で全実装改修済み）
+- キー構築はキャッシュサービスのヘルパーを経由し orgId の付与漏れを防ぐ（例: api-gateway の `RedisCacheService.tenantKey(orgId, ...)`）
 - 全キーに TTL 設定（デフォルト 1h）
 - cache-aside パターン遵守


### PR DESCRIPTION
## 概要
`.claude/rules/service.md` の Redis キー規約が P0-1（キャッシュキーのテナント隔離、セキュリティ評価 2026-03-27）対応**前**の古い形式 `openpos:{service}:{entity}:{id}` のままだったため、実装済みの形式に更新する。

## 背景
- 実装は改修済み: `RedisCacheService.tenantKey(orgId, ...)`（api-gateway）、`openpos:product-service:{orgId}:{entity}:{id}`（product-service）
- ルール文書だけが古く、このルールを読む後続開発・エージェントが orgId なしのテナント漏えいキーを再生産するリスクがあった

## 変更内容
- キー形式に `{orgId}` を追加し、orgId 必須の理由（テナント間キャッシュ漏えい防止）を明記
- ヘルパー経由のキー構築を明記

ドキュメントのみの変更（コード変更なし）。